### PR TITLE
🐛 fix view modal crash when viewing swarm agent configuration

### DIFF
--- a/lib/user-interface/react-app/src/components/admin/agent-core/view-version-modal.tsx
+++ b/lib/user-interface/react-app/src/components/admin/agent-core/view-version-modal.tsx
@@ -189,21 +189,27 @@ export default function ViewVersionModal({
         return <Box display="inline">{String(value)}</Box>;
     };
 
+    const isSwarm = agentConfig && isSwarmConfig(agentConfig);
+
     const toolTableItems =
-        agentConfig?.tools.map((toolName) => ({
-            name: toolName,
-            parameters: agentConfig.toolParameters[toolName] || {},
-        })) || [];
+        !isSwarm && agentConfig?.tools
+            ? agentConfig.tools.map((toolName) => ({
+                  name: toolName,
+                  parameters: agentConfig.toolParameters[toolName] || {},
+              }))
+            : [];
 
     // Get MCP server details for configured servers
     const mcpServerTableItems =
-        agentConfig?.mcpServers?.map((serverName) => {
-            const serverInfo = availableMcpServers.find((s) => s.name === serverName);
-            return {
-                name: serverName,
-                description: serverInfo?.description || "No description available",
-            };
-        }) || [];
+        !isSwarm && agentConfig?.mcpServers
+            ? agentConfig.mcpServers.map((serverName) => {
+                  const serverInfo = availableMcpServers.find((s) => s.name === serverName);
+                  return {
+                      name: serverName,
+                      description: serverInfo?.description || "No description available",
+                  };
+              })
+            : [];
 
     return (
         <Modal


### PR DESCRIPTION
## Fix: View modal crash for swarm agents

Clicking "View" on a swarm agent in the AgentCore Runtime Manager throws:
`TypeError: Cannot read properties of undefined (reading 'map')`

### Root cause

`toolTableItems` and `mcpServerTableItems` are computed on every render by calling `.map()` on `agentConfig.tools` and `agentConfig.mcpServers`. When the config is a `SwarmConfiguration`, these properties don't exist at the top level (tools live inside each agent definition at `agents[].tools`), so `.map()` is called on `undefined`.

### Fix

Guard both computations with an `isSwarm` check so they only run for single-agent configs. For swarm configs, both default to empty arrays and their corresponding table sections don't render.

### Changed files

- `lib/user-interface/react-app/src/components/admin/agent-core/view-version-modal.tsx`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
