### PR TITLE
♻️ refactor wizard into architecture-specific files

### DIFF
--- a/lib/user-interface/react-app/src/components/wizard/architectures/single-agent-steps.tsx
+++ b/lib/user-interface/react-app/src/components/wizard/architectures/single-agent-steps.tsx
@@ -1,0 +1,697 @@
+// ----------------------------------------------------------------------
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: MIT-0
+// ----------------------------------------------------------------------
+import {
+    Alert,
+    Box,
+    Button,
+    Checkbox,
+    Container,
+    FormField,
+    Header,
+    Icon,
+    Input,
+    Popover,
+    Select,
+    SpaceBetween,
+    Table,
+    Textarea,
+} from "@cloudscape-design/components";
+import ReactMarkdown from "react-markdown";
+import { AgentCoreRuntimeConfiguration } from "../types";
+import { CONVERSATION_MANAGER_OPTIONS, STEP_MIN_HEIGHT } from "../wizard-utils";
+
+interface SingleAgentStepsProps {
+    config: AgentCoreRuntimeConfiguration;
+    setConfig: React.Dispatch<React.SetStateAction<AgentCoreRuntimeConfiguration>>;
+    modelOptions: { label: string; value: string }[];
+    availableToolsOptions: { label: string; value: string; description?: string }[];
+    availableSubAgents: { label: string; value: string }[];
+    availableMcpServersOptions: { label: string; value: string; description?: string }[];
+    availableKnowledgeBases: { label: string; value: string }[];
+    selectedToolsData: { name: string; description: string }[];
+    selectedSubAgentsData: { toolName: string; agentName: string; params: any }[];
+    selectedMcpServersData: { name: string; description: string; mcpUrl: string }[];
+    selectedKnowledgeBasesData: {
+        toolName: string;
+        name: string;
+        description: string;
+        numberOfResults: string;
+    }[];
+    knowledgeBaseIsSupported: boolean;
+    isCreating: boolean;
+    addTool: (toolName: string | undefined) => void;
+    removeTool: (toolName: string) => void;
+    addSubAgent: (agentName: string | undefined) => void;
+    addMcpServer: (serverName: string | undefined) => void;
+    removeMcpServer: (serverName: string) => void;
+    addKnowledgeBase: (kbId: string | undefined) => void;
+    openConfigureModal: (toolName: string) => void;
+}
+
+export function getSingleAgentSteps({
+    config,
+    setConfig,
+    modelOptions,
+    availableToolsOptions,
+    availableSubAgents,
+    availableMcpServersOptions,
+    availableKnowledgeBases,
+    selectedToolsData,
+    selectedSubAgentsData,
+    selectedMcpServersData,
+    selectedKnowledgeBasesData,
+    knowledgeBaseIsSupported,
+    isCreating,
+    addTool,
+    removeTool,
+    addSubAgent,
+    addMcpServer,
+    removeMcpServer,
+    addKnowledgeBase,
+    openConfigureModal,
+}: SingleAgentStepsProps) {
+    const steps = [
+        {
+            title: "Basic Configuration",
+            content: (
+                <div style={{ minHeight: STEP_MIN_HEIGHT }}>
+                    <Container header={<Header variant="h2">Agent Instructions</Header>}>
+                        <SpaceBetween direction="vertical" size="l">
+                            <FormField
+                                label="Agent Name"
+                                description="Enter a unique name for your agent"
+                                errorText={
+                                    config.agentName.trim() === ""
+                                        ? "Agent name is required"
+                                        : !/^[a-zA-Z][a-zA-Z0-9_]{0,47}$/.test(config.agentName)
+                                          ? "Agent name must start with a letter and contain only letters, numbers, and underscores (max 48 characters)"
+                                          : ""
+                                }
+                            >
+                                <Input
+                                    value={config.agentName}
+                                    onChange={({ detail }) =>
+                                        setConfig((prev) => ({ ...prev, agentName: detail.value }))
+                                    }
+                                    placeholder="Enter agent name..."
+                                    invalid={config.agentName.trim() === ""}
+                                />
+                            </FormField>
+                            <FormField
+                                label="Instructions"
+                                description="Provide detailed instructions for your agent"
+                                errorText={
+                                    config.instructions.trim() === ""
+                                        ? "Instructions are required"
+                                        : ""
+                                }
+                            >
+                                <Textarea
+                                    value={config.instructions}
+                                    onChange={({ detail }) =>
+                                        setConfig((prev) => ({
+                                            ...prev,
+                                            instructions: detail.value,
+                                        }))
+                                    }
+                                    placeholder="Enter agent instructions..."
+                                    rows={8}
+                                    invalid={config.instructions.trim() === ""}
+                                />
+                            </FormField>
+                            <FormField label="Conversation Manager">
+                                <Select
+                                    selectedOption={
+                                        CONVERSATION_MANAGER_OPTIONS.find(
+                                            (opt) => opt.value === config.conversationManager,
+                                        ) || null
+                                    }
+                                    onChange={({ detail }) =>
+                                        setConfig((prev) => ({
+                                            ...prev,
+                                            conversationManager: (detail.selectedOption?.value ||
+                                                "sliding_window") as
+                                                | "null"
+                                                | "sliding_window"
+                                                | "summarizing",
+                                        }))
+                                    }
+                                    options={CONVERSATION_MANAGER_OPTIONS}
+                                />
+                            </FormField>
+                        </SpaceBetween>
+                    </Container>
+                </div>
+            ),
+        },
+        {
+            title: "Model Configuration",
+            content: (
+                <div style={{ minHeight: STEP_MIN_HEIGHT }}>
+                    <Container header={<Header variant="h2">Model & Parameters</Header>}>
+                        <SpaceBetween direction="vertical" size="l">
+                            <FormField label="Model">
+                                <Select
+                                    selectedOption={
+                                        modelOptions.find(
+                                            (opt) =>
+                                                opt.value ===
+                                                config.modelInferenceParameters.modelId,
+                                        ) || null
+                                    }
+                                    onChange={({ detail }) =>
+                                        setConfig((prev) => ({
+                                            ...prev,
+                                            modelInferenceParameters: {
+                                                ...prev.modelInferenceParameters,
+                                                modelId: detail.selectedOption?.value || "",
+                                            },
+                                        }))
+                                    }
+                                    options={modelOptions}
+                                />
+                            </FormField>
+                            <FormField label="Temperature" description="Value between 0 and 1">
+                                <Input
+                                    value={config.modelInferenceParameters.parameters.temperature.toString()}
+                                    onChange={({ detail }) => {
+                                        const value = parseFloat(detail.value) || 0;
+                                        if (value >= 0 && value <= 1) {
+                                            setConfig((prev) => ({
+                                                ...prev,
+                                                modelInferenceParameters: {
+                                                    ...prev.modelInferenceParameters,
+                                                    parameters: {
+                                                        ...prev.modelInferenceParameters.parameters,
+                                                        temperature: value,
+                                                    },
+                                                },
+                                            }));
+                                        }
+                                    }}
+                                    type="number"
+                                    step={0.05}
+                                />
+                            </FormField>
+                            <FormField label="Max Tokens" description="Value between 100 and 4000">
+                                <Input
+                                    value={config.modelInferenceParameters.parameters.maxTokens.toString()}
+                                    onChange={({ detail }) => {
+                                        const value = parseInt(detail.value) || 100;
+                                        if (value >= 100 && value <= 4000) {
+                                            setConfig((prev) => ({
+                                                ...prev,
+                                                modelInferenceParameters: {
+                                                    ...prev.modelInferenceParameters,
+                                                    parameters: {
+                                                        ...prev.modelInferenceParameters.parameters,
+                                                        maxTokens: value,
+                                                    },
+                                                },
+                                            }));
+                                        }
+                                    }}
+                                    type="number"
+                                    step={100}
+                                />
+                            </FormField>
+                        </SpaceBetween>
+                    </Container>
+                </div>
+            ),
+        },
+        {
+            title: "Memory Configuration",
+            content: (
+                <div style={{ minHeight: STEP_MIN_HEIGHT }}>
+                    <Container header={<Header variant="h2">Memory Settings</Header>}>
+                        <SpaceBetween direction="vertical" size="l">
+                            <FormField
+                                label="AgentCore Memory"
+                                description="Create an AgentCore Memory and attach it to your agent Runtime."
+                            >
+                                <Checkbox
+                                    checked={config.useMemory || false}
+                                    onChange={({ detail }) =>
+                                        setConfig((prev) => ({
+                                            ...prev,
+                                            useMemory: detail.checked,
+                                        }))
+                                    }
+                                >
+                                    Enable AgentCore Memory
+                                </Checkbox>
+                            </FormField>
+                            {config.useMemory && (
+                                <Alert type="info" header="AgentCore Memory Enabled">
+                                    AgentCore Memory will be created and attached to your agent
+                                    Runtime. This allows the agent to maintain conversation context
+                                    even when sessions are terminated (due to inactivity or reaching
+                                    max duration).
+                                </Alert>
+                            )}
+                        </SpaceBetween>
+                    </Container>
+                </div>
+            ),
+        },
+        {
+            title: "Tools Configuration",
+            content: (
+                <div style={{ minHeight: STEP_MIN_HEIGHT }}>
+                    <Container header={<Header variant="h2">Configure Tools</Header>}>
+                        <SpaceBetween direction="vertical" size="l">
+                            <FormField label="Available Tools">
+                                <Select
+                                    placeholder={
+                                        availableToolsOptions.length === 0
+                                            ? "No additional tools available"
+                                            : "Select a tool to add"
+                                    }
+                                    options={availableToolsOptions}
+                                    disabled={availableToolsOptions.length === 0}
+                                    onChange={({ detail }) => {
+                                        if (detail.selectedOption) {
+                                            addTool(detail.selectedOption.value);
+                                        }
+                                    }}
+                                    selectedOption={null}
+                                />
+                            </FormField>
+
+                            <FormField
+                                label="Available Sub-Agents"
+                                description="Sub-agents that this orchestrator can invoke as tools"
+                            >
+                                <Select
+                                    placeholder={
+                                        availableSubAgents.length === 0
+                                            ? "No additional sub-agents available"
+                                            : "Select a sub-agent to add as a tool"
+                                    }
+                                    options={availableSubAgents}
+                                    disabled={availableSubAgents.length === 0}
+                                    onChange={({ detail }) => {
+                                        if (detail.selectedOption) {
+                                            addSubAgent(detail.selectedOption.value);
+                                        }
+                                    }}
+                                    selectedOption={null}
+                                />
+                            </FormField>
+
+                            <Container header={<Header variant="h3">Selected Tools</Header>}>
+                                {selectedToolsData.length === 0 ? (
+                                    <Alert type="info">No tools selected</Alert>
+                                ) : (
+                                    <Table
+                                        columnDefinitions={[
+                                            {
+                                                id: "name",
+                                                header: "Tool Name",
+                                                cell: (item) => item.name,
+                                            },
+                                            {
+                                                id: "description",
+                                                header: "Description",
+                                                cell: (item) => (
+                                                    <Popover
+                                                        dismissButton={false}
+                                                        position="top"
+                                                        size="medium"
+                                                        triggerType="custom"
+                                                        content={
+                                                            <Box padding="xs">
+                                                                <ReactMarkdown>
+                                                                    {item.description}
+                                                                </ReactMarkdown>
+                                                            </Box>
+                                                        }
+                                                    >
+                                                        <Icon name="status-info" />
+                                                    </Popover>
+                                                ),
+                                            },
+                                            {
+                                                id: "actions",
+                                                header: "Actions",
+                                                cell: (item) => (
+                                                    <Button
+                                                        variant="icon"
+                                                        iconName="close"
+                                                        onClick={() => removeTool(item.name)}
+                                                    />
+                                                ),
+                                            },
+                                        ]}
+                                        items={selectedToolsData}
+                                        loadingText="Loading tools"
+                                        empty={
+                                            <Box textAlign="center" color="inherit">
+                                                <b>No tools selected</b>
+                                                <Box
+                                                    padding={{ bottom: "s" }}
+                                                    variant="p"
+                                                    color="inherit"
+                                                >
+                                                    Select tools from the dropdown above.
+                                                </Box>
+                                            </Box>
+                                        }
+                                    />
+                                )}
+                            </Container>
+
+                            <Container
+                                header={<Header variant="h3">Selected Sub-Agents (Tools)</Header>}
+                            >
+                                {selectedSubAgentsData.length === 0 ? (
+                                    <Alert type="info">No sub-agents selected</Alert>
+                                ) : (
+                                    <Table
+                                        columnDefinitions={[
+                                            {
+                                                id: "name",
+                                                header: "Agent Name",
+                                                cell: (item) => item.agentName,
+                                            },
+                                            {
+                                                id: "parameters",
+                                                header: "Parameters",
+                                                cell: (item) => {
+                                                    const isConfigured =
+                                                        item.params?.qualifier && item.params?.role;
+                                                    return (
+                                                        <Button
+                                                            variant="normal"
+                                                            onClick={() =>
+                                                                openConfigureModal(item.toolName)
+                                                            }
+                                                        >
+                                                            {isConfigured
+                                                                ? "Configured"
+                                                                : "Configure"}
+                                                        </Button>
+                                                    );
+                                                },
+                                            },
+                                            {
+                                                id: "actions",
+                                                header: "Actions",
+                                                cell: (item) => (
+                                                    <Button
+                                                        variant="icon"
+                                                        iconName="close"
+                                                        onClick={() => removeTool(item.toolName)}
+                                                    />
+                                                ),
+                                            },
+                                        ]}
+                                        items={selectedSubAgentsData}
+                                        loadingText="Loading sub-agents"
+                                        empty={
+                                            <Box textAlign="center" color="inherit">
+                                                <b>No sub-agents selected</b>
+                                                <Box
+                                                    padding={{ bottom: "s" }}
+                                                    variant="p"
+                                                    color="inherit"
+                                                >
+                                                    Select sub-agents from the dropdown above.
+                                                </Box>
+                                            </Box>
+                                        }
+                                    />
+                                )}
+                            </Container>
+                        </SpaceBetween>
+                    </Container>
+                </div>
+            ),
+        },
+        {
+            title: "MCP Servers Configuration",
+            content: (
+                <div style={{ minHeight: STEP_MIN_HEIGHT }}>
+                    <Container header={<Header variant="h2">Configure MCP Servers</Header>}>
+                        <SpaceBetween direction="vertical" size="l">
+                            <FormField
+                                label="Available MCP Servers"
+                                description="Model Context Protocol servers provide additional capabilities to your agent"
+                            >
+                                <Select
+                                    placeholder={
+                                        availableMcpServersOptions.length === 0
+                                            ? "No MCP servers available"
+                                            : "Select an MCP server to add"
+                                    }
+                                    options={availableMcpServersOptions}
+                                    disabled={availableMcpServersOptions.length === 0}
+                                    onChange={({ detail }) => {
+                                        if (detail.selectedOption) {
+                                            addMcpServer(detail.selectedOption.value);
+                                        }
+                                    }}
+                                    selectedOption={null}
+                                />
+                            </FormField>
+
+                            <Container header={<Header variant="h3">Selected MCP Servers</Header>}>
+                                {selectedMcpServersData.length === 0 ? (
+                                    <Alert type="info">No MCP servers selected</Alert>
+                                ) : (
+                                    <Table
+                                        columnDefinitions={[
+                                            {
+                                                id: "name",
+                                                header: "Server Name",
+                                                cell: (item) => item.name,
+                                            },
+                                            {
+                                                id: "description",
+                                                header: "Description",
+                                                cell: (item) => (
+                                                    <Popover
+                                                        dismissButton={false}
+                                                        position="top"
+                                                        size="medium"
+                                                        triggerType="custom"
+                                                        content={
+                                                            <Box padding="xs">
+                                                                <ReactMarkdown>
+                                                                    {item.description}
+                                                                </ReactMarkdown>
+                                                            </Box>
+                                                        }
+                                                    >
+                                                        <Icon name="status-info" />
+                                                    </Popover>
+                                                ),
+                                            },
+                                            {
+                                                id: "actions",
+                                                header: "Actions",
+                                                cell: (item) => (
+                                                    <Button
+                                                        variant="icon"
+                                                        iconName="close"
+                                                        onClick={() => removeMcpServer(item.name)}
+                                                    />
+                                                ),
+                                            },
+                                        ]}
+                                        items={selectedMcpServersData}
+                                        loadingText="Loading MCP servers"
+                                        empty={
+                                            <Box textAlign="center" color="inherit">
+                                                <b>No MCP servers selected</b>
+                                                <Box
+                                                    padding={{ bottom: "s" }}
+                                                    variant="p"
+                                                    color="inherit"
+                                                >
+                                                    Select MCP servers from the dropdown above.
+                                                </Box>
+                                            </Box>
+                                        }
+                                    />
+                                )}
+                            </Container>
+                        </SpaceBetween>
+                    </Container>
+                </div>
+            ),
+        },
+    ];
+
+    // Conditionally add Knowledge Bases step
+    if (knowledgeBaseIsSupported) {
+        steps.push({
+            title: "Knowledge Bases",
+            content: (
+                <div style={{ minHeight: STEP_MIN_HEIGHT }}>
+                    <Container
+                        header={<Header variant="h2">Configure Knowledge Bases</Header>}
+                    >
+                        <SpaceBetween direction="vertical" size="l">
+                            <FormField label="Available Knowledge Bases">
+                                <Select
+                                    placeholder={
+                                        availableKnowledgeBases.length === 0
+                                            ? "No additional knowledge bases available"
+                                            : "Select a knowledge base to add"
+                                    }
+                                    options={availableKnowledgeBases}
+                                    disabled={availableKnowledgeBases.length === 0}
+                                    onChange={({ detail }) => {
+                                        if (detail.selectedOption) {
+                                            addKnowledgeBase(detail.selectedOption.value);
+                                        }
+                                    }}
+                                    selectedOption={null}
+                                />
+                            </FormField>
+
+                            <Container
+                                header={
+                                    <Header variant="h3">Selected Knowledge Bases</Header>
+                                }
+                            >
+                                {selectedKnowledgeBasesData.length === 0 ? (
+                                    <Alert type="info">No knowledge bases selected</Alert>
+                                ) : (
+                                    <Table
+                                        columnDefinitions={[
+                                            {
+                                                id: "name",
+                                                header: "Knowledge Base",
+                                                cell: (item) => item.name,
+                                            },
+                                            {
+                                                id: "description",
+                                                header: "Description",
+                                                cell: (item) => (
+                                                    <Popover
+                                                        dismissButton={false}
+                                                        position="top"
+                                                        size="medium"
+                                                        triggerType="custom"
+                                                        content={
+                                                            <Box padding="xs">
+                                                                <ReactMarkdown>
+                                                                    {item.description}
+                                                                </ReactMarkdown>
+                                                            </Box>
+                                                        }
+                                                    >
+                                                        <Icon name="status-info" />
+                                                    </Popover>
+                                                ),
+                                            },
+                                            {
+                                                id: "parameters",
+                                                header: "Parameters",
+                                                cell: (item) => (
+                                                    <Button
+                                                        variant="normal"
+                                                        onClick={() =>
+                                                            openConfigureModal(item.toolName)
+                                                        }
+                                                    >
+                                                        Configure
+                                                    </Button>
+                                                ),
+                                            },
+                                            {
+                                                id: "actions",
+                                                header: "Actions",
+                                                cell: (item) => (
+                                                    <Button
+                                                        variant="icon"
+                                                        iconName="close"
+                                                        onClick={() =>
+                                                            removeTool(item.toolName)
+                                                        }
+                                                    />
+                                                ),
+                                            },
+                                        ]}
+                                        items={selectedKnowledgeBasesData}
+                                        loadingText="Loading knowledge bases"
+                                        empty={
+                                            <Box textAlign="center" color="inherit">
+                                                <b>No knowledge bases selected</b>
+                                                <Box
+                                                    padding={{ bottom: "s" }}
+                                                    variant="p"
+                                                    color="inherit"
+                                                >
+                                                    Select knowledge bases from the dropdown
+                                                    above.
+                                                </Box>
+                                            </Box>
+                                        }
+                                    />
+                                )}
+                            </Container>
+                        </SpaceBetween>
+                    </Container>
+                </div>
+            ),
+        });
+    }
+
+    // Review step
+    steps.push({
+        title: "Review",
+        content: (
+            <div style={{ minHeight: STEP_MIN_HEIGHT }}>
+                <Container header={<Header variant="h2">Review Configuration</Header>}>
+                    <SpaceBetween direction="vertical" size="m">
+                        {!isCreating && (
+                            <Alert type="info" header="Configuration Summary">
+                                Review your agent configuration before creating.
+                            </Alert>
+                        )}
+                        <Box padding="m" variant="code">
+                            <pre style={{ margin: 0, overflow: "auto" }}>
+                                {JSON.stringify(config, null, 2)}
+                            </pre>
+                        </Box>
+                    </SpaceBetween>
+                </Container>
+            </div>
+        ),
+    });
+
+    return steps;
+}
+
+/** Validate a single-agent step */
+export function isSingleAgentStepValid(
+    stepIndex: number,
+    config: AgentCoreRuntimeConfiguration,
+): boolean {
+    // stepIndex is relative to the architecture-specific steps (0 = Basic Config, etc.)
+    if (stepIndex === 0) {
+        const agentNamePattern = /^[a-zA-Z][a-zA-Z0-9_]{0,47}$/;
+        return (
+            config.instructions.trim() !== "" &&
+            config.agentName.trim() !== "" &&
+            agentNamePattern.test(config.agentName)
+        );
+    }
+    // Step 3 = Tools Config
+    if (stepIndex === 3) {
+        return !config.tools.some((tool) => {
+            return (
+                tool.startsWith("invoke_subagent_") &&
+                !config.toolParameters[tool]?.agentName
+            );
+        });
+    }
+    return true;
+}

--- a/lib/user-interface/react-app/src/components/wizard/architectures/swarm-agent-steps.tsx
+++ b/lib/user-interface/react-app/src/components/wizard/architectures/swarm-agent-steps.tsx
@@ -1,0 +1,435 @@
+// ----------------------------------------------------------------------
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: MIT-0
+// ----------------------------------------------------------------------
+import {
+    Alert,
+    Box,
+    Button,
+    ColumnLayout,
+    Container,
+    FormField,
+    Header,
+    Input,
+    Select,
+    SpaceBetween,
+    Table,
+} from "@cloudscape-design/components";
+import { RuntimeSummary } from "../../../API";
+import { AgentCoreRuntimeConfiguration, SwarmConfiguration } from "../types";
+import { CONVERSATION_MANAGER_OPTIONS, STEP_MIN_HEIGHT } from "../wizard-utils";
+
+interface SwarmAgentStepsProps {
+    config: AgentCoreRuntimeConfiguration;
+    setConfig: React.Dispatch<React.SetStateAction<AgentCoreRuntimeConfiguration>>;
+    swarmConfig: SwarmConfiguration;
+    setSwarmConfig: React.Dispatch<React.SetStateAction<SwarmConfiguration>>;
+    availableAgents: RuntimeSummary[];
+    isCreating: boolean;
+    architectureType: string;
+    addAgentReference: (agentName: string) => void;
+    removeAgentReference: (index: number) => void;
+    updateAgentReferenceEndpoint: (index: number, endpointName: string) => void;
+    getSwarmAgentNames: () => string[];
+}
+
+export function getSwarmAgentSteps({
+    config,
+    setConfig,
+    swarmConfig,
+    setSwarmConfig,
+    availableAgents,
+    isCreating,
+    architectureType,
+    addAgentReference,
+    removeAgentReference,
+    updateAgentReferenceEndpoint,
+    getSwarmAgentNames,
+}: SwarmAgentStepsProps) {
+    return [
+        {
+            title: "Swarm Configuration",
+            content: (
+                <div style={{ minHeight: STEP_MIN_HEIGHT }}>
+                    <SpaceBetween direction="vertical" size="l">
+                        <Container header={<Header variant="h2">Agent Name</Header>}>
+                            <FormField
+                                label="Agent Name"
+                                description="Enter a unique name for your swarm agent"
+                                errorText={
+                                    config.agentName.trim() === ""
+                                        ? "Agent name is required"
+                                        : !/^[a-zA-Z][a-zA-Z0-9_]{0,47}$/.test(config.agentName)
+                                          ? "Agent name must start with a letter and contain only letters, numbers, and underscores (max 48 characters)"
+                                          : ""
+                                }
+                            >
+                                <Input
+                                    value={config.agentName}
+                                    onChange={({ detail }) =>
+                                        setConfig((prev) => ({
+                                            ...prev,
+                                            agentName: detail.value,
+                                        }))
+                                    }
+                                    placeholder="Enter agent name..."
+                                    invalid={config.agentName.trim() === ""}
+                                />
+                            </FormField>
+                        </Container>
+
+                        <Container header={<Header variant="h2">Agent Source</Header>}>
+                            <SpaceBetween direction="vertical" size="l">
+                                <SpaceBetween direction="vertical" size="m">
+                                    <FormField label="Select Agent">
+                                        <Select
+                                            placeholder="Select an existing agent to reference"
+                                            options={availableAgents
+                                                .filter(
+                                                    (a) =>
+                                                        a.agentName !== config.agentName &&
+                                                        !swarmConfig.agentReferences.some(
+                                                            (r) =>
+                                                                r.agentName === a.agentName,
+                                                        ),
+                                                )
+                                                .map((a) => ({
+                                                    label: a.agentName,
+                                                    value: a.agentName,
+                                                }))}
+                                            onChange={({ detail }) => {
+                                                if (detail.selectedOption?.value) {
+                                                    addAgentReference(
+                                                        detail.selectedOption.value,
+                                                    );
+                                                }
+                                            }}
+                                            selectedOption={null}
+                                        />
+                                    </FormField>
+                                    {swarmConfig.agentReferences.length === 0 ? (
+                                        <Alert type="info">
+                                            No agent references added yet.
+                                        </Alert>
+                                    ) : (
+                                        <Table
+                                            items={swarmConfig.agentReferences}
+                                            columnDefinitions={[
+                                                {
+                                                    id: "agentName",
+                                                    header: "Agent Name",
+                                                    cell: (item) => item.agentName,
+                                                    isRowHeader: true,
+                                                },
+                                                {
+                                                    id: "endpointName",
+                                                    header: "Endpoint",
+                                                    cell: (item) => {
+                                                        const idx =
+                                                            swarmConfig.agentReferences.findIndex(
+                                                                (r) => r.agentName === item.agentName,
+                                                            );
+                                                        const agent = availableAgents.find(
+                                                            (a) =>
+                                                                a.agentName ===
+                                                                item.agentName,
+                                                        );
+                                                        const endpointOptions: {
+                                                            label: string;
+                                                            value: string;
+                                                        }[] = [];
+                                                        if (agent?.qualifierToVersion) {
+                                                            try {
+                                                                const qtv = JSON.parse(
+                                                                    agent.qualifierToVersion,
+                                                                );
+                                                                if (
+                                                                    qtv &&
+                                                                    typeof qtv === "object"
+                                                                ) {
+                                                                    endpointOptions.push(
+                                                                        ...Object.keys(
+                                                                            qtv,
+                                                                        ).map((key) => ({
+                                                                            label: key,
+                                                                            value: key,
+                                                                        })),
+                                                                    );
+                                                                }
+                                                            } catch (error) {
+                                                                console.error(
+                                                                    "Failed to parse qualifierToVersion:",
+                                                                    error,
+                                                                );
+                                                            }
+                                                        }
+                                                        if (
+                                                            !endpointOptions.some(
+                                                                (o) =>
+                                                                    o.value === "DEFAULT",
+                                                            )
+                                                        ) {
+                                                            endpointOptions.unshift({
+                                                                label: "DEFAULT",
+                                                                value: "DEFAULT",
+                                                            });
+                                                        }
+                                                        return (
+                                                            <Select
+                                                                expandToViewport
+                                                                selectedOption={
+                                                                    endpointOptions.find(
+                                                                        (o) =>
+                                                                            o.value ===
+                                                                            item.endpointName,
+                                                                    ) || {
+                                                                        label: item.endpointName,
+                                                                        value: item.endpointName,
+                                                                    }
+                                                                }
+                                                                onChange={({ detail }) =>
+                                                                    updateAgentReferenceEndpoint(
+                                                                        idx,
+                                                                        detail.selectedOption
+                                                                            ?.value ||
+                                                                            "DEFAULT",
+                                                                    )
+                                                                }
+                                                                options={endpointOptions}
+                                                            />
+                                                        );
+                                                    },
+                                                },
+                                                {
+                                                    id: "actions",
+                                                    header: "Actions",
+                                                    cell: (item) => {
+                                                        const idx =
+                                                            swarmConfig.agentReferences.findIndex(
+                                                                (r) => r.agentName === item.agentName,
+                                                            );
+                                                        return (
+                                                            <Button
+                                                                variant="icon"
+                                                                iconName="close"
+                                                                onClick={() =>
+                                                                    removeAgentReference(idx)
+                                                                }
+                                                            />
+                                                        );
+                                                    },
+                                                },
+                                            ]}
+                                        />
+                                    )}
+                                </SpaceBetween>
+                            </SpaceBetween>
+                        </Container>
+
+                        <Container header={<Header variant="h2">Entry Agent</Header>}>
+                            <FormField
+                                label="Entry Agent"
+                                description="The agent that receives the initial user message"
+                            >
+                                <Select
+                                    placeholder="Select entry agent"
+                                    options={getSwarmAgentNames().map((name) => ({
+                                        label: name,
+                                        value: name,
+                                    }))}
+                                    selectedOption={
+                                        swarmConfig.entryAgent
+                                            ? {
+                                                  label: swarmConfig.entryAgent,
+                                                  value: swarmConfig.entryAgent,
+                                              }
+                                            : null
+                                    }
+                                    onChange={({ detail }) =>
+                                        setSwarmConfig((prev) => ({
+                                            ...prev,
+                                            entryAgent: detail.selectedOption?.value || "",
+                                        }))
+                                    }
+                                    disabled={getSwarmAgentNames().length === 0}
+                                />
+                            </FormField>
+                        </Container>
+
+                        <Container
+                            header={<Header variant="h2">Orchestrator Settings</Header>}
+                        >
+                            <ColumnLayout columns={2} variant="text-grid">
+                                <FormField
+                                    label="Max Handoffs"
+                                    description="Maximum agent-to-agent handoffs"
+                                >
+                                    <Input
+                                        type="number"
+                                        value={swarmConfig.orchestrator.maxHandoffs.toString()}
+                                        onChange={({ detail }) =>
+                                            setSwarmConfig((prev) => ({
+                                                ...prev,
+                                                orchestrator: {
+                                                    ...prev.orchestrator,
+                                                    maxHandoffs: parseInt(detail.value) || 15,
+                                                },
+                                            }))
+                                        }
+                                    />
+                                </FormField>
+                                <FormField
+                                    label="Max Iterations"
+                                    description="Maximum total iterations"
+                                >
+                                    <Input
+                                        type="number"
+                                        value={swarmConfig.orchestrator.maxIterations.toString()}
+                                        onChange={({ detail }) =>
+                                            setSwarmConfig((prev) => ({
+                                                ...prev,
+                                                orchestrator: {
+                                                    ...prev.orchestrator,
+                                                    maxIterations: parseInt(detail.value) || 50,
+                                                },
+                                            }))
+                                        }
+                                    />
+                                </FormField>
+                                <FormField
+                                    label="Execution Timeout (s)"
+                                    description="Total execution timeout in seconds"
+                                    errorText={
+                                        swarmConfig.orchestrator.executionTimeoutSeconds <= 0
+                                            ? "Must be greater than 0"
+                                            : ""
+                                    }
+                                >
+                                    <Input
+                                        type="number"
+                                        value={swarmConfig.orchestrator.executionTimeoutSeconds.toString()}
+                                        onChange={({ detail }) =>
+                                            setSwarmConfig((prev) => ({
+                                                ...prev,
+                                                orchestrator: {
+                                                    ...prev.orchestrator,
+                                                    executionTimeoutSeconds:
+                                                        parseFloat(detail.value) || 300,
+                                                },
+                                            }))
+                                        }
+                                    />
+                                </FormField>
+                                <FormField
+                                    label="Node Timeout (s)"
+                                    description="Per-agent timeout in seconds"
+                                    errorText={
+                                        swarmConfig.orchestrator.nodeTimeoutSeconds >
+                                        swarmConfig.orchestrator.executionTimeoutSeconds
+                                            ? "Node timeout must not exceed execution timeout"
+                                            : ""
+                                    }
+                                >
+                                    <Input
+                                        type="number"
+                                        value={swarmConfig.orchestrator.nodeTimeoutSeconds.toString()}
+                                        onChange={({ detail }) =>
+                                            setSwarmConfig((prev) => ({
+                                                ...prev,
+                                                orchestrator: {
+                                                    ...prev.orchestrator,
+                                                    nodeTimeoutSeconds:
+                                                        parseFloat(detail.value) || 60,
+                                                },
+                                            }))
+                                        }
+                                    />
+                                </FormField>
+                            </ColumnLayout>
+                        </Container>
+
+                        <Container
+                            header={<Header variant="h2">Conversation Manager</Header>}
+                        >
+                            <FormField label="Conversation Manager">
+                                <Select
+                                    selectedOption={
+                                        CONVERSATION_MANAGER_OPTIONS.find(
+                                            (opt) =>
+                                                opt.value === swarmConfig.conversationManager,
+                                        ) || null
+                                    }
+                                    onChange={({ detail }) =>
+                                        setSwarmConfig((prev) => ({
+                                            ...prev,
+                                            conversationManager:
+                                                (detail.selectedOption?.value ||
+                                                    "sliding_window") as
+                                                    | "null"
+                                                    | "sliding_window"
+                                                    | "summarizing",
+                                        }))
+                                    }
+                                    options={CONVERSATION_MANAGER_OPTIONS}
+                                />
+                            </FormField>
+                        </Container>
+                    </SpaceBetween>
+                </div>
+            ),
+        },
+        {
+            title: "Review",
+            content: (
+                <div style={{ minHeight: STEP_MIN_HEIGHT }}>
+                    <Container header={<Header variant="h2">Review Configuration</Header>}>
+                        <SpaceBetween direction="vertical" size="m">
+                            {!isCreating && (
+                                <Alert type="info" header="Configuration Summary">
+                                    Review your swarm agent configuration before creating.
+                                </Alert>
+                            )}
+                            <Box padding="m" variant="code">
+                                <pre style={{ margin: 0, overflow: "auto" }}>
+                                    {JSON.stringify(
+                                        {
+                                            agentName: config.agentName,
+                                            architectureType,
+                                            swarmConfig,
+                                        },
+                                        null,
+                                        2,
+                                    )}
+                                </pre>
+                            </Box>
+                        </SpaceBetween>
+                    </Container>
+                </div>
+            ),
+        },
+    ];
+}
+
+/** Validate a swarm step */
+export function isSwarmStepValid(
+    stepIndex: number,
+    config: AgentCoreRuntimeConfiguration,
+    swarmConfig: SwarmConfiguration,
+): boolean {
+    // stepIndex 0 = Swarm Configuration
+    if (stepIndex === 0) {
+        const agentNamePattern = /^[a-zA-Z][a-zA-Z0-9_]{0,47}$/;
+        const hasAgentName =
+            config.agentName.trim() !== "" && agentNamePattern.test(config.agentName);
+        const hasAgents = swarmConfig.agentReferences.length > 0;
+        const hasEntryAgent = swarmConfig.entryAgent.trim() !== "";
+        const validTimeouts =
+            swarmConfig.orchestrator.executionTimeoutSeconds > 0 &&
+            swarmConfig.orchestrator.nodeTimeoutSeconds > 0 &&
+            swarmConfig.orchestrator.nodeTimeoutSeconds <=
+            swarmConfig.orchestrator.executionTimeoutSeconds;
+        return hasAgentName && hasAgents && hasEntryAgent && validTimeouts;
+    }
+    return true;
+}

--- a/lib/user-interface/react-app/src/components/wizard/wizard-utils.ts
+++ b/lib/user-interface/react-app/src/components/wizard/wizard-utils.ts
@@ -1,0 +1,62 @@
+// ----------------------------------------------------------------------
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: MIT-0
+// ----------------------------------------------------------------------
+
+// Set of dangerous keys that could lead to prototype pollution
+const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+// Helper function to check for prototype pollution attacks
+const isSafePropertyKey = (key: string): boolean => {
+    return !DANGEROUS_KEYS.has(key);
+};
+
+// Safe deep property setter that prevents prototype pollution using recursion
+const safeDeepSetRecursive = (
+    obj: Record<string, any>,
+    keys: readonly string[],
+    keyIndex: number,
+    value: any,
+): Record<string, any> => {
+    if (keyIndex === keys.length - 1) {
+        const finalKey = keys[keyIndex];
+        return { ...obj, [finalKey]: value };
+    }
+
+    const currentKey = keys[keyIndex];
+    const currentValue = Object.prototype.hasOwnProperty.call(obj, currentKey)
+        ? obj[currentKey]
+        : null;
+    const nestedObj =
+        typeof currentValue === "object" && currentValue !== null
+            ? currentValue
+            : Object.create(null);
+
+    return {
+        ...obj,
+        [currentKey]: safeDeepSetRecursive(nestedObj, keys, keyIndex + 1, value),
+    };
+};
+
+/** Safe deep property setter that prevents prototype pollution */
+export const safeDeepSet = <T extends Record<string, any>>(obj: T, path: string, value: any): T => {
+    const keys = path.split(".");
+
+    if (!keys.every(isSafePropertyKey)) {
+        console.error("Invalid property path detected - potential prototype pollution");
+        return obj;
+    }
+
+    return safeDeepSetRecursive(obj, keys, 0, value) as T;
+};
+
+export { DANGEROUS_KEYS };
+
+export const CONVERSATION_MANAGER_OPTIONS = [
+    { label: "Sliding Window", value: "sliding_window" },
+    { label: "Summarizing", value: "summarizing" },
+    { label: "None", value: "null" },
+];
+
+export const STEP_MIN_HEIGHT = "62vh";


### PR DESCRIPTION
## Refactor: Split agent runtime wizard into architecture-specific files

### What

The `agent-core-runtime-wizard.tsx` file (~1930 lines) has been split into focused modules:

- `wizard/agent-core-runtime-wizard.tsx` — shell with state, data fetching, actions, Wizard component
- `wizard/wizard-utils.ts` — shared constants and safeDeepSet utility
- `wizard/types.ts` — unchanged
- `wizard/architectures/single-agent-steps.tsx` — single-agent wizard steps and validation
- `wizard/architectures/swarm-agent-steps.tsx` — swarm wizard steps and validation

### Bug fixes included

- **New version flow for swarm agents**: When creating a new version from an existing swarm agent (`/agent-core/create?from=...`), the wizard now correctly detects the swarm config, skips the architecture selector step, and pre-populates the swarm configuration.
- **Self-reference in swarm dropdown**: The current agent is now filtered out of the agent source dropdown so you can't add yourself as a swarm member.
- **indexOf fragility**: Replaced `indexOf` with `findIndex` using `agentName` for stable matching in swarm agent table cell renderers.
- **Orchestrator timeout validation**: Added UI validation that node timeout must not exceed execution timeout, and both must be greater than 0. The wizard blocks progression when these constraints are violated.
- **Stale initialData useEffect**: Fixed empty dependency array to include `initialData` so KB reranking and search type toggles correctly initialize when loading an existing agent config asynchronously.
- **Duplicate KB guard**: `addKnowledgeBase` now checks for duplicates before adding, matching the existing pattern in `addTool`.

### What didn't change

All wizard behavior, step ordering, UI layout, and submission logic remain identical. The refactor is a structural split with no functional changes beyond the fixes listed above.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
