### PR TITLE
✨ Add evaluation module to Terraform Infrastructure

### DIFF
--- a/iac-terraform/modules/api_tables/main.tf
+++ b/iac-terraform/modules/api_tables/main.tf
@@ -90,3 +90,33 @@ resource "aws_dynamodb_table" "favorite_runtime" {
     Name = "${local.name_prefix}-favoriteRuntimeTable"
   })
 }
+
+# -----------------------------------------------------------------------------
+# Evaluators Table
+# Stores evaluation configurations and results
+# -----------------------------------------------------------------------------
+
+resource "aws_dynamodb_table" "evaluators" {
+  name         = "${local.name_prefix}-evaluatorsTable"
+  billing_mode = "PAY_PER_REQUEST"
+
+  hash_key = "EvaluatorName"
+
+  attribute {
+    name = "EvaluatorName"
+    type = "S"
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = var.kms_key_arn
+  }
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-evaluatorsTable"
+  })
+}

--- a/iac-terraform/modules/api_tables/outputs.tf
+++ b/iac-terraform/modules/api_tables/outputs.tf
@@ -37,3 +37,17 @@ output "favorite_runtime_table_arn" {
   description = "ARN of the favorite runtime DynamoDB table"
   value       = aws_dynamodb_table.favorite_runtime.arn
 }
+
+# -----------------------------------------------------------------------------
+# Evaluators Table Outputs
+# -----------------------------------------------------------------------------
+
+output "evaluators_table_name" {
+  description = "Name of the evaluators DynamoDB table"
+  value       = aws_dynamodb_table.evaluators.name
+}
+
+output "evaluators_table_arn" {
+  description = "ARN of the evaluators DynamoDB table"
+  value       = aws_dynamodb_table.evaluators.arn
+}

--- a/iac-terraform/modules/evaluation/iam.tf
+++ b/iac-terraform/modules/evaluation/iam.tf
@@ -1,0 +1,203 @@
+/* Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0
+----------------------------------------------------------------------
+Evaluation Module - IAM Roles and Policies
+*/
+
+data "aws_iam_policy_document" "lambda_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+# -----------------------------------------------------------------------------
+# EvaluationResolver IAM Role
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role" "evaluation_resolver" {
+  name               = "${local.name_prefix}-evaluation-resolver-role"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+  tags               = merge(var.tags, { Name = "${local.name_prefix}-evaluation-resolver-role" })
+}
+
+resource "aws_iam_role_policy_attachment" "evaluation_resolver_basic" {
+  role       = aws_iam_role.evaluation_resolver.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy_attachment" "evaluation_resolver_xray" {
+  role       = aws_iam_role.evaluation_resolver.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+}
+
+resource "aws_iam_role_policy" "evaluation_resolver" {
+  name = "${local.name_prefix}-evaluation-resolver-policy"
+  role = aws_iam_role.evaluation_resolver.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "DynamoDBAccess"
+        Effect = "Allow"
+        Action = [
+          "dynamodb:GetItem",
+          "dynamodb:PutItem",
+          "dynamodb:UpdateItem",
+          "dynamodb:DeleteItem",
+          "dynamodb:Query",
+          "dynamodb:Scan"
+        ]
+        Resource = [
+          var.evaluators_table_arn,
+          "${var.evaluators_table_arn}/index/*"
+        ]
+      },
+      {
+        Sid    = "S3Access"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket"
+        ]
+        Resource = [
+          aws_s3_bucket.evaluations.arn,
+          "${aws_s3_bucket.evaluations.arn}/*"
+        ]
+      },
+      {
+        Sid      = "SQSSendMessages"
+        Effect   = "Allow"
+        Action   = ["sqs:SendMessage", "sqs:GetQueueAttributes"]
+        Resource = [aws_sqs_queue.evaluation.arn]
+      },
+      {
+        Sid    = "KMSAccess"
+        Effect = "Allow"
+        Action = [
+          "kms:Decrypt",
+          "kms:GenerateDataKey*"
+        ]
+        Resource = [var.kms_key_arn]
+      }
+    ]
+  })
+}
+
+# -----------------------------------------------------------------------------
+# EvaluationExecutor IAM Role
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role" "evaluation_executor" {
+  name               = "${local.name_prefix}-evaluation-executor-role"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+  tags               = merge(var.tags, { Name = "${local.name_prefix}-evaluation-executor-role" })
+}
+
+resource "aws_iam_role_policy_attachment" "evaluation_executor_basic" {
+  role       = aws_iam_role.evaluation_executor.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy_attachment" "evaluation_executor_xray" {
+  role       = aws_iam_role.evaluation_executor.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+}
+
+resource "aws_iam_role_policy" "evaluation_executor" {
+  name = "${local.name_prefix}-evaluation-executor-policy"
+  role = aws_iam_role.evaluation_executor.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "DynamoDBAccess"
+        Effect = "Allow"
+        Action = [
+          "dynamodb:GetItem",
+          "dynamodb:PutItem",
+          "dynamodb:UpdateItem",
+          "dynamodb:DeleteItem",
+          "dynamodb:Query",
+          "dynamodb:Scan"
+        ]
+        Resource = [
+          var.evaluators_table_arn,
+          "${var.evaluators_table_arn}/index/*"
+        ]
+      },
+      {
+        Sid    = "S3Access"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket"
+        ]
+        Resource = [
+          aws_s3_bucket.evaluations.arn,
+          "${aws_s3_bucket.evaluations.arn}/*"
+        ]
+      },
+      {
+        Sid      = "SQSConsumeMessages"
+        Effect   = "Allow"
+        Action   = ["sqs:ReceiveMessage", "sqs:DeleteMessage", "sqs:GetQueueAttributes"]
+        Resource = [aws_sqs_queue.evaluation.arn]
+      },
+      {
+        Sid    = "BedrockAgentCoreAccess"
+        Effect = "Allow"
+        Action = [
+          "bedrock-agentcore:InvokeAgentRuntime",
+          "bedrock-agentcore:InvokeAgentRuntimeForUser",
+          "bedrock-agentcore:StopRuntimeSession",
+          "bedrock-agentcore:ListAgentRuntimes",
+          "bedrock-agentcore:GetAgentRuntimeEndpoint",
+          "bedrock-agentcore-control:ListAgentRuntimes",
+          "bedrock-agentcore-control:GetAgentRuntimeEndpoint"
+        ]
+        Resource = ["*"]
+      },
+      {
+        Sid    = "BedrockModelInvocation"
+        Effect = "Allow"
+        Action = [
+          "bedrock:InvokeModel",
+          "bedrock:InvokeModelWithResponseStream",
+          "bedrock:Converse",
+          "bedrock:ConverseStream"
+        ]
+        Resource = [
+          "arn:aws:bedrock:*::foundation-model/*",
+          "arn:aws:bedrock:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:inference-profile/*"
+        ]
+      },
+      {
+        Sid      = "AppSyncGraphQL"
+        Effect   = "Allow"
+        Action   = ["appsync:GraphQL"]
+        Resource = ["arn:aws:appsync:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:apis/${var.appsync_api_id}/*"]
+      },
+      {
+        Sid    = "KMSAccess"
+        Effect = "Allow"
+        Action = [
+          "kms:Decrypt",
+          "kms:GenerateDataKey*"
+        ]
+        Resource = [var.kms_key_arn]
+      }
+    ]
+  })
+}

--- a/iac-terraform/modules/evaluation/lambdas.tf
+++ b/iac-terraform/modules/evaluation/lambdas.tf
@@ -1,0 +1,241 @@
+/* Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0
+----------------------------------------------------------------------
+Evaluation Module - Lambda Functions
+
+Creates:
+- EvaluationResolver: Handles CRUD operations, submits test cases to SQS
+- EvaluationExecutor: Processes individual test cases from SQS (bundled with strands-agents-evals)
+*/
+
+# -----------------------------------------------------------------------------
+# EvaluationResolver Lambda
+# Handles: listEvaluators, getEvaluator, createEvaluator, deleteEvaluator, runEvaluation
+# -----------------------------------------------------------------------------
+
+resource "aws_cloudwatch_log_group" "evaluation_resolver" {
+  # checkov:skip=CKV_AWS_338:Log retention configurable, 30 days acceptable
+  name              = "/aws/lambda/${local.name_prefix}-evaluation-resolver"
+  retention_in_days = 30
+  kms_key_id        = var.kms_key_arn
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-evaluation-resolver-logs"
+  })
+}
+
+data "archive_file" "evaluation_resolver" {
+  type        = "zip"
+  source_dir  = "${local.functions_dir}/evaluation-resolver"
+  output_path = "${path.module}/../../../iac-terraform/build/evaluation-resolver.zip"
+  excludes    = ["__pycache__", "*.pyc", ".pytest_cache"]
+}
+
+resource "aws_lambda_function" "evaluation_resolver" {
+  # checkov:skip=CKV_AWS_116:DLQ not needed for synchronous API resolver
+  # checkov:skip=CKV_AWS_117:VPC not required for this function
+  # checkov:skip=CKV_AWS_272:Code signing not required for internal functions
+  # checkov:skip=CKV_AWS_115:Concurrency limit managed at account level
+  # checkov:skip=CKV_AWS_173:Environment variables do not contain secrets
+  function_name = "${local.name_prefix}-evaluation-resolver"
+  description   = "Handles evaluation CRUD operations and submits test cases to SQS"
+
+  filename         = data.archive_file.evaluation_resolver.output_path
+  source_code_hash = data.archive_file.evaluation_resolver.output_base64sha256
+  handler          = "index.handler"
+  runtime          = var.python_runtime
+  architectures    = [var.lambda_architecture]
+  timeout          = 30
+  memory_size      = 512
+
+  role = aws_iam_role.evaluation_resolver.arn
+
+  layers = [var.powertools_layer_arn]
+
+  environment {
+    variables = {
+      POWERTOOLS_SERVICE_NAME = "evaluation-resolver"
+      POWERTOOLS_LOG_LEVEL    = "INFO"
+      EVALUATIONS_TABLE       = var.evaluators_table_name
+      EVALUATIONS_BUCKET      = aws_s3_bucket.evaluations.id
+      EVALUATION_QUEUE_URL    = aws_sqs_queue.evaluation.url
+      BY_USER_ID_INDEX        = var.by_user_id_index
+      ACCOUNT_ID              = data.aws_caller_identity.current.account_id
+    }
+  }
+
+  tracing_config {
+    mode = "Active"
+  }
+
+  depends_on = [aws_cloudwatch_log_group.evaluation_resolver]
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-evaluation-resolver"
+  })
+}
+
+# -----------------------------------------------------------------------------
+# EvaluationExecutor Lambda
+# Processes individual test cases from SQS queue
+# Bundled with strands-agents-evals via build script
+# -----------------------------------------------------------------------------
+
+resource "aws_cloudwatch_log_group" "evaluation_executor" {
+  # checkov:skip=CKV_AWS_338:Log retention configurable, 30 days acceptable
+  name              = "/aws/lambda/${local.name_prefix}-evaluation-executor"
+  retention_in_days = 30
+  kms_key_id        = var.kms_key_arn
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-evaluation-executor-logs"
+  })
+}
+
+# Build the executor package with strands-agents-evals bundled
+# Uses Docker to avoid requiring local Python/pip and to compile packages for Linux (Lambda runtime)
+resource "null_resource" "evaluation_executor_deps" {
+  triggers = {
+    requirements = filemd5("${local.functions_dir}/evaluation-executor/evaluator.py")
+    index        = filemd5("${local.functions_dir}/evaluation-executor/index.py")
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command     = <<-EOF
+      set -e
+
+      # Get absolute paths (required for Docker volume mounts)
+      MODULE_DIR="$(cd "${path.module}" && pwd)"
+      SOURCE_DIR="$(cd "${local.functions_dir}/evaluation-executor" && pwd)"
+      BUILD_DIR="$(cd "${path.module}/../../.." && pwd)/iac-terraform/build/evaluation-executor-package"
+
+      echo "Building evaluation executor Lambda package with Docker..."
+      echo "Source: $SOURCE_DIR"
+      echo "Build:  $BUILD_DIR"
+
+      # Clean and create build directory
+      rm -rf "$BUILD_DIR"
+      mkdir -p "$BUILD_DIR"
+
+      # Map Lambda architecture to Docker platform
+      LAMBDA_ARCH="${var.lambda_architecture}"
+      if [ "$LAMBDA_ARCH" = "arm64" ]; then
+        DOCKER_PLATFORM="linux/arm64"
+      else
+        DOCKER_PLATFORM="linux/amd64"
+      fi
+
+      # Build using Docker (consistent with knowledge_base module approach)
+      # Strips tests and __pycache__ to reduce package size (dist-info kept for entry_points discovery)
+      # Uses --platform to compile native extensions (.so) for the correct Lambda architecture
+      # Extract Python minor version from runtime (e.g., "python3.14" -> "3.14")
+      PYTHON_VERSION=$(echo "${var.python_runtime}" | sed 's/python//')
+
+      docker run --rm \
+        --platform "$DOCKER_PLATFORM" \
+        --entrypoint /bin/bash \
+        -v "$SOURCE_DIR":/source:ro \
+        -v "$BUILD_DIR":/output \
+        "public.ecr.aws/docker/library/python:$PYTHON_VERSION-slim" \
+        -c "
+          pip install strands-agents-evals -t /output --quiet --upgrade && \
+          cp /source/*.py /output/ && \
+          find /output -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null; \
+          find /output -type d -name 'tests' -exec rm -rf {} + 2>/dev/null; \
+          find /output -type d -name 'test' -exec rm -rf {} + 2>/dev/null; \
+          find /output -type f -name '*.pyc' -delete 2>/dev/null; \
+          true
+        "
+
+      echo "Evaluation executor package built: $BUILD_DIR"
+    EOF
+  }
+}
+
+data "archive_file" "evaluation_executor" {
+  type        = "zip"
+  source_dir  = "${path.module}/../../../iac-terraform/build/evaluation-executor-package"
+  output_path = "${path.module}/../../../iac-terraform/build/evaluation-executor.zip"
+  excludes    = ["__pycache__", "*.pyc", ".pytest_cache"]
+
+  depends_on = [null_resource.evaluation_executor_deps]
+}
+
+# Upload to S3 first — the bundled zip (~80MB) exceeds Lambda's direct upload limit (67MB)
+resource "aws_s3_object" "evaluation_executor_code" {
+  bucket      = aws_s3_bucket.evaluations.id
+  key         = "lambda-code/evaluation-executor.zip"
+  source      = data.archive_file.evaluation_executor.output_path
+  source_hash = data.archive_file.evaluation_executor.output_md5
+
+  depends_on = [data.archive_file.evaluation_executor]
+}
+
+resource "aws_lambda_function" "evaluation_executor" {
+  # checkov:skip=CKV_AWS_116:DLQ handled by SQS redrive policy
+  # checkov:skip=CKV_AWS_117:VPC not required for this function
+  # checkov:skip=CKV_AWS_272:Code signing not required for internal functions
+  # checkov:skip=CKV_AWS_115:Concurrency limit managed via SQS event source maxConcurrency
+  # checkov:skip=CKV_AWS_173:Environment variables do not contain secrets
+  function_name = "${local.name_prefix}-evaluation-executor"
+  description   = "Processes individual evaluation test cases from SQS"
+
+  s3_bucket        = aws_s3_object.evaluation_executor_code.bucket
+  s3_key           = aws_s3_object.evaluation_executor_code.key
+  source_code_hash = data.archive_file.evaluation_executor.output_base64sha256
+  handler          = "index.handler"
+  runtime          = var.python_runtime
+  architectures    = [var.lambda_architecture]
+  timeout          = 900 # 15 minutes
+  memory_size      = 2048
+
+  role = aws_iam_role.evaluation_executor.arn
+
+  layers = [
+    var.powertools_layer_arn,
+    var.boto3_layer_arn,
+    var.genai_core_layer_arn,
+  ]
+
+  environment {
+    variables = {
+      POWERTOOLS_SERVICE_NAME = "evaluation-executor"
+      POWERTOOLS_LOG_LEVEL    = "INFO"
+      REGION_NAME             = data.aws_region.current.id
+      EVALUATIONS_TABLE       = var.evaluators_table_name
+      EVALUATIONS_BUCKET      = aws_s3_bucket.evaluations.id
+      ACCOUNT_ID              = data.aws_caller_identity.current.account_id
+      APPSYNC_API_ENDPOINT    = var.graphql_url
+    }
+  }
+
+  tracing_config {
+    mode = "Active"
+  }
+
+  depends_on = [aws_cloudwatch_log_group.evaluation_executor]
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-evaluation-executor"
+  })
+}
+
+# -----------------------------------------------------------------------------
+# SQS Event Source Mapping
+# Connects the evaluation queue to the executor Lambda
+# -----------------------------------------------------------------------------
+
+resource "aws_lambda_event_source_mapping" "evaluation_executor" {
+  event_source_arn = aws_sqs_queue.evaluation.arn
+  function_name    = aws_lambda_function.evaluation_executor.arn
+  batch_size       = 1 # Process one test case at a time
+  enabled          = true
+
+  scaling_config {
+    maximum_concurrency = 50 # Throttling limit (prevents overwhelming Bedrock/AgentCore)
+  }
+
+  function_response_types = ["ReportBatchItemFailures"]
+}

--- a/iac-terraform/modules/evaluation/main.tf
+++ b/iac-terraform/modules/evaluation/main.tf
@@ -1,0 +1,222 @@
+/* Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0
+----------------------------------------------------------------------
+Evaluation Module - S3 Buckets & SQS Queues
+
+Architecture: AppSync → Resolver Lambda → SQS → Executor Lambda → DynamoDB/S3
+
+Creates:
+- S3 logging bucket for evaluation data access logs
+- S3 bucket for evaluation test cases and results
+- SQS dead letter queue for failed evaluations
+- SQS queue for test case processing
+*/
+
+locals {
+  name_prefix   = lower(var.prefix)
+  functions_dir = "${path.module}/../../../lib/api/functions"
+}
+
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+# -----------------------------------------------------------------------------
+# S3 Logging Bucket
+# -----------------------------------------------------------------------------
+
+resource "aws_s3_bucket" "evaluations_logging" {
+  # checkov:skip=CKV_AWS_144:Cross-region replication not needed for logging
+  # checkov:skip=CKV_AWS_145:S3 managed encryption sufficient for logging
+  # checkov:skip=CKV_AWS_18:Logging bucket does not need its own access logging
+  # checkov:skip=CKV2_AWS_62:Event notifications not needed for logging bucket
+  # checkov:skip=CKV2_AWS_61:Lifecycle configuration not needed for logging bucket
+  bucket = "${local.name_prefix}-logging-evaluations-${data.aws_region.current.id}-${data.aws_caller_identity.current.account_id}"
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-logging-evaluations"
+  })
+}
+
+resource "aws_s3_bucket_versioning" "evaluations_logging" {
+  bucket = aws_s3_bucket.evaluations_logging.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "evaluations_logging" {
+  bucket = aws_s3_bucket.evaluations_logging.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "evaluations_logging" {
+  bucket                  = aws_s3_bucket.evaluations_logging.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_policy" "evaluations_logging" {
+  bucket = aws_s3_bucket.evaluations_logging.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "EnforceSSL"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          aws_s3_bucket.evaluations_logging.arn,
+          "${aws_s3_bucket.evaluations_logging.arn}/*"
+        ]
+        Condition = {
+          Bool = { "aws:SecureTransport" = "false" }
+        }
+      }
+    ]
+  })
+}
+
+# -----------------------------------------------------------------------------
+# S3 Evaluations Bucket
+# Stores test case data and evaluation results
+# -----------------------------------------------------------------------------
+
+resource "aws_s3_bucket" "evaluations" {
+  # checkov:skip=CKV_AWS_144:Cross-region replication not needed
+  # checkov:skip=CKV_AWS_145:S3 managed encryption sufficient
+  # checkov:skip=CKV2_AWS_62:Event notifications not needed
+  # checkov:skip=CKV2_AWS_61:Lifecycle configuration not needed
+  bucket = "${local.name_prefix}-evaluations-${data.aws_region.current.id}-${data.aws_caller_identity.current.account_id}"
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-evaluations"
+  })
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "evaluations" {
+  bucket = aws_s3_bucket.evaluations.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "evaluations" {
+  bucket                  = aws_s3_bucket.evaluations.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_logging" "evaluations" {
+  bucket        = aws_s3_bucket.evaluations.id
+  target_bucket = aws_s3_bucket.evaluations_logging.id
+  target_prefix = "/aws/${local.name_prefix}/evaluations-bucket/logs"
+}
+
+resource "aws_s3_bucket_policy" "evaluations" {
+  bucket = aws_s3_bucket.evaluations.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "EnforceSSL"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          aws_s3_bucket.evaluations.arn,
+          "${aws_s3_bucket.evaluations.arn}/*"
+        ]
+        Condition = {
+          Bool = { "aws:SecureTransport" = "false" }
+        }
+      }
+    ]
+  })
+}
+
+# -----------------------------------------------------------------------------
+# SQS Dead Letter Queue
+# Captures failed evaluation test cases after max retries
+# -----------------------------------------------------------------------------
+
+resource "aws_sqs_queue" "evaluation_dlq" {
+  # checkov:skip=CKV_AWS_27:DLQ does not need its own DLQ
+  name                      = "${local.name_prefix}-evaluation-dlq"
+  message_retention_seconds = 1209600 # 14 days
+  sqs_managed_sse_enabled   = true
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-evaluation-dlq"
+  })
+}
+
+resource "aws_sqs_queue_policy" "evaluation_dlq" {
+  queue_url = aws_sqs_queue.evaluation_dlq.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "EnforceSSL"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "sqs:*"
+        Resource  = aws_sqs_queue.evaluation_dlq.arn
+        Condition = {
+          Bool = { "aws:SecureTransport" = "false" }
+        }
+      }
+    ]
+  })
+}
+
+# -----------------------------------------------------------------------------
+# SQS Evaluation Queue
+# Each message represents a single test case to be evaluated
+# -----------------------------------------------------------------------------
+
+resource "aws_sqs_queue" "evaluation" {
+  name                       = "${local.name_prefix}-evaluation-queue"
+  visibility_timeout_seconds = 900     # 15 minutes (match Lambda timeout)
+  message_retention_seconds  = 1209600 # 14 days
+  sqs_managed_sse_enabled    = true
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.evaluation_dlq.arn
+    maxReceiveCount     = 3
+  })
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-evaluation-queue"
+  })
+}
+
+resource "aws_sqs_queue_policy" "evaluation" {
+  queue_url = aws_sqs_queue.evaluation.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "EnforceSSL"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "sqs:*"
+        Resource  = aws_sqs_queue.evaluation.arn
+        Condition = {
+          Bool = { "aws:SecureTransport" = "false" }
+        }
+      }
+    ]
+  })
+}

--- a/iac-terraform/modules/evaluation/outputs.tf
+++ b/iac-terraform/modules/evaluation/outputs.tf
@@ -1,0 +1,47 @@
+/* Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0
+----------------------------------------------------------------------
+Evaluation Module - Outputs
+*/
+
+output "operations" {
+  description = "List of GraphQL operations handled by the evaluation module"
+  value = [
+    "listEvaluators",
+    "getEvaluator",
+    "createEvaluator",
+    "deleteEvaluator",
+    "runEvaluation",
+  ]
+}
+
+output "evaluations_bucket_name" {
+  description = "Name of the S3 bucket for evaluation data"
+  value       = aws_s3_bucket.evaluations.id
+}
+
+output "evaluations_bucket_arn" {
+  description = "ARN of the S3 bucket for evaluation data"
+  value       = aws_s3_bucket.evaluations.arn
+}
+
+output "evaluation_queue_url" {
+  description = "URL of the SQS evaluation queue"
+  value       = aws_sqs_queue.evaluation.url
+}
+
+output "evaluation_queue_arn" {
+  description = "ARN of the SQS evaluation queue"
+  value       = aws_sqs_queue.evaluation.arn
+}
+
+output "evaluation_resolver_function_name" {
+  description = "Name of the evaluation resolver Lambda function"
+  value       = aws_lambda_function.evaluation_resolver.function_name
+}
+
+output "evaluation_executor_function_name" {
+  description = "Name of the evaluation executor Lambda function"
+  value       = aws_lambda_function.evaluation_executor.function_name
+}

--- a/iac-terraform/modules/evaluation/resolvers.tf
+++ b/iac-terraform/modules/evaluation/resolvers.tf
@@ -1,0 +1,97 @@
+/* Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0
+----------------------------------------------------------------------
+Evaluation Module - AppSync Resolvers
+
+Creates:
+- Lambda data source for the evaluation resolver
+- Resolvers for 5 evaluation GraphQL operations
+- None data source + resolvers for evaluation update pub/sub
+*/
+
+# -----------------------------------------------------------------------------
+# AppSync Lambda Data Source
+# -----------------------------------------------------------------------------
+
+resource "aws_appsync_datasource" "evaluation" {
+  api_id           = var.appsync_api_id
+  name             = "${replace(local.name_prefix, "-", "_")}_EvaluationDataSource"
+  type             = "AWS_LAMBDA"
+  service_role_arn = aws_iam_role.appsync_evaluation_ds.arn
+
+  lambda_config {
+    function_arn = aws_lambda_function.evaluation_resolver.arn
+  }
+}
+
+resource "aws_iam_role" "appsync_evaluation_ds" {
+  name = "${local.name_prefix}-appsync-eval-ds-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "appsync.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  tags = merge(var.tags, { Name = "${local.name_prefix}-appsync-eval-ds-role" })
+}
+
+resource "aws_iam_role_policy" "appsync_evaluation_ds" {
+  name = "${local.name_prefix}-appsync-eval-ds-policy"
+  role = aws_iam_role.appsync_evaluation_ds.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = ["lambda:InvokeFunction"]
+      Resource = [
+        aws_lambda_function.evaluation_resolver.arn,
+        "${aws_lambda_function.evaluation_resolver.arn}:*"
+      ]
+    }]
+  })
+}
+
+# -----------------------------------------------------------------------------
+# AppSync Resolvers for Evaluation Operations
+# -----------------------------------------------------------------------------
+
+resource "aws_appsync_resolver" "list_evaluators" {
+  api_id      = var.appsync_api_id
+  type        = "Query"
+  field       = "listEvaluators"
+  data_source = aws_appsync_datasource.evaluation.name
+}
+
+resource "aws_appsync_resolver" "get_evaluator" {
+  api_id      = var.appsync_api_id
+  type        = "Query"
+  field       = "getEvaluator"
+  data_source = aws_appsync_datasource.evaluation.name
+}
+
+resource "aws_appsync_resolver" "create_evaluator" {
+  api_id      = var.appsync_api_id
+  type        = "Mutation"
+  field       = "createEvaluator"
+  data_source = aws_appsync_datasource.evaluation.name
+}
+
+resource "aws_appsync_resolver" "delete_evaluator" {
+  api_id      = var.appsync_api_id
+  type        = "Mutation"
+  field       = "deleteEvaluator"
+  data_source = aws_appsync_datasource.evaluation.name
+}
+
+resource "aws_appsync_resolver" "run_evaluation" {
+  api_id      = var.appsync_api_id
+  type        = "Mutation"
+  field       = "runEvaluation"
+  data_source = aws_appsync_datasource.evaluation.name
+}

--- a/iac-terraform/modules/evaluation/variables.tf
+++ b/iac-terraform/modules/evaluation/variables.tf
@@ -1,0 +1,90 @@
+/* Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0
+----------------------------------------------------------------------
+Evaluation Module - Input Variables
+*/
+
+variable "prefix" {
+  description = "Prefix for resource names (e.g., 'dev-aca')"
+  type        = string
+}
+
+# -----------------------------------------------------------------------------
+# Lambda Layers & Runtime
+# -----------------------------------------------------------------------------
+
+variable "powertools_layer_arn" {
+  description = "ARN of the Lambda Powertools layer"
+  type        = string
+}
+
+variable "boto3_layer_arn" {
+  description = "ARN of the Boto3 layer"
+  type        = string
+}
+
+variable "genai_core_layer_arn" {
+  description = "ARN of the GenAI Core layer"
+  type        = string
+}
+
+variable "python_runtime" {
+  description = "Python runtime version for Lambda"
+  type        = string
+  default     = "python3.13"
+}
+
+variable "lambda_architecture" {
+  description = "Lambda architecture (x86_64 or arm64)"
+  type        = string
+  default     = "arm64"
+}
+
+# -----------------------------------------------------------------------------
+# DynamoDB Tables
+# -----------------------------------------------------------------------------
+
+variable "evaluators_table_name" {
+  description = "Name of the evaluators DynamoDB table"
+  type        = string
+}
+
+variable "evaluators_table_arn" {
+  description = "ARN of the evaluators DynamoDB table"
+  type        = string
+}
+
+variable "by_user_id_index" {
+  description = "Name of the byUserId GSI on sessions table"
+  type        = string
+}
+
+# -----------------------------------------------------------------------------
+# AppSync
+# -----------------------------------------------------------------------------
+
+variable "appsync_api_id" {
+  description = "AppSync GraphQL API ID"
+  type        = string
+}
+
+variable "graphql_url" {
+  description = "AppSync GraphQL endpoint URL"
+  type        = string
+}
+
+# -----------------------------------------------------------------------------
+# KMS & Tags
+# -----------------------------------------------------------------------------
+
+variable "kms_key_arn" {
+  description = "ARN of the KMS key for encryption"
+  type        = string
+}
+
+variable "tags" {
+  description = "Additional tags to apply to resources"
+  type        = map(string)
+  default     = {}
+}

--- a/iac-terraform/modules/evaluation/versions.tf
+++ b/iac-terraform/modules/evaluation/versions.tf
@@ -1,0 +1,25 @@
+/* Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0
+----------------------------------------------------------------------
+Evaluation Module - Provider Requirements
+*/
+
+terraform {
+  required_version = ">= 1.12"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.98"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = ">= 2.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.0"
+    }
+  }
+}

--- a/iac-terraform/modules/user_interface/variables.tf
+++ b/iac-terraform/modules/user_interface/variables.tf
@@ -71,6 +71,20 @@ variable "data_bucket_name" {
 }
 
 # -----------------------------------------------------------------------------
+# Evaluator Configuration (Optional)
+# -----------------------------------------------------------------------------
+
+variable "evaluator_config" {
+  description = "Evaluator configuration for the frontend (models, threshold, rubrics)"
+  type = object({
+    supported_models = map(string)
+    pass_threshold   = number
+    default_rubrics  = map(string)
+  })
+  default = null
+}
+
+# -----------------------------------------------------------------------------
 # Geo Restrictions (Optional)
 # -----------------------------------------------------------------------------
 

--- a/iac-terraform/outputs.tf
+++ b/iac-terraform/outputs.tf
@@ -234,3 +234,28 @@ output "transaction_search_enabled" {
   description = "Whether X-Ray Transaction Search is enabled"
   value       = var.observability != null ? module.observability[0].transaction_search_enabled : null
 }
+
+# -----------------------------------------------------------------------------
+# Evaluation Module Outputs
+# S3 bucket, SQS queue, and Lambda functions for agent evaluation
+# -----------------------------------------------------------------------------
+
+output "evaluations_bucket_name" {
+  description = "Name of the S3 bucket for evaluation data"
+  value       = module.evaluation.evaluations_bucket_name
+}
+
+output "evaluation_queue_url" {
+  description = "URL of the SQS evaluation queue"
+  value       = module.evaluation.evaluation_queue_url
+}
+
+output "evaluation_resolver_function_name" {
+  description = "Name of the evaluation resolver Lambda function"
+  value       = module.evaluation.evaluation_resolver_function_name
+}
+
+output "evaluation_executor_function_name" {
+  description = "Name of the evaluation executor Lambda function"
+  value       = module.evaluation.evaluation_executor_function_name
+}

--- a/iac-terraform/terraform.tfvars.example
+++ b/iac-terraform/terraform.tfvars.example
@@ -240,3 +240,37 @@ ecr_image_tag = "latest"
 #     max_lifetime_hours                   = 24   # Maximum runtime lifetime
 #   }
 # }
+
+# =============================================================================
+# Evaluator Configuration (Optional)
+# Configures agent evaluation using Strands Eval SDK
+# =============================================================================
+
+# Uncomment to configure evaluation settings:
+# evaluator_config = {
+#   # Models available for LLM-based evaluations
+#   # Key = display name, Value = Bedrock model ID
+#   # Use [REGION-PREFIX] for cross-region inference profiles
+#   supported_models = {
+#     "Claude Haiku 4.5"  = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+#     "Claude Sonnet 4.5" = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+#     "Nova 2 Lite"       = "us.amazon.nova-2-lite-v1:0"
+#   }
+#
+#   # Score threshold (0.0-1.0) above which a test case is considered passed
+#   pass_threshold = 0.8
+#
+#   # Default rubrics for each evaluator type
+#   default_rubrics = {
+#     OutputEvaluator = <<-EOT
+#       Evaluate the response based on:
+#       1. Accuracy - Is the information correct compared to expected output?
+#       2. Completeness - Does it fully answer the question?
+#       3. Clarity - Is it easy to understand?
+#
+#       Score 1.0 if all criteria are met excellently.
+#       Score 0.5 if some criteria are partially met.
+#       Score 0.0 if the response is inadequate.
+#     EOT
+#   }
+# }

--- a/iac-terraform/variables.tf
+++ b/iac-terraform/variables.tf
@@ -215,3 +215,18 @@ variable "observability" {
   })
   default = null
 }
+
+# -----------------------------------------------------------------------------
+# Evaluator Configuration (Optional)
+# Configures the agent evaluation framework using Strands Eval SDK
+# -----------------------------------------------------------------------------
+
+variable "evaluator_config" {
+  description = "Optional evaluator configuration for agent evaluation. Defines supported models, pass thresholds, and default rubrics."
+  type = object({
+    supported_models = optional(map(string), {})
+    pass_threshold   = optional(number, 0.8)
+    default_rubrics  = optional(map(string), {})
+  })
+  default = null
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3497,6 +3497,7 @@
                 "mime-types"
             ],
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-cdk/asset-awscli-v1": "2.2.263",
                 "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",


### PR DESCRIPTION
Allows to deploy agent evaluation via Strands Eval SDK with Terraform:

- Add new evaluation Terraform module with S3 buckets, SQS queues, Lambda functions, and AppSync resolvers for running evaluations
- Add evaluators DynamoDB table to api_tables module
- Integrate evaluation module in main.tf with proper dependencies
- Exclude evaluation API operations from http_api_resolver
- Pass evaluator_config to user_interface module for evaluation wizard
