### PR TITLE
✨ Implement Agent Experiments Feature

### DIFF
--- a/bin/config.ts
+++ b/bin/config.ts
@@ -88,6 +88,15 @@ export function getConfig(): SystemConfig {
                     Score 0.0 if the trajectory was significantly flawed or failed to achieve the goal.`,
             },
         },
+
+        experimentsConfig: {
+            // Models available for synthetic data generation
+            supportedModels: {
+                "Claude Haiku 4.5": "[REGION-PREFIX].anthropic.claude-haiku-4-5-20251001-v1:0",
+                "Claude Sonnet 4.5": "[REGION-PREFIX].anthropic.claude-sonnet-4-5-20250929-v1:0",
+                "Nova 2 Lite": "[REGION-PREFIX].amazon.nova-2-lite-v1:0",
+            },
+        },
     };
 }
 

--- a/lib/api/evaluation-api.ts
+++ b/lib/api/evaluation-api.ts
@@ -156,6 +156,7 @@ export class EvaluationApi extends Construct {
         const evaluationExecutor = new lambda.Function(this, "EvaluationExecutor", {
             functionName: `${prefix}-evaluation-executor`,
             code: lambda.Code.fromAsset(path.join(__dirname, "functions/evaluation-executor"), {
+                exclude: ["**/__pycache__", "**/*.рус", "**/.pytest_cache"],
                 bundling: {
                     image: props.shared.pythonRuntime.bundlingImage,
                     platform: props.shared.lambdaArchitecture.dockerPlatform,

--- a/lib/api/experiments-api.ts
+++ b/lib/api/experiments-api.ts
@@ -87,10 +87,11 @@ export class ExperimentOps extends Construct {
                 actions: ["batch:SubmitJob", "batch:DescribeJobs", "batch:TerminateJob"],
                 resources: [
                     this.batch.jobQueue.jobQueueArn,
-                    // Allow all job definitions in the account (needed for SubmitJob)
-                    `arn:aws:batch:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:job-definition/*`,
-                    // Allow all job instances
-                    `arn:aws:batch:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:job/*`,
+                    // Include both the bare ARN and the revision wildcard. AWS Batch evaluates
+                    // SubmitJob against the resolved revision ARN (e.g. :3), so :* alone is
+                    // insufficient in some SDK/API paths that pass the bare name.
+                    `arn:aws:batch:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:job-definition/${this.batch.jobDefinition.jobDefinitionName}`,
+                    `arn:aws:batch:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:job-definition/${this.batch.jobDefinition.jobDefinitionName}:*`,
                 ],
             }),
         );

--- a/lib/api/experiments-api.ts
+++ b/lib/api/experiments-api.ts
@@ -1,0 +1,155 @@
+// ----------------------------------------------------------------------
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+// ----------------------------------------------------------------------
+
+import * as cdk from "aws-cdk-lib";
+import { Duration, RemovalPolicy } from "aws-cdk-lib";
+import * as appsync from "aws-cdk-lib/aws-appsync";
+import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as logs from "aws-cdk-lib/aws-logs";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import { NagSuppressions } from "cdk-nag";
+import { Construct } from "constructs";
+import * as path from "path";
+
+import { ExperimentsBatch } from "../experiments-batch";
+import { Shared } from "../shared";
+import { SystemConfig } from "../shared/types";
+import { generatePrefix } from "../shared/utils";
+
+export interface ExperimentOpsProps {
+    readonly api: appsync.GraphqlApi;
+    readonly shared: Shared;
+    readonly config: SystemConfig;
+    readonly experimentsTable: dynamodb.Table;
+    readonly evaluationsBucket: s3.Bucket;
+}
+
+export class ExperimentOps extends Construct {
+    readonly operations: string[];
+    readonly batch: ExperimentsBatch;
+
+    constructor(scope: Construct, id: string, props: ExperimentOpsProps) {
+        super(scope, id);
+
+        const prefix = generatePrefix(this);
+
+        this.operations = [];
+
+        // Create AWS Batch infrastructure for experiment generation
+        this.batch = new ExperimentsBatch(this, "Batch", {
+            shared: props.shared,
+            config: props.config,
+            experimentsTableName: props.experimentsTable.tableName,
+            evaluationsBucketName: props.evaluationsBucket.bucketName,
+        });
+
+        // Create CloudWatch log group for the ExperimentResolver
+        const resolverLogGroup = new logs.LogGroup(this, "ExperimentResolverLogGroup", {
+            logGroupName: `/aws/lambda/${prefix}-experiment-resolver`,
+            retention: logs.RetentionDays.ONE_MONTH,
+            removalPolicy: RemovalPolicy.DESTROY,
+        });
+
+        // Lambda resolver for Experiment operations
+        const experimentResolver = new lambda.Function(this, "ExperimentResolver", {
+            runtime: props.shared.pythonRuntime,
+            handler: "index.handler",
+            code: lambda.Code.fromAsset(path.join(__dirname, "functions/experiment-resolver")),
+            timeout: Duration.minutes(15),
+            memorySize: 256,
+            logGroup: resolverLogGroup,
+            architecture: props.shared.lambdaArchitecture,
+            layers: [props.shared.powerToolsLayer, props.shared.boto3Layer],
+            tracing: lambda.Tracing.ACTIVE,
+            environment: {
+                ...props.shared.defaultEnvironmentVariables,
+                EXPERIMENTS_TABLE_NAME: props.experimentsTable.tableName,
+                EXPERIMENTS_BUCKET_NAME: props.evaluationsBucket.bucketName,
+                ACCOUNT_ID: cdk.Aws.ACCOUNT_ID,
+                BATCH_JOB_QUEUE: this.batch.jobQueue.jobQueueName,
+                BATCH_JOB_DEFINITION: this.batch.jobDefinition.jobDefinitionName,
+            },
+        });
+
+        // Grant permissions
+        props.experimentsTable.grantReadWriteData(experimentResolver);
+        props.evaluationsBucket.grantReadWrite(experimentResolver);
+
+        // Grant permissions to submit Batch jobs
+        experimentResolver.addToRolePolicy(
+            new iam.PolicyStatement({
+                effect: iam.Effect.ALLOW,
+                actions: ["batch:SubmitJob", "batch:DescribeJobs", "batch:TerminateJob"],
+                resources: [
+                    this.batch.jobQueue.jobQueueArn,
+                    // Allow all job definitions in the account (needed for SubmitJob)
+                    `arn:aws:batch:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:job-definition/*`,
+                    // Allow all job instances
+                    `arn:aws:batch:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:job/*`,
+                ],
+            }),
+        );
+
+        // Create AppSync data source
+        const experimentDataSource = props.api.addLambdaDataSource(
+            "ExperimentResolverDataSource",
+            experimentResolver,
+            {
+                name: `${prefix}-experimentResolverDataSource`,
+            },
+        );
+
+        // Associate resolver to operations
+        const operations = [
+            { type: "Query", field: "listExperiments" },
+            { type: "Query", field: "getExperiment" },
+            { type: "Query", field: "getExperimentPresignedUrl" },
+            { type: "Mutation", field: "createExperiment" },
+            { type: "Mutation", field: "updateExperiment" },
+            { type: "Mutation", field: "deleteExperiment" },
+            { type: "Mutation", field: "runExperiment" },
+        ];
+
+        operations.forEach((op) => {
+            props.api.createResolver(`${op.field}-resolver`, {
+                typeName: op.type,
+                fieldName: op.field,
+                dataSource: experimentDataSource,
+            });
+            this.operations.push(op.field);
+        });
+
+        // CDK NAG Suppressions for Lambda
+        NagSuppressions.addResourceSuppressions(
+            experimentResolver,
+            [
+                {
+                    id: "AwsSolutions-IAM4",
+                    reason: "Lambda uses AWS managed policy for basic execution role.",
+                },
+                {
+                    id: "AwsSolutions-IAM5",
+                    reason: "Wildcard permissions required for DynamoDB indexes, Lambda self-invocation, and AgentCore runtime operations.",
+                },
+            ],
+            true,
+        );
+
+        // CDK NAG Suppressions for AppSync Data Source
+        NagSuppressions.addResourceSuppressions(
+            experimentDataSource,
+            [
+                {
+                    id: "AwsSolutions-IAM5",
+                    reason: "AppSync data source requires wildcard permissions for Lambda invocation.",
+                },
+            ],
+            true,
+        );
+    }
+}

--- a/lib/api/experiments-api.ts
+++ b/lib/api/experiments-api.ts
@@ -1,8 +1,5 @@
-// ----------------------------------------------------------------------
 // Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-//
-// SPDX-License-Identifier: Apache-2.0
-// ----------------------------------------------------------------------
+// SPDX-License-Identifier: MIT-0
 
 import * as cdk from "aws-cdk-lib";
 import { Duration, RemovalPolicy } from "aws-cdk-lib";
@@ -41,6 +38,8 @@ export class ExperimentOps extends Construct {
         this.operations = [];
 
         // Create AWS Batch infrastructure for experiment generation
+        // Note: vpc can be passed via ExperimentsBatchProps to reuse an existing VPC;
+        // if omitted, ExperimentsBatch will create a dedicated VPC for Batch workloads.
         this.batch = new ExperimentsBatch(this, "Batch", {
             shared: props.shared,
             config: props.config,
@@ -60,8 +59,8 @@ export class ExperimentOps extends Construct {
             runtime: props.shared.pythonRuntime,
             handler: "index.handler",
             code: lambda.Code.fromAsset(path.join(__dirname, "functions/experiment-resolver")),
-            timeout: Duration.minutes(15),
-            memorySize: 256,
+            timeout: Duration.seconds(30),
+            memorySize: 128,
             logGroup: resolverLogGroup,
             architecture: props.shared.lambdaArchitecture,
             layers: [props.shared.powerToolsLayer, props.shared.boto3Layer],

--- a/lib/api/functions/experiment-resolver/index.py
+++ b/lib/api/functions/experiment-resolver/index.py
@@ -7,7 +7,9 @@ from __future__ import annotations
 
 import json
 import os
+import uuid
 from datetime import datetime, timezone
+from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import boto3
@@ -34,13 +36,23 @@ BATCH_JOB_QUEUE = os.environ.get("BATCH_JOB_QUEUE", "")
 BATCH_JOB_DEFINITION = os.environ.get("BATCH_JOB_DEFINITION", "")
 # ---------------------------------------------------------- #
 
-# --------------- DynamoDB Tables ------------------- #
+# --------------- DynamoDB / Batch clients ------------------- #
 EXPERIMENTS_TABLE = boto3.resource("dynamodb").Table(EXPERIMENTS_TABLE_NAME)  # type: ignore
-# ---------------------------------------------------- #
+BATCH_CLIENT = boto3.client("batch")
+S3_CLIENT = boto3.client("s3")
+PRESIGNED_URL_EXPIRES_IN = int(os.environ.get("PRESIGNED_URL_EXPIRES_IN", 600))
+# ------------------------------------------------------------ #
 
 # ---------------- API Routes ---------------- #
 app = AppSyncResolver()
 # -------------------------------------------- #
+
+
+class ExperimentStatus(str, Enum):
+    DRAFT = "DRAFT"
+    RUNNING = "RUNNING"
+    COMPLETED = "COMPLETED"
+    FAILED = "FAILED"
 
 
 # Routes
@@ -53,12 +65,10 @@ def list_experiments() -> List[Dict[str, Any]]:
     """
     logger.info("Listing experiments")
 
-    # Get user ID from context
     user_id = app.current_event.get("identity", {}).get("username")
     if not user_id:
         raise ValueError("User ID not found in request context")
 
-    # Query by UserId using GSI
     try:
         response = EXPERIMENTS_TABLE.query(
             IndexName="byUserId", KeyConditionExpression=Key("UserId").eq(user_id)
@@ -68,7 +78,6 @@ def list_experiments() -> List[Dict[str, Any]]:
         logger.exception(f"Error querying experiments: {str(e)}")
         raise ValueError(f"Failed to list experiments: {str(e)}")
 
-    # Format response
     return [_format_experiment_response(exp) for exp in experiments]
 
 
@@ -80,12 +89,10 @@ def get_experiment(experimentId: str) -> Optional[Dict[str, Any]]:
     """
     logger.info(f"Getting experiment: {experimentId}")
 
-    # Get user ID from context for authorization
     user_id = app.current_event.get("identity", {}).get("username")
     if not user_id:
         raise ValueError("User ID not found in request context")
 
-    # Get experiment from DynamoDB
     try:
         response = EXPERIMENTS_TABLE.get_item(
             Key={"ExperimentId": experimentId, "UserId": user_id}
@@ -98,7 +105,6 @@ def get_experiment(experimentId: str) -> Optional[Dict[str, Any]]:
     if not experiment:
         return None
 
-    # Verify user has access to this experiment
     if experiment.get("UserId") != user_id:
         raise ValueError("Unauthorized access to experiment")
 
@@ -110,51 +116,37 @@ def get_experiment(experimentId: str) -> Optional[Dict[str, Any]]:
 def create_experiment(
     name: str,
     description: Optional[str] = None,
-    s3Path: Optional[str] = None,
     generationConfig: Optional[str] = None,
     modelId: str = "",
 ) -> str:
     """
     Create a new experiment and automatically trigger execution.
-    Uses the dedicated experiments runtime for test case generation.
     Returns the experimentId.
     """
     logger.info(f"Creating experiment: {name}")
 
-    # Get user ID from context
     user_id = app.current_event.get("identity", {}).get("username")
     if not user_id:
         raise ValueError("User ID not found in request context")
 
-    # Generate experiment ID
-    import uuid
-
     experiment_id = str(uuid.uuid4())
     timestamp = datetime.now(timezone.utc).isoformat()
 
-    # Parse generation config if provided
-    generation_config = {}
-    if generationConfig:
-        generation_config = json.loads(generationConfig)
+    generation_config = json.loads(generationConfig) if generationConfig else {}
 
-    # Create experiment item with RUNNING status
-    experiment_item = {
+    experiment_item: Dict[str, Any] = {
         "ExperimentId": experiment_id,
         "UserId": user_id,
         "Name": name,
-        "Status": "RUNNING",
+        "Status": ExperimentStatus.RUNNING,
         "CreatedAt": timestamp,
         "UpdatedAt": timestamp,
+        "ModelId": modelId,
     }
 
-    # Add optional fields
     if description:
         experiment_item["Description"] = description
-    if s3Path:
-        experiment_item["S3Path"] = s3Path
-    experiment_item["ModelId"] = modelId
 
-    # Add generation config fields
     if generation_config:
         if "context" in generation_config:
             experiment_item["Context"] = generation_config["context"]
@@ -165,7 +157,6 @@ def create_experiment(
         if "numTopics" in generation_config:
             experiment_item["NumTopics"] = generation_config["numTopics"]
 
-    # Validate that generation config exists
     if not all(
         [
             experiment_item.get("Context"),
@@ -179,15 +170,13 @@ def create_experiment(
             "Experiment missing required generation config (context, taskDescription, numCases, numTopics, modelId)"
         )
 
-    # Save to DynamoDB
     try:
         EXPERIMENTS_TABLE.put_item(Item=experiment_item)
     except ClientError as e:
         logger.exception(f"Error creating experiment: {str(e)}")
         raise ValueError(f"Failed to create experiment: {str(e)}")
 
-    logger.info(f"Created experiment: {experiment_id}")
-    logger.info(f"Auto-running experiment {experiment_id}")
+    logger.info(f"Created experiment: {experiment_id}, auto-running")
     run_experiment(experimentId=experiment_id)
 
     return experiment_id
@@ -207,17 +196,15 @@ def update_experiment(
     """
     logger.info(f"Updating experiment: {experimentId}")
 
-    # Get user ID from context for authorization
     user_id = app.current_event.get("identity", {}).get("username")
     if not user_id:
         raise ValueError("User ID not found in request context")
 
-    # Build update expression
-    update_parts = []
-    expression_attribute_names = {}
-    expression_attribute_values = {":updatedAt": datetime.now(timezone.utc).isoformat()}
-
-    update_parts.append("UpdatedAt = :updatedAt")
+    update_parts = ["UpdatedAt = :updatedAt"]
+    expression_attribute_names: Dict[str, str] = {}
+    expression_attribute_values: Dict[str, Any] = {
+        ":updatedAt": datetime.now(timezone.utc).isoformat()
+    }
 
     if name:
         update_parts.append("#name = :name")
@@ -233,21 +220,16 @@ def update_experiment(
         expression_attribute_names["#status"] = "Status"
         expression_attribute_values[":status"] = status
 
-    if not update_parts:
-        return True  # Nothing to update
-
     update_expression = "SET " + ", ".join(update_parts)
+    expression_attribute_values[":userId"] = user_id
 
-    # Update in DynamoDB
     try:
-        update_kwargs = {
+        update_kwargs: Dict[str, Any] = {
             "Key": {"ExperimentId": experimentId, "UserId": user_id},
             "UpdateExpression": update_expression,
             "ExpressionAttributeValues": expression_attribute_values,
             "ConditionExpression": "UserId = :userId",
         }
-        expression_attribute_values[":userId"] = user_id
-
         if expression_attribute_names:
             update_kwargs["ExpressionAttributeNames"] = expression_attribute_names
 
@@ -269,12 +251,10 @@ def delete_experiment(experimentId: str) -> Dict[str, Any]:
     """
     logger.info(f"Deleting experiment: {experimentId}")
 
-    # Get user ID from context for authorization
     user_id = app.current_event.get("identity", {}).get("username")
     if not user_id:
         raise ValueError("User ID not found in request context")
 
-    # Delete from DynamoDB
     try:
         EXPERIMENTS_TABLE.delete_item(
             Key={"ExperimentId": experimentId, "UserId": user_id},
@@ -298,12 +278,10 @@ def run_experiment(experimentId: str) -> Dict[str, Any]:
     """
     logger.info(f"Running experiment: {experimentId}")
 
-    # Get user ID from context for authorization
     user_id = app.current_event.get("identity", {}).get("username")
     if not user_id:
         raise ValueError("User ID not found in request context")
 
-    # Get experiment from DynamoDB
     try:
         response = EXPERIMENTS_TABLE.get_item(
             Key={"ExperimentId": experimentId, "UserId": user_id}
@@ -316,11 +294,9 @@ def run_experiment(experimentId: str) -> Dict[str, Any]:
     if not experiment:
         raise ValueError(f"Experiment not found: {experimentId}")
 
-    # Verify user has access to this experiment
     if experiment.get("UserId") != user_id:
         raise ValueError("Unauthorized access to experiment")
 
-    # Validate that generation config exists
     if not all(
         [
             experiment.get("Context"),
@@ -334,40 +310,45 @@ def run_experiment(experimentId: str) -> Dict[str, Any]:
             "Experiment missing required generation config (context, taskDescription, numCases, numTopics, modelId)"
         )
 
-    # Submit AWS Batch job
-    import boto3
-
-    batch_client = boto3.client("batch")
-
     job_name = (
         f"experiment-{experimentId[:8]}-{int(datetime.now(timezone.utc).timestamp())}"
     )
 
     try:
-        response = batch_client.submit_job(
+        batch_response = BATCH_CLIENT.submit_job(
             jobName=job_name,
             jobQueue=BATCH_JOB_QUEUE,
             jobDefinition=BATCH_JOB_DEFINITION,
             containerOverrides={
-                "command": [
-                    "python",
-                    "batch_runner.py",
-                ],
+                "command": ["python", "batch_runner.py"],
                 "environment": [
                     {"name": "EXPERIMENT_ID", "value": experimentId},
                     {"name": "USER_ID", "value": user_id},
                 ],
             },
         )
-
-        batch_job_id = response["jobId"]
+        batch_job_id = batch_response["jobId"]
         logger.info(f"Submitted Batch job {batch_job_id} for experiment {experimentId}")
-
     except ClientError as e:
         logger.exception(f"Error submitting Batch job: {str(e)}")
+        # Mark experiment as FAILED so the user knows something went wrong
+        try:
+            EXPERIMENTS_TABLE.update_item(
+                Key={"ExperimentId": experimentId, "UserId": user_id},
+                UpdateExpression="SET #status = :status, UpdatedAt = :updatedAt, ErrorMessage = :errorMessage",
+                ExpressionAttributeNames={"#status": "Status"},
+                ExpressionAttributeValues={
+                    ":status": ExperimentStatus.FAILED,
+                    ":updatedAt": datetime.now(timezone.utc).isoformat(),
+                    ":errorMessage": str(e),
+                    ":userId": user_id,
+                },
+                ConditionExpression="UserId = :userId",
+            )
+        except ClientError:
+            logger.exception("Failed to update experiment status to FAILED")
         raise ValueError(f"Failed to submit Batch job: {str(e)}")
 
-    # Update status to RUNNING with Batch job ID
     timestamp = datetime.now(timezone.utc).isoformat()
     try:
         EXPERIMENTS_TABLE.update_item(
@@ -375,7 +356,7 @@ def run_experiment(experimentId: str) -> Dict[str, Any]:
             UpdateExpression="SET #status = :status, UpdatedAt = :updatedAt, BatchJobId = :batchJobId",
             ExpressionAttributeNames={"#status": "Status"},
             ExpressionAttributeValues={
-                ":status": "RUNNING",
+                ":status": ExperimentStatus.RUNNING,
                 ":updatedAt": timestamp,
                 ":batchJobId": batch_job_id,
                 ":userId": user_id,
@@ -386,16 +367,10 @@ def run_experiment(experimentId: str) -> Dict[str, Any]:
         logger.exception(f"Error updating experiment status: {str(e)}")
         raise ValueError(f"Failed to update experiment status: {str(e)}")
 
-    # Return updated experiment
-    experiment["Status"] = "RUNNING"
+    experiment["Status"] = ExperimentStatus.RUNNING
     experiment["UpdatedAt"] = timestamp
     experiment["BatchJobId"] = batch_job_id
     return _format_experiment_response(experiment)
-
-
-# ---- S3 Presigned URL ---- #
-S3_CLIENT = boto3.client("s3")
-PRESIGNED_URL_EXPIRES_IN = int(os.environ.get("PRESIGNED_URL_EXPIRES_IN", 600))
 
 
 @app.resolver(field_name="getExperimentPresignedUrl")
@@ -403,12 +378,6 @@ PRESIGNED_URL_EXPIRES_IN = int(os.environ.get("PRESIGNED_URL_EXPIRES_IN", 600))
 def get_experiment_presigned_url(s3Uri: str) -> Optional[str]:
     """
     Generate a presigned URL for accessing an S3 object in the evaluations bucket.
-
-    Args:
-        s3Uri: S3 URI in format s3://bucket-name/path/to/object
-
-    Returns:
-        Presigned URL string, or None on error
     """
     user_id = app.current_event.get("identity", {}).get("username")
     if not user_id:
@@ -420,9 +389,7 @@ def get_experiment_presigned_url(s3Uri: str) -> Optional[str]:
     if len(parts) < 2:
         raise ValueError(f"Invalid S3 URI format: {s3Uri}")
 
-    bucket_name = parts[0]
-    object_key = parts[1]
-
+    bucket_name, object_key = parts[0], parts[1]
     logger.info(f"Bucket: {bucket_name}, Key: {object_key}")
 
     url = S3_CLIENT.generate_presigned_url(
@@ -466,7 +433,6 @@ def _format_experiment_response(experiment: Dict[str, Any]) -> Dict[str, Any]:
 @tracer.capture_method
 def handler(event: Dict, context: LambdaContext):
     try:
-        # Otherwise, handle as AppSync resolver
         logger.info(
             "Incoming API request for Experiment related operation",
             extra={

--- a/lib/api/functions/experiment-resolver/index.py
+++ b/lib/api/functions/experiment-resolver/index.py
@@ -1,8 +1,5 @@
-# ---------------------------------------------------------------------------- #
 # Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# SPDX-License-Identifier: Apache-2.0
-# ---------------------------------------------------------------------------- #
+# SPDX-License-Identifier: MIT-0
 from __future__ import annotations
 
 import json
@@ -31,7 +28,6 @@ logger = Logger(service=SERVICE_ID)
 
 # -------------------- Env Variables ----------------------- #
 EXPERIMENTS_TABLE_NAME = os.environ.get("EXPERIMENTS_TABLE_NAME", "")
-EXPERIMENTS_BUCKET_NAME = os.environ.get("EXPERIMENTS_BUCKET_NAME", "")
 BATCH_JOB_QUEUE = os.environ.get("BATCH_JOB_QUEUE", "")
 BATCH_JOB_DEFINITION = os.environ.get("BATCH_JOB_DEFINITION", "")
 # ---------------------------------------------------------- #
@@ -65,7 +61,7 @@ def list_experiments() -> List[Dict[str, Any]]:
     """
     logger.info("Listing experiments")
 
-    user_id = app.current_event.get("identity", {}).get("username")
+    user_id = app.current_event.get("identity", {}).get("sub")
     if not user_id:
         raise ValueError("User ID not found in request context")
 
@@ -89,7 +85,7 @@ def get_experiment(experimentId: str) -> Optional[Dict[str, Any]]:
     """
     logger.info(f"Getting experiment: {experimentId}")
 
-    user_id = app.current_event.get("identity", {}).get("username")
+    user_id = app.current_event.get("identity", {}).get("sub")
     if not user_id:
         raise ValueError("User ID not found in request context")
 
@@ -115,9 +111,9 @@ def get_experiment(experimentId: str) -> Optional[Dict[str, Any]]:
 @tracer.capture_method
 def create_experiment(
     name: str,
+    generationConfig: str,
+    modelId: str,
     description: Optional[str] = None,
-    generationConfig: Optional[str] = None,
-    modelId: str = "",
 ) -> str:
     """
     Create a new experiment and automatically trigger execution.
@@ -125,14 +121,14 @@ def create_experiment(
     """
     logger.info(f"Creating experiment: {name}")
 
-    user_id = app.current_event.get("identity", {}).get("username")
+    user_id = app.current_event.get("identity", {}).get("sub")
     if not user_id:
         raise ValueError("User ID not found in request context")
 
     experiment_id = str(uuid.uuid4())
     timestamp = datetime.now(timezone.utc).isoformat()
 
-    generation_config = json.loads(generationConfig) if generationConfig else {}
+    generation_config = json.loads(generationConfig)
 
     experiment_item: Dict[str, Any] = {
         "ExperimentId": experiment_id,
@@ -147,15 +143,14 @@ def create_experiment(
     if description:
         experiment_item["Description"] = description
 
-    if generation_config:
-        if "context" in generation_config:
-            experiment_item["Context"] = generation_config["context"]
-        if "taskDescription" in generation_config:
-            experiment_item["TaskDescription"] = generation_config["taskDescription"]
-        if "numCases" in generation_config:
-            experiment_item["NumCases"] = generation_config["numCases"]
-        if "numTopics" in generation_config:
-            experiment_item["NumTopics"] = generation_config["numTopics"]
+    if "context" in generation_config:
+        experiment_item["Context"] = generation_config["context"]
+    if "taskDescription" in generation_config:
+        experiment_item["TaskDescription"] = generation_config["taskDescription"]
+    if "numCases" in generation_config:
+        experiment_item["NumCases"] = generation_config["numCases"]
+    if "numTopics" in generation_config:
+        experiment_item["NumTopics"] = generation_config["numTopics"]
 
     if not all(
         [
@@ -174,6 +169,22 @@ def create_experiment(
         EXPERIMENTS_TABLE.put_item(Item=experiment_item)
     except ClientError as e:
         logger.exception(f"Error creating experiment: {str(e)}")
+        # Mark experiment as FAILED so the user knows something went wrong
+        try:
+            EXPERIMENTS_TABLE.update_item(
+                Key={"ExperimentId": experiment_id, "UserId": user_id},
+                UpdateExpression="SET #status = :status, UpdatedAt = :updatedAt, ErrorMessage = :errorMessage",
+                ExpressionAttributeNames={"#status": "Status"},
+                ExpressionAttributeValues={
+                    ":status": ExperimentStatus.FAILED,
+                    ":updatedAt": datetime.now(timezone.utc).isoformat(),
+                    ":errorMessage": str(e),
+                    ":userId": user_id,
+                },
+                ConditionExpression="UserId = :userId",
+            )
+        except ClientError:
+            logger.exception("Failed to update experiment status to FAILED")
         raise ValueError(f"Failed to create experiment: {str(e)}")
 
     logger.info(f"Created experiment: {experiment_id}, auto-running")
@@ -196,7 +207,7 @@ def update_experiment(
     """
     logger.info(f"Updating experiment: {experimentId}")
 
-    user_id = app.current_event.get("identity", {}).get("username")
+    user_id = app.current_event.get("identity", {}).get("sub")
     if not user_id:
         raise ValueError("User ID not found in request context")
 
@@ -251,7 +262,7 @@ def delete_experiment(experimentId: str) -> Dict[str, Any]:
     """
     logger.info(f"Deleting experiment: {experimentId}")
 
-    user_id = app.current_event.get("identity", {}).get("username")
+    user_id = app.current_event.get("identity", {}).get("sub")
     if not user_id:
         raise ValueError("User ID not found in request context")
 
@@ -278,7 +289,7 @@ def run_experiment(experimentId: str) -> Dict[str, Any]:
     """
     logger.info(f"Running experiment: {experimentId}")
 
-    user_id = app.current_event.get("identity", {}).get("username")
+    user_id = app.current_event.get("identity", {}).get("sub")
     if not user_id:
         raise ValueError("User ID not found in request context")
 
@@ -379,7 +390,7 @@ def get_experiment_presigned_url(s3Uri: str) -> Optional[str]:
     """
     Generate a presigned URL for accessing an S3 object in the evaluations bucket.
     """
-    user_id = app.current_event.get("identity", {}).get("username")
+    user_id = app.current_event.get("identity", {}).get("sub")
     if not user_id:
         raise ValueError("User ID not found in request context")
 

--- a/lib/api/functions/experiment-resolver/index.py
+++ b/lib/api/functions/experiment-resolver/index.py
@@ -1,0 +1,487 @@
+# ---------------------------------------------------------------------------- #
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+# ---------------------------------------------------------------------------- #
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+import boto3
+from aws_lambda_powertools import Logger, Tracer
+from aws_lambda_powertools.event_handler import AppSyncResolver
+from aws_lambda_powertools.logging import correlation_paths
+from boto3.dynamodb.conditions import Key
+from botocore.exceptions import ClientError
+from pydantic import ValidationError
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
+
+# -------- Lambda PT Logger and Tracing -------- #
+SERVICE_ID = "graphQL-experimentOps"
+tracer = Tracer(service=SERVICE_ID)
+logger = Logger(service=SERVICE_ID)
+# ---------------------------------------------- #
+
+# -------------------- Env Variables ----------------------- #
+EXPERIMENTS_TABLE_NAME = os.environ.get("EXPERIMENTS_TABLE_NAME", "")
+EXPERIMENTS_BUCKET_NAME = os.environ.get("EXPERIMENTS_BUCKET_NAME", "")
+BATCH_JOB_QUEUE = os.environ.get("BATCH_JOB_QUEUE", "")
+BATCH_JOB_DEFINITION = os.environ.get("BATCH_JOB_DEFINITION", "")
+# ---------------------------------------------------------- #
+
+# --------------- DynamoDB Tables ------------------- #
+EXPERIMENTS_TABLE = boto3.resource("dynamodb").Table(EXPERIMENTS_TABLE_NAME)  # type: ignore
+# ---------------------------------------------------- #
+
+# ---------------- API Routes ---------------- #
+app = AppSyncResolver()
+# -------------------------------------------- #
+
+
+# Routes
+@app.resolver(field_name="listExperiments")
+@tracer.capture_method
+def list_experiments() -> List[Dict[str, Any]]:
+    """
+    List experiments for the current user.
+    Uses GSI byUserId.
+    """
+    logger.info("Listing experiments")
+
+    # Get user ID from context
+    user_id = app.current_event.get("identity", {}).get("username")
+    if not user_id:
+        raise ValueError("User ID not found in request context")
+
+    # Query by UserId using GSI
+    try:
+        response = EXPERIMENTS_TABLE.query(
+            IndexName="byUserId", KeyConditionExpression=Key("UserId").eq(user_id)
+        )
+        experiments = response.get("Items", [])
+    except ClientError as e:
+        logger.exception(f"Error querying experiments: {str(e)}")
+        raise ValueError(f"Failed to list experiments: {str(e)}")
+
+    # Format response
+    return [_format_experiment_response(exp) for exp in experiments]
+
+
+@app.resolver(field_name="getExperiment")
+@tracer.capture_method
+def get_experiment(experimentId: str) -> Optional[Dict[str, Any]]:
+    """
+    Get a single experiment by ID.
+    """
+    logger.info(f"Getting experiment: {experimentId}")
+
+    # Get user ID from context for authorization
+    user_id = app.current_event.get("identity", {}).get("username")
+    if not user_id:
+        raise ValueError("User ID not found in request context")
+
+    # Get experiment from DynamoDB
+    try:
+        response = EXPERIMENTS_TABLE.get_item(
+            Key={"ExperimentId": experimentId, "UserId": user_id}
+        )
+        experiment = response.get("Item")
+    except ClientError as e:
+        logger.exception(f"Error getting experiment: {str(e)}")
+        raise ValueError(f"Failed to get experiment: {str(e)}")
+
+    if not experiment:
+        return None
+
+    # Verify user has access to this experiment
+    if experiment.get("UserId") != user_id:
+        raise ValueError("Unauthorized access to experiment")
+
+    return _format_experiment_response(experiment)
+
+
+@app.resolver(field_name="createExperiment")
+@tracer.capture_method
+def create_experiment(
+    name: str,
+    description: Optional[str] = None,
+    s3Path: Optional[str] = None,
+    generationConfig: Optional[str] = None,
+    modelId: str = "",
+) -> str:
+    """
+    Create a new experiment and automatically trigger execution.
+    Uses the dedicated experiments runtime for test case generation.
+    Returns the experimentId.
+    """
+    logger.info(f"Creating experiment: {name}")
+
+    # Get user ID from context
+    user_id = app.current_event.get("identity", {}).get("username")
+    if not user_id:
+        raise ValueError("User ID not found in request context")
+
+    # Generate experiment ID
+    import uuid
+
+    experiment_id = str(uuid.uuid4())
+    timestamp = datetime.now(timezone.utc).isoformat()
+
+    # Parse generation config if provided
+    generation_config = {}
+    if generationConfig:
+        generation_config = json.loads(generationConfig)
+
+    # Create experiment item with RUNNING status
+    experiment_item = {
+        "ExperimentId": experiment_id,
+        "UserId": user_id,
+        "Name": name,
+        "Status": "RUNNING",
+        "CreatedAt": timestamp,
+        "UpdatedAt": timestamp,
+    }
+
+    # Add optional fields
+    if description:
+        experiment_item["Description"] = description
+    if s3Path:
+        experiment_item["S3Path"] = s3Path
+    experiment_item["ModelId"] = modelId
+
+    # Add generation config fields
+    if generation_config:
+        if "context" in generation_config:
+            experiment_item["Context"] = generation_config["context"]
+        if "taskDescription" in generation_config:
+            experiment_item["TaskDescription"] = generation_config["taskDescription"]
+        if "numCases" in generation_config:
+            experiment_item["NumCases"] = generation_config["numCases"]
+        if "numTopics" in generation_config:
+            experiment_item["NumTopics"] = generation_config["numTopics"]
+
+    # Validate that generation config exists
+    if not all(
+        [
+            experiment_item.get("Context"),
+            experiment_item.get("TaskDescription"),
+            experiment_item.get("NumCases"),
+            experiment_item.get("NumTopics"),
+            experiment_item.get("ModelId"),
+        ]
+    ):
+        raise ValueError(
+            "Experiment missing required generation config (context, taskDescription, numCases, numTopics, modelId)"
+        )
+
+    # Save to DynamoDB
+    try:
+        EXPERIMENTS_TABLE.put_item(Item=experiment_item)
+    except ClientError as e:
+        logger.exception(f"Error creating experiment: {str(e)}")
+        raise ValueError(f"Failed to create experiment: {str(e)}")
+
+    logger.info(f"Created experiment: {experiment_id}")
+    logger.info(f"Auto-running experiment {experiment_id}")
+    run_experiment(experimentId=experiment_id)
+
+    return experiment_id
+
+
+@app.resolver(field_name="updateExperiment")
+@tracer.capture_method
+def update_experiment(
+    experimentId: str,
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+    status: Optional[str] = None,
+) -> bool:
+    """
+    Update an existing experiment.
+    Returns True if successful.
+    """
+    logger.info(f"Updating experiment: {experimentId}")
+
+    # Get user ID from context for authorization
+    user_id = app.current_event.get("identity", {}).get("username")
+    if not user_id:
+        raise ValueError("User ID not found in request context")
+
+    # Build update expression
+    update_parts = []
+    expression_attribute_names = {}
+    expression_attribute_values = {":updatedAt": datetime.now(timezone.utc).isoformat()}
+
+    update_parts.append("UpdatedAt = :updatedAt")
+
+    if name:
+        update_parts.append("#name = :name")
+        expression_attribute_names["#name"] = "Name"
+        expression_attribute_values[":name"] = name
+
+    if description:
+        update_parts.append("Description = :description")
+        expression_attribute_values[":description"] = description
+
+    if status:
+        update_parts.append("#status = :status")
+        expression_attribute_names["#status"] = "Status"
+        expression_attribute_values[":status"] = status
+
+    if not update_parts:
+        return True  # Nothing to update
+
+    update_expression = "SET " + ", ".join(update_parts)
+
+    # Update in DynamoDB
+    try:
+        update_kwargs = {
+            "Key": {"ExperimentId": experimentId, "UserId": user_id},
+            "UpdateExpression": update_expression,
+            "ExpressionAttributeValues": expression_attribute_values,
+            "ConditionExpression": "UserId = :userId",
+        }
+        expression_attribute_values[":userId"] = user_id
+
+        if expression_attribute_names:
+            update_kwargs["ExpressionAttributeNames"] = expression_attribute_names
+
+        EXPERIMENTS_TABLE.update_item(**update_kwargs)
+    except ClientError as e:
+        logger.exception(f"Error updating experiment: {str(e)}")
+        raise ValueError(f"Failed to update experiment: {str(e)}")
+
+    logger.info(f"Updated experiment: {experimentId}")
+    return True
+
+
+@app.resolver(field_name="deleteExperiment")
+@tracer.capture_method
+def delete_experiment(experimentId: str) -> Dict[str, Any]:
+    """
+    Delete an experiment.
+    Returns deletion result.
+    """
+    logger.info(f"Deleting experiment: {experimentId}")
+
+    # Get user ID from context for authorization
+    user_id = app.current_event.get("identity", {}).get("username")
+    if not user_id:
+        raise ValueError("User ID not found in request context")
+
+    # Delete from DynamoDB
+    try:
+        EXPERIMENTS_TABLE.delete_item(
+            Key={"ExperimentId": experimentId, "UserId": user_id},
+            ConditionExpression="UserId = :userId",
+            ExpressionAttributeValues={":userId": user_id},
+        )
+    except ClientError as e:
+        logger.exception(f"Error deleting experiment: {str(e)}")
+        raise ValueError(f"Failed to delete experiment: {str(e)}")
+
+    logger.info(f"Deleted experiment: {experimentId}")
+    return {"experimentId": experimentId, "deleted": True}
+
+
+@app.resolver(field_name="runExperiment")
+@tracer.capture_method
+def run_experiment(experimentId: str) -> Dict[str, Any]:
+    """
+    Run experiment to generate synthetic test cases using AWS Batch.
+    Submits a Batch job and returns immediately with RUNNING status.
+    """
+    logger.info(f"Running experiment: {experimentId}")
+
+    # Get user ID from context for authorization
+    user_id = app.current_event.get("identity", {}).get("username")
+    if not user_id:
+        raise ValueError("User ID not found in request context")
+
+    # Get experiment from DynamoDB
+    try:
+        response = EXPERIMENTS_TABLE.get_item(
+            Key={"ExperimentId": experimentId, "UserId": user_id}
+        )
+        experiment = response.get("Item")
+    except ClientError as e:
+        logger.exception(f"Error getting experiment: {str(e)}")
+        raise ValueError(f"Failed to get experiment: {str(e)}")
+
+    if not experiment:
+        raise ValueError(f"Experiment not found: {experimentId}")
+
+    # Verify user has access to this experiment
+    if experiment.get("UserId") != user_id:
+        raise ValueError("Unauthorized access to experiment")
+
+    # Validate that generation config exists
+    if not all(
+        [
+            experiment.get("Context"),
+            experiment.get("TaskDescription"),
+            experiment.get("NumCases"),
+            experiment.get("NumTopics"),
+            experiment.get("ModelId"),
+        ]
+    ):
+        raise ValueError(
+            "Experiment missing required generation config (context, taskDescription, numCases, numTopics, modelId)"
+        )
+
+    # Submit AWS Batch job
+    import boto3
+
+    batch_client = boto3.client("batch")
+
+    job_name = (
+        f"experiment-{experimentId[:8]}-{int(datetime.now(timezone.utc).timestamp())}"
+    )
+
+    try:
+        response = batch_client.submit_job(
+            jobName=job_name,
+            jobQueue=BATCH_JOB_QUEUE,
+            jobDefinition=BATCH_JOB_DEFINITION,
+            containerOverrides={
+                "command": [
+                    "python",
+                    "batch_runner.py",
+                ],
+                "environment": [
+                    {"name": "EXPERIMENT_ID", "value": experimentId},
+                    {"name": "USER_ID", "value": user_id},
+                ],
+            },
+        )
+
+        batch_job_id = response["jobId"]
+        logger.info(f"Submitted Batch job {batch_job_id} for experiment {experimentId}")
+
+    except ClientError as e:
+        logger.exception(f"Error submitting Batch job: {str(e)}")
+        raise ValueError(f"Failed to submit Batch job: {str(e)}")
+
+    # Update status to RUNNING with Batch job ID
+    timestamp = datetime.now(timezone.utc).isoformat()
+    try:
+        EXPERIMENTS_TABLE.update_item(
+            Key={"ExperimentId": experimentId, "UserId": user_id},
+            UpdateExpression="SET #status = :status, UpdatedAt = :updatedAt, BatchJobId = :batchJobId",
+            ExpressionAttributeNames={"#status": "Status"},
+            ExpressionAttributeValues={
+                ":status": "RUNNING",
+                ":updatedAt": timestamp,
+                ":batchJobId": batch_job_id,
+                ":userId": user_id,
+            },
+            ConditionExpression="UserId = :userId",
+        )
+    except ClientError as e:
+        logger.exception(f"Error updating experiment status: {str(e)}")
+        raise ValueError(f"Failed to update experiment status: {str(e)}")
+
+    # Return updated experiment
+    experiment["Status"] = "RUNNING"
+    experiment["UpdatedAt"] = timestamp
+    experiment["BatchJobId"] = batch_job_id
+    return _format_experiment_response(experiment)
+
+
+# ---- S3 Presigned URL ---- #
+S3_CLIENT = boto3.client("s3")
+PRESIGNED_URL_EXPIRES_IN = int(os.environ.get("PRESIGNED_URL_EXPIRES_IN", 600))
+
+
+@app.resolver(field_name="getExperimentPresignedUrl")
+@tracer.capture_method
+def get_experiment_presigned_url(s3Uri: str) -> Optional[str]:
+    """
+    Generate a presigned URL for accessing an S3 object in the evaluations bucket.
+
+    Args:
+        s3Uri: S3 URI in format s3://bucket-name/path/to/object
+
+    Returns:
+        Presigned URL string, or None on error
+    """
+    user_id = app.current_event.get("identity", {}).get("username")
+    if not user_id:
+        raise ValueError("User ID not found in request context")
+
+    logger.info(f"Generating presigned URL for user {user_id}")
+
+    parts = s3Uri.replace("s3://", "").split("/", 1)
+    if len(parts) < 2:
+        raise ValueError(f"Invalid S3 URI format: {s3Uri}")
+
+    bucket_name = parts[0]
+    object_key = parts[1]
+
+    logger.info(f"Bucket: {bucket_name}, Key: {object_key}")
+
+    url = S3_CLIENT.generate_presigned_url(
+        "get_object",
+        Params={"Bucket": bucket_name, "Key": object_key},
+        ExpiresIn=PRESIGNED_URL_EXPIRES_IN,
+    )
+    logger.info(f"Generated presigned URL valid for {PRESIGNED_URL_EXPIRES_IN} seconds")
+    return url
+
+
+# Helpers
+def _format_experiment_response(experiment: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Formats DynamoDB experiment item to GraphQL Experiment type.
+    """
+    return {
+        "experimentId": experiment["ExperimentId"],
+        "userId": experiment["UserId"],
+        "name": experiment["Name"],
+        "description": experiment.get("Description"),
+        "createdAt": experiment["CreatedAt"],
+        "updatedAt": experiment.get("UpdatedAt", experiment["CreatedAt"]),
+        "status": experiment["Status"],
+        "generatedCasesS3Url": experiment.get("GeneratedCasesS3Url"),
+        "taskDescription": experiment.get("TaskDescription"),
+        "context": experiment.get("Context"),
+        "numCases": experiment.get("NumCases"),
+        "numTopics": experiment.get("NumTopics"),
+        "modelId": experiment.get("ModelId"),
+        "generatedCasesCount": experiment.get("GeneratedCasesCount"),
+        "errorMessage": experiment.get("ErrorMessage"),
+        "batchJobId": experiment.get("BatchJobId"),
+    }
+
+
+# Handler
+@logger.inject_lambda_context(
+    log_event=False, correlation_id_path=correlation_paths.APPSYNC_RESOLVER
+)
+@tracer.capture_method
+def handler(event: Dict, context: LambdaContext):
+    try:
+        # Otherwise, handle as AppSync resolver
+        logger.info(
+            "Incoming API request for Experiment related operation",
+            extra={
+                "payload": {
+                    "fieldName": event.get("info", {}).get("fieldName"),
+                    "arguments": event.get("arguments"),
+                    "identity": event.get("identity"),
+                }
+            },
+        )
+        return app.resolve(event, context)
+    except ValidationError as e:
+        errors = e.errors(include_url=False, include_context=False, include_input=False)
+        logger.warning("Validation error", errors=errors)
+        raise ValueError(f"Invalid request. Details: {errors}")
+    except Exception as e:
+        logger.exception(e)
+        raise RuntimeError("Something went wrong")

--- a/lib/api/http-api-backend.ts
+++ b/lib/api/http-api-backend.ts
@@ -26,6 +26,7 @@ export interface HttpApiBackendProps {
     readonly userPool: cognito.UserPool;
     readonly sessionsTable: dynamodb.Table;
     readonly favoriteRuntimeTable: dynamodb.Table;
+    readonly experimentsTable: dynamodb.Table;
     readonly toolRegistryTable: dynamodb.Table;
     readonly mcpServerRegistryTable: dynamodb.Table;
     readonly byUserIdIndex: string;
@@ -60,6 +61,7 @@ export class HttpApiBackend extends Construct {
             ...props.shared.defaultEnvironmentVariables,
             SESSIONS_TABLE_NAME: props.sessionsTable.tableName,
             SESSIONS_BY_USER_ID_INDEX_NAME: props.byUserIdIndex,
+            EXPERIMENTS_TABLE_NAME: props.experimentsTable.tableName,
             TOOL_REGISTRY_TABLE: props.toolRegistryTable.tableName,
             MCP_SERVER_REGISTRY_TABLE: props.mcpServerRegistryTable.tableName,
             REGION_NAME: cdk.Aws.REGION,
@@ -83,6 +85,7 @@ export class HttpApiBackend extends Construct {
 
         props.sessionsTable.grantReadWriteData(lambdaResolver);
         props.favoriteRuntimeTable.grantReadWriteData(lambdaResolver);
+        props.experimentsTable.grantReadWriteData(lambdaResolver);
         props.toolRegistryTable.grantReadData(lambdaResolver);
         props.mcpServerRegistryTable.grantReadData(lambdaResolver);
 

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -24,6 +24,7 @@ import { SystemConfig } from "../shared/types";
 import { generatePrefix } from "../shared/utils";
 import { AgentCoreApis } from "./agent-core-runtime";
 import { EvaluationApi } from "./evaluation-api";
+import { ExperimentOps } from "./experiments-api";
 import { HttpApiBackend } from "./http-api-backend";
 import { KnowledgeBaseOps } from "./knowledge-base";
 import { ChatbotDynamoDBTables } from "./tables";
@@ -67,6 +68,7 @@ export interface ChatbotApiProps {
 export class ChatbotApi extends Construct {
     public readonly messagesTopic: sns.Topic;
     public readonly sessionsTable: dynamodb.Table;
+    public readonly experimentsTable: dynamodb.Table;
     public readonly agentsTable: dynamodb.Table;
     public readonly byUserIndex: string;
     public readonly graphqlApi: appsync.GraphqlApi;
@@ -142,13 +144,21 @@ export class ChatbotApi extends Construct {
             byUserIdIndex: chatTables.byUserIdIndex,
         });
 
+        const experimentOps = new ExperimentOps(this, "ExperimentOps", {
+            ...props,
+            api: api,
+            experimentsTable: chatTables.experimentsTable,
+            evaluationsBucket: evaluationApi.evaluationsBucket,
+        });
+
         new HttpApiBackend(this, "SyncApiBackend", {
             ...props,
             api: api,
             sessionsTable: chatTables.sessionsTable,
             favoriteRuntimeTable: chatTables.favoriteRuntimeTable,
+            experimentsTable: chatTables.experimentsTable,
             byUserIdIndex: chatTables.byUserIdIndex,
-            operationToExclude: [...agentCoreApis.operations, ...kbApis.operations, ...evaluationApi.operations],
+            operationToExclude: [...agentCoreApis.operations, ...kbApis.operations, ...evaluationApi.operations, ...experimentOps.operations]
         });
 
         // CDK outputs
@@ -158,6 +168,7 @@ export class ChatbotApi extends Construct {
         this.messagesTopic = realtimeBackend.messagesTopic;
         this.graphqlApi = api;
         this.sessionsTable = chatTables.sessionsTable;
+        this.experimentsTable = chatTables.experimentsTable;
         this.byUserIndex = chatTables.byUserIdIndex;
 
         // CDK NAG Suppression

--- a/lib/api/schema/schema.graphql
+++ b/lib/api/schema/schema.graphql
@@ -104,6 +104,37 @@ type FavoriteRuntime @aws_cognito_user_pools {
     endpointName: String!
 }
 
+type Experiment @aws_cognito_user_pools {
+    experimentId: String!
+    userId: String!
+    name: String!
+    description: String
+    createdAt: AWSDateTime!
+    updatedAt: AWSDateTime!
+    status: ExperimentStatus!
+    generatedCasesS3Url: String
+    taskDescription: String
+    context: String
+    numCases: Int
+    numTopics: Int
+    modelId: String
+    generatedCasesCount: Int
+    errorMessage: String
+    batchJobId: String
+}
+
+enum ExperimentStatus {
+    DRAFT
+    RUNNING
+    COMPLETED
+    FAILED
+}
+
+type DeleteExperimentResult @aws_cognito_user_pools {
+    experimentId: String
+    deleted: Boolean!
+}
+
 type AgentFactoryNotification @aws_iam @aws_cognito_user_pools {
     agentName: String
 }
@@ -199,6 +230,11 @@ type Mutation {
     deleteEvaluator(evaluatorId: ID!): Boolean @aws_cognito_user_pools
     runEvaluation(evaluatorId: ID!): Evaluator @aws_cognito_user_pools
     publishEvaluationUpdate(evaluatorId: String!, status: String!): EvaluationNotification @aws_iam
+    # Experiments
+    createExperiment(name: String!, description: String, s3Path: String, generationConfig: String, modelId: String!): String! @aws_cognito_user_pools
+    updateExperiment(experimentId: String!, name: String, description: String, status: ExperimentStatus): Boolean @aws_cognito_user_pools
+    deleteExperiment(experimentId: String!): DeleteExperimentResult @aws_cognito_user_pools
+    runExperiment(experimentId: String!): Experiment @aws_cognito_user_pools
 }
 
 type Subscription {
@@ -242,6 +278,10 @@ type Query {
     # Evaluators
     listEvaluators: [Evaluator!] @aws_cognito_user_pools
     getEvaluator(evaluatorId: ID!): Evaluator @aws_cognito_user_pools
+    # Experiments
+    listExperiments: [Experiment!]! @aws_cognito_user_pools
+    getExperiment(experimentId: String!): Experiment @aws_cognito_user_pools
+    getExperimentPresignedUrl(s3Uri: String!): String @aws_cognito_user_pools
 }
 
 schema {

--- a/lib/api/schema/schema.graphql
+++ b/lib/api/schema/schema.graphql
@@ -231,7 +231,7 @@ type Mutation {
     runEvaluation(evaluatorId: ID!): Evaluator @aws_cognito_user_pools
     publishEvaluationUpdate(evaluatorId: String!, status: String!): EvaluationNotification @aws_iam
     # Experiments
-    createExperiment(name: String!, description: String, s3Path: String, generationConfig: String, modelId: String!): String! @aws_cognito_user_pools
+    createExperiment(name: String!, description: String, generationConfig: String, modelId: String!): String! @aws_cognito_user_pools
     updateExperiment(experimentId: String!, name: String, description: String, status: ExperimentStatus): Boolean @aws_cognito_user_pools
     deleteExperiment(experimentId: String!): DeleteExperimentResult @aws_cognito_user_pools
     runExperiment(experimentId: String!): Experiment @aws_cognito_user_pools

--- a/lib/api/schema/schema.graphql
+++ b/lib/api/schema/schema.graphql
@@ -231,7 +231,7 @@ type Mutation {
     runEvaluation(evaluatorId: ID!): Evaluator @aws_cognito_user_pools
     publishEvaluationUpdate(evaluatorId: String!, status: String!): EvaluationNotification @aws_iam
     # Experiments
-    createExperiment(name: String!, description: String, generationConfig: String, modelId: String!): String! @aws_cognito_user_pools
+    createExperiment(name: String!, description: String, generationConfig: String!, modelId: String!): String! @aws_cognito_user_pools
     updateExperiment(experimentId: String!, name: String, description: String, status: ExperimentStatus): Boolean @aws_cognito_user_pools
     deleteExperiment(experimentId: String!): DeleteExperimentResult @aws_cognito_user_pools
     runExperiment(experimentId: String!): Experiment @aws_cognito_user_pools

--- a/lib/api/tables/index.ts
+++ b/lib/api/tables/index.ts
@@ -19,6 +19,7 @@ export class ChatbotDynamoDBTables extends Construct {
     public readonly sessionsTable: dynamodb.Table;
     public readonly favoriteRuntimeTable: dynamodb.Table;
     public readonly evaluatorsTable: dynamodb.Table;
+    public readonly experimentsTable: dynamodb.Table;
     public readonly byUserIdIndex: string = "byUserId";
 
     constructor(scope: Construct, id: string) {
@@ -84,5 +85,38 @@ export class ChatbotDynamoDBTables extends Construct {
         this.sessionsTable = sessionsTable;
         this.favoriteRuntimeTable = favoriteTable;
         this.evaluatorsTable = evaluatorsTable;
+
+        // Experiments Table
+        const experimentsTable = new dynamodb.Table(this, "ExperimentsTable", {
+            tableName: `${prefix}-experimentsTable`,
+            partitionKey: {
+                name: "ExperimentId",
+                type: dynamodb.AttributeType.STRING,
+            },
+            sortKey: {
+                name: "UserId",
+                type: dynamodb.AttributeType.STRING,
+            },
+            billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+            encryption: dynamodb.TableEncryption.AWS_MANAGED,
+            removalPolicy: cdk.RemovalPolicy.DESTROY,
+            pointInTimeRecoverySpecification: {
+                pointInTimeRecoveryEnabled: true,
+            },
+        });
+
+        experimentsTable.addGlobalSecondaryIndex({
+            indexName: this.byUserIdIndex,
+            partitionKey: {
+                name: "UserId",
+                type: dynamodb.AttributeType.STRING,
+            },
+            sortKey: {
+                name: "CreatedAt",
+                type: dynamodb.AttributeType.STRING,
+            },
+        });
+
+        this.experimentsTable = experimentsTable;
     }
 }

--- a/lib/experiments-batch/docker/Dockerfile
+++ b/lib/experiments-batch/docker/Dockerfile
@@ -1,0 +1,14 @@
+FROM public.ecr.aws/docker/library/python:3.13-slim
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY batch_runner.py .
+
+ENV PYTHONUNBUFFERED=1
+
+RUN useradd -m -u 1000 batch_user
+USER batch_user
+
+CMD ["python", "batch_runner.py"]

--- a/lib/experiments-batch/docker/batch_runner.py
+++ b/lib/experiments-batch/docker/batch_runner.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+# ---------------------------------------------------------------------------- #
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+# ---------------------------------------------------------------------------- #
+"""
+AWS Batch job runner for experiment generation.
+Standalone script for generating synthetic test cases.
+"""
+
+import asyncio
+import json
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+import boto3
+from botocore.exceptions import ClientError
+from strands_evals.generators import ExperimentGenerator
+
+
+def update_experiment_status(
+    experiment_id: str,
+    user_id: str,
+    status: str,
+    error_message: str = None,
+    s3_uri: str = None,
+    num_cases_generated: int = None,
+):
+    """Update experiment status in DynamoDB."""
+    dynamodb = boto3.resource("dynamodb")
+    table_name = os.environ["EXPERIMENTS_TABLE_NAME"]
+    table = dynamodb.Table(table_name)
+    update_expr = "SET #status = :status, UpdatedAt = :updatedAt"
+    expr_attr_names = {"#status": "Status"}
+    expr_attr_values = {
+        ":status": status,
+        ":updatedAt": datetime.now(timezone.utc).isoformat(),
+        ":userId": user_id,
+    }
+    if error_message:
+        update_expr += ", ErrorMessage = :errorMessage"
+        expr_attr_values[":errorMessage"] = error_message
+
+    if s3_uri:
+        update_expr += ", GeneratedCasesS3Url = :s3Uri"
+        expr_attr_values[":s3Uri"] = s3_uri
+
+    if num_cases_generated is not None:
+        update_expr += ", GeneratedCasesCount = :numCases"
+        expr_attr_values[":numCases"] = num_cases_generated
+
+    try:
+        table.update_item(
+            Key={"ExperimentId": experiment_id, "UserId": user_id},
+            UpdateExpression=update_expr,
+            ExpressionAttributeNames=expr_attr_names,
+            ExpressionAttributeValues=expr_attr_values,
+            ConditionExpression="UserId = :userId",
+        )
+        print(f"Updated experiment {experiment_id} status to {status}")
+    except ClientError as e:
+        print(f"Error updating experiment status: {e}")
+        raise
+
+
+def get_experiment(experiment_id: str, user_id: str) -> Dict[str, Any]:
+    """Retrieve experiment from DynamoDB."""
+    dynamodb = boto3.resource("dynamodb")
+    table_name = os.environ["EXPERIMENTS_TABLE_NAME"]
+    table = dynamodb.Table(table_name)
+    try:
+        response = table.get_item(
+            Key={"ExperimentId": experiment_id, "UserId": user_id}
+        )
+        return response.get("Item")
+    except ClientError as e:
+        print(f"Error retrieving experiment: {e}")
+        raise
+
+
+def upload_to_s3(experiment_id: str, user_id: str, test_cases: List[Any]) -> str:
+    """Upload generated test cases to S3."""
+    s3_client = boto3.client("s3")
+    bucket_name = os.environ["EXPERIMENTS_BUCKET_NAME"]
+    key = f"experiments/generated-cases/{user_id}/{experiment_id}/cases.json"
+
+    # Convert test cases to JSON
+    cases_data = []
+    for case in test_cases:
+        case_dict = {
+            "caseId": str(uuid.uuid4()),
+            "name": case.name if hasattr(case, "name") else None,
+            "input": case.input,
+            "expected_output": case.expected_output
+            if hasattr(case, "expected_output")
+            else None,
+            "metadata": case.metadata if hasattr(case, "metadata") else {},
+        }
+        cases_data.append(case_dict)
+
+    try:
+        s3_client.put_object(
+            Bucket=bucket_name,
+            Key=key,
+            Body=json.dumps(cases_data, indent=2),
+            ContentType="application/json",
+            ServerSideEncryption="AES256",
+        )
+        s3_uri = f"s3://{bucket_name}/{key}"
+        print(f"Uploaded {len(cases_data)} test cases to {s3_uri}")
+        return s3_uri
+    except ClientError as e:
+        print(f"Error uploading to S3: {e}")
+        raise
+
+
+async def run_experiment_generation(experiment_id: str, user_id: str):
+    """Main experiment generation logic."""
+    print(f"Starting experiment generation for {experiment_id}")
+
+    try:
+        # Update status to RUNNING
+        update_experiment_status(experiment_id, user_id, "RUNNING")
+
+        # Retrieve experiment configuration
+        experiment = get_experiment(experiment_id, user_id)
+        if not experiment:
+            raise ValueError(f"Experiment {experiment_id} not found")
+
+        print(f"Retrieved experiment config: {experiment}")
+
+        # Extract configuration
+        context = experiment["Context"]
+        task_description = experiment["TaskDescription"]
+        num_cases = int(experiment["NumCases"])
+        num_topics = int(experiment["NumTopics"])
+        model_id = experiment.get("ModelId", "global.amazon.nova-2-lite-v1:0")
+
+        print(
+            f"Generating {num_cases} test cases across {num_topics} topics using model {model_id}"
+        )
+
+        # Initialize ExperimentGenerator
+        generator = ExperimentGenerator[str, str](
+            input_type=str,
+            output_type=str,
+            include_expected_output=True,
+            include_expected_trajectory=True,
+            include_metadata=True,
+            model=model_id,
+        )
+
+        # Generate test cases
+        experiment_obj = await generator.from_context_async(
+            context=context,
+            task_description=task_description,
+            num_cases=num_cases,
+            num_topics=num_topics,
+        )
+
+        test_cases = experiment_obj.cases
+        print(f"Generated {len(test_cases)} test cases")
+
+        # Upload to S3
+        s3_uri = upload_to_s3(experiment_id, user_id, test_cases)
+
+        # Update status to COMPLETED
+        update_experiment_status(
+            experiment_id,
+            user_id,
+            "COMPLETED",
+            s3_uri=s3_uri,
+            num_cases_generated=len(test_cases),
+        )
+
+        print(f"Experiment {experiment_id} completed successfully")
+        return {
+            "status": "COMPLETED",
+            "s3_uri": s3_uri,
+            "num_cases": len(test_cases),
+        }
+
+    except Exception as e:
+        error_msg = str(e)
+        print(f"Error generating experiment: {error_msg}")
+        update_experiment_status(
+            experiment_id, user_id, "FAILED", error_message=error_msg
+        )
+        raise
+
+
+def main():
+    """Entry point for Batch job."""
+    # Get job parameters from environment
+    experiment_id = os.environ.get("EXPERIMENT_ID")
+    user_id = os.environ.get("USER_ID")
+
+    if not experiment_id or not user_id:
+        print("Error: EXPERIMENT_ID and USER_ID must be set")
+        sys.exit(1)
+
+    print(f"Batch job started for experiment {experiment_id}, user {user_id}")
+
+    try:
+        # Run async generation
+        result = asyncio.run(run_experiment_generation(experiment_id, user_id))
+        print(f"Job completed successfully: {result}")
+        sys.exit(0)
+    except Exception as e:
+        print(f"Job failed: {e}")
+        import traceback
+
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/experiments-batch/docker/batch_runner.py
+++ b/lib/experiments-batch/docker/batch_runner.py
@@ -1,9 +1,5 @@
-#!/usr/bin/env python3
-# ---------------------------------------------------------------------------- #
 # Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# SPDX-License-Identifier: Apache-2.0
-# ---------------------------------------------------------------------------- #
+# SPDX-License-Identifier: MIT-0
 """
 AWS Batch job runner for experiment generation.
 Standalone script for generating synthetic test cases.
@@ -16,7 +12,7 @@ import os
 import sys
 import uuid
 from datetime import datetime, timezone
-from typing import Any, Dict, List
+from typing import Any, List, TypedDict
 
 import boto3
 from botocore.exceptions import ClientError
@@ -27,6 +23,20 @@ logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s %(levelname)s %(name)s %(message)s",
 )
+
+EXPERIMENTS_S3_PREFIX = os.environ.get(
+    "EXPERIMENTS_S3_PREFIX", "experiments/generated-cases"
+)
+
+
+class ExperimentItem(TypedDict):
+    ExperimentId: str
+    UserId: str
+    Context: str
+    TaskDescription: str
+    NumCases: int
+    NumTopics: int
+    ModelId: str
 
 
 def update_experiment_status(
@@ -74,7 +84,7 @@ def update_experiment_status(
         raise
 
 
-def get_experiment(experiment_id: str, user_id: str) -> Dict[str, Any]:
+def get_experiment(experiment_id: str, user_id: str) -> ExperimentItem:
     """Retrieve experiment from DynamoDB."""
     dynamodb = boto3.resource("dynamodb")
     table_name = os.environ["EXPERIMENTS_TABLE_NAME"]
@@ -93,7 +103,8 @@ def upload_to_s3(experiment_id: str, user_id: str, test_cases: List[Any]) -> str
     """Upload generated test cases to S3."""
     s3_client = boto3.client("s3")
     bucket_name = os.environ["EXPERIMENTS_BUCKET_NAME"]
-    key = f"experiments/generated-cases/{user_id}/{experiment_id}/cases.json"
+    s3_prefix = EXPERIMENTS_S3_PREFIX
+    key = f"{s3_prefix}/{user_id}/{experiment_id}/cases.json"
 
     # Convert test cases to JSON
     cases_data = []
@@ -145,7 +156,9 @@ async def run_experiment_generation(experiment_id: str, user_id: str):
         task_description = experiment["TaskDescription"]
         num_cases = int(experiment["NumCases"])
         num_topics = int(experiment["NumTopics"])
-        model_id = experiment.get("ModelId", "global.amazon.nova-2-lite-v1:0")
+        model_id = experiment.get("ModelId")
+        if not model_id:
+            raise ValueError("ModelId is required but not set on the experiment")
 
         logger.info(
             f"Generating {num_cases} test cases across {num_topics} topics using model {model_id}"

--- a/lib/experiments-batch/docker/batch_runner.py
+++ b/lib/experiments-batch/docker/batch_runner.py
@@ -11,6 +11,7 @@ Standalone script for generating synthetic test cases.
 
 import asyncio
 import json
+import logging
 import os
 import sys
 import uuid
@@ -20,6 +21,12 @@ from typing import Any, Dict, List
 import boto3
 from botocore.exceptions import ClientError
 from strands_evals.generators import ExperimentGenerator
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
 
 
 def update_experiment_status(
@@ -61,9 +68,9 @@ def update_experiment_status(
             ExpressionAttributeValues=expr_attr_values,
             ConditionExpression="UserId = :userId",
         )
-        print(f"Updated experiment {experiment_id} status to {status}")
+        logger.info(f"Updated experiment {experiment_id} status to {status}")
     except ClientError as e:
-        print(f"Error updating experiment status: {e}")
+        logger.error(f"Error updating experiment status: {e}")
         raise
 
 
@@ -78,7 +85,7 @@ def get_experiment(experiment_id: str, user_id: str) -> Dict[str, Any]:
         )
         return response.get("Item")
     except ClientError as e:
-        print(f"Error retrieving experiment: {e}")
+        logger.error(f"Error retrieving experiment: {e}")
         raise
 
 
@@ -111,16 +118,16 @@ def upload_to_s3(experiment_id: str, user_id: str, test_cases: List[Any]) -> str
             ServerSideEncryption="AES256",
         )
         s3_uri = f"s3://{bucket_name}/{key}"
-        print(f"Uploaded {len(cases_data)} test cases to {s3_uri}")
+        logger.info(f"Uploaded {len(cases_data)} test cases to {s3_uri}")
         return s3_uri
     except ClientError as e:
-        print(f"Error uploading to S3: {e}")
+        logger.error(f"Error uploading to S3: {e}")
         raise
 
 
 async def run_experiment_generation(experiment_id: str, user_id: str):
     """Main experiment generation logic."""
-    print(f"Starting experiment generation for {experiment_id}")
+    logger.info(f"Starting experiment generation for {experiment_id}")
 
     try:
         # Update status to RUNNING
@@ -131,7 +138,7 @@ async def run_experiment_generation(experiment_id: str, user_id: str):
         if not experiment:
             raise ValueError(f"Experiment {experiment_id} not found")
 
-        print(f"Retrieved experiment config: {experiment}")
+        logger.info(f"Retrieved experiment config: {experiment}")
 
         # Extract configuration
         context = experiment["Context"]
@@ -140,7 +147,7 @@ async def run_experiment_generation(experiment_id: str, user_id: str):
         num_topics = int(experiment["NumTopics"])
         model_id = experiment.get("ModelId", "global.amazon.nova-2-lite-v1:0")
 
-        print(
+        logger.info(
             f"Generating {num_cases} test cases across {num_topics} topics using model {model_id}"
         )
 
@@ -163,7 +170,7 @@ async def run_experiment_generation(experiment_id: str, user_id: str):
         )
 
         test_cases = experiment_obj.cases
-        print(f"Generated {len(test_cases)} test cases")
+        logger.info(f"Generated {len(test_cases)} test cases")
 
         # Upload to S3
         s3_uri = upload_to_s3(experiment_id, user_id, test_cases)
@@ -177,7 +184,7 @@ async def run_experiment_generation(experiment_id: str, user_id: str):
             num_cases_generated=len(test_cases),
         )
 
-        print(f"Experiment {experiment_id} completed successfully")
+        logger.info(f"Experiment {experiment_id} completed successfully")
         return {
             "status": "COMPLETED",
             "s3_uri": s3_uri,
@@ -186,7 +193,7 @@ async def run_experiment_generation(experiment_id: str, user_id: str):
 
     except Exception as e:
         error_msg = str(e)
-        print(f"Error generating experiment: {error_msg}")
+        logger.error(f"Error generating experiment: {error_msg}")
         update_experiment_status(
             experiment_id, user_id, "FAILED", error_message=error_msg
         )
@@ -195,26 +202,21 @@ async def run_experiment_generation(experiment_id: str, user_id: str):
 
 def main():
     """Entry point for Batch job."""
-    # Get job parameters from environment
     experiment_id = os.environ.get("EXPERIMENT_ID")
     user_id = os.environ.get("USER_ID")
 
     if not experiment_id or not user_id:
-        print("Error: EXPERIMENT_ID and USER_ID must be set")
+        logger.error("EXPERIMENT_ID and USER_ID must be set")
         sys.exit(1)
 
-    print(f"Batch job started for experiment {experiment_id}, user {user_id}")
+    logger.info(f"Batch job started for experiment {experiment_id}, user {user_id}")
 
     try:
-        # Run async generation
         result = asyncio.run(run_experiment_generation(experiment_id, user_id))
-        print(f"Job completed successfully: {result}")
+        logger.info(f"Job completed successfully: {result}")
         sys.exit(0)
     except Exception as e:
-        print(f"Job failed: {e}")
-        import traceback
-
-        traceback.print_exc()
+        logger.exception(f"Job failed: {e}")
         sys.exit(1)
 
 

--- a/lib/experiments-batch/docker/requirements.txt
+++ b/lib/experiments-batch/docker/requirements.txt
@@ -1,0 +1,3 @@
+boto3==1.42.26
+strands-agents-evals==0.1.0
+pydantic==2.12.3

--- a/lib/experiments-batch/index.ts
+++ b/lib/experiments-batch/index.ts
@@ -1,8 +1,5 @@
-// ----------------------------------------------------------------------
 // Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-//
-// SPDX-License-Identifier: Apache-2.0
-// ----------------------------------------------------------------------
+// SPDX-License-Identifier: MIT-0
 
 import * as cdk from "aws-cdk-lib";
 import * as batch from "aws-cdk-lib/aws-batch";
@@ -24,7 +21,6 @@ export interface ExperimentsBatchProps {
     readonly config: SystemConfig;
     readonly experimentsTableName: string;
     readonly evaluationsBucketName: string;
-    readonly vpc?: ec2.IVpc;
 }
 
 export class ExperimentsBatch extends Construct {
@@ -45,30 +41,28 @@ export class ExperimentsBatch extends Construct {
             platform: Platform.LINUX_ARM64,
         });
 
-        // Create or use existing VPC for Batch
-        const vpc = props.vpc || new ec2.Vpc(this, "BatchVpc", {
+        // Create VPC for Batch compute environment
+        const vpc = new ec2.Vpc(this, "BatchVpc", {
             maxAzs: 2,
             natGateways: 1,
         });
 
         // Add VPC Flow Logs for security compliance
-        if (!props.vpc) {
-            const flowLogRole = new iam.Role(this, "FlowLogRole", {
-                assumedBy: new iam.ServicePrincipal("vpc-flow-logs.amazonaws.com"),
-            });
+        const flowLogRole = new iam.Role(this, "FlowLogRole", {
+            assumedBy: new iam.ServicePrincipal("vpc-flow-logs.amazonaws.com"),
+        });
 
-            const flowLogGroup = new logs.LogGroup(this, "FlowLogGroup", {
-                retention: logs.RetentionDays.ONE_WEEK,
-                removalPolicy: cdk.RemovalPolicy.DESTROY,
-            });
+        const flowLogGroup = new logs.LogGroup(this, "FlowLogGroup", {
+            retention: logs.RetentionDays.ONE_WEEK,
+            removalPolicy: cdk.RemovalPolicy.DESTROY,
+        });
 
-            flowLogGroup.grantWrite(flowLogRole);
+        flowLogGroup.grantWrite(flowLogRole);
 
-            new ec2.FlowLog(this, "FlowLog", {
-                resourceType: ec2.FlowLogResourceType.fromVpc(vpc),
-                destination: ec2.FlowLogDestination.toCloudWatchLogs(flowLogGroup, flowLogRole),
-            });
-        }
+        new ec2.FlowLog(this, "FlowLog", {
+            resourceType: ec2.FlowLogResourceType.fromVpc(vpc),
+            destination: ec2.FlowLogDestination.toCloudWatchLogs(flowLogGroup, flowLogRole),
+        });
 
         // Create IAM role for Batch job execution
         const jobRole = new iam.Role(this, "ExperimentJobRole", {
@@ -169,6 +163,7 @@ export class ExperimentsBatch extends Construct {
                 environment: {
                     EXPERIMENTS_TABLE_NAME: props.experimentsTableName,
                     EXPERIMENTS_BUCKET_NAME: props.evaluationsBucketName,
+                    EXPERIMENTS_S3_PREFIX: "experiments/generated-cases",
                     AWS_REGION: cdk.Aws.REGION,
                 },
                 logging: ecs.LogDriver.awsLogs({
@@ -212,18 +207,16 @@ export class ExperimentsBatch extends Construct {
             true,
         );
 
-        // Suppress VPC flow log warning if using provided VPC
-        if (!props.vpc) {
-            NagSuppressions.addResourceSuppressions(
-                vpc,
-                [
-                    {
-                        id: "AwsSolutions-VPC7",
-                        reason: "VPC Flow Logs are enabled for the Batch VPC.",
-                    },
-                ],
-                true,
-            );
-        }
+        // Suppress VPC flow log warning
+        NagSuppressions.addResourceSuppressions(
+            vpc,
+            [
+                {
+                    id: "AwsSolutions-VPC7",
+                    reason: "VPC Flow Logs are enabled for the Batch VPC.",
+                },
+            ],
+            true,
+        );
     }
 }

--- a/lib/experiments-batch/index.ts
+++ b/lib/experiments-batch/index.ts
@@ -1,0 +1,229 @@
+// ----------------------------------------------------------------------
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+// ----------------------------------------------------------------------
+
+import * as cdk from "aws-cdk-lib";
+import * as batch from "aws-cdk-lib/aws-batch";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as ecs from "aws-cdk-lib/aws-ecs";
+import { DockerImageAsset, Platform } from "aws-cdk-lib/aws-ecr-assets";
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as logs from "aws-cdk-lib/aws-logs";
+import { Construct } from "constructs";
+import { NagSuppressions } from "cdk-nag";
+import * as path from "path";
+
+import { Shared } from "../shared";
+import { SystemConfig } from "../shared/types";
+import { generatePrefix } from "../shared/utils";
+
+export interface ExperimentsBatchProps {
+    readonly shared: Shared;
+    readonly config: SystemConfig;
+    readonly experimentsTableName: string;
+    readonly evaluationsBucketName: string;
+    readonly vpc?: ec2.IVpc;
+}
+
+export class ExperimentsBatch extends Construct {
+    public readonly jobQueue: batch.IJobQueue;
+    public readonly jobDefinition: batch.IJobDefinition;
+    public readonly computeEnvironment: batch.IComputeEnvironment;
+    public readonly batchImage: DockerImageAsset;
+
+    constructor(scope: Construct, id: string, props: ExperimentsBatchProps) {
+        super(scope, id);
+
+        const prefix = generatePrefix(this);
+
+        // Build Batch-specific Docker image
+        this.batchImage = new DockerImageAsset(this, "BatchImage", {
+            assetName: `${prefix}-experiments-batch`,
+            directory: path.join(__dirname, "docker"),
+            platform: Platform.LINUX_ARM64,
+        });
+
+        // Create or use existing VPC for Batch
+        const vpc = props.vpc || new ec2.Vpc(this, "BatchVpc", {
+            maxAzs: 2,
+            natGateways: 1,
+        });
+
+        // Add VPC Flow Logs for security compliance
+        if (!props.vpc) {
+            const flowLogRole = new iam.Role(this, "FlowLogRole", {
+                assumedBy: new iam.ServicePrincipal("vpc-flow-logs.amazonaws.com"),
+            });
+
+            const flowLogGroup = new logs.LogGroup(this, "FlowLogGroup", {
+                retention: logs.RetentionDays.ONE_WEEK,
+                removalPolicy: cdk.RemovalPolicy.DESTROY,
+            });
+
+            flowLogGroup.grantWrite(flowLogRole);
+
+            new ec2.FlowLog(this, "FlowLog", {
+                resourceType: ec2.FlowLogResourceType.fromVpc(vpc),
+                destination: ec2.FlowLogDestination.toCloudWatchLogs(flowLogGroup, flowLogRole),
+            });
+        }
+
+        // Create IAM role for Batch job execution
+        const jobRole = new iam.Role(this, "ExperimentJobRole", {
+            assumedBy: new iam.ServicePrincipal("ecs-tasks.amazonaws.com"),
+            description: "Role for AWS Batch experiment generation jobs",
+        });
+
+        // Grant permissions to access DynamoDB and S3
+        jobRole.addToPolicy(
+            new iam.PolicyStatement({
+                effect: iam.Effect.ALLOW,
+                actions: [
+                    "dynamodb:GetItem",
+                    "dynamodb:UpdateItem",
+                ],
+                resources: [
+                    `arn:aws:dynamodb:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:table/${props.experimentsTableName}`,
+                ],
+            }),
+        );
+
+        jobRole.addToPolicy(
+            new iam.PolicyStatement({
+                effect: iam.Effect.ALLOW,
+                actions: [
+                    "s3:PutObject",
+                ],
+                resources: [
+                    `arn:aws:s3:::${props.evaluationsBucketName}/*`,
+                ],
+            }),
+        );
+
+        // Grant Bedrock model access for test case generation
+        jobRole.addToPolicy(
+            new iam.PolicyStatement({
+                effect: iam.Effect.ALLOW,
+                actions: [
+                    "bedrock:InvokeModel",
+                    "bedrock:InvokeModelWithResponseStream",
+                    "bedrock:Converse",
+                    "bedrock:ConverseStream",
+                ],
+                resources: [
+                    `arn:aws:bedrock:*::foundation-model/*`,
+                    `arn:aws:bedrock:*:${cdk.Stack.of(this).account}:inference-profile/*`,
+                    `arn:aws:bedrock:*::inference-profile/*`,
+                ],
+            }),
+        );
+
+        // Create execution role for Batch
+        const executionRole = new iam.Role(this, "ExperimentJobExecutionRole", {
+            assumedBy: new iam.ServicePrincipal("ecs-tasks.amazonaws.com"),
+            managedPolicies: [
+                iam.ManagedPolicy.fromAwsManagedPolicyName(
+                    "service-role/AmazonECSTaskExecutionRolePolicy",
+                ),
+            ],
+        });
+
+        // Create CloudWatch log group
+        const logGroup = new logs.LogGroup(this, "ExperimentJobLogs", {
+            logGroupName: `/aws/batch/experiments`,
+            retention: logs.RetentionDays.ONE_WEEK,
+            removalPolicy: cdk.RemovalPolicy.DESTROY,
+        });
+
+        // Create Batch Compute Environment (Fargate)
+        this.computeEnvironment = new batch.FargateComputeEnvironment(
+            this,
+            "ExperimentComputeEnv",
+            {
+                vpc,
+                maxvCpus: 4,
+            },
+        );
+
+        // Create Job Queue
+        this.jobQueue = new batch.JobQueue(this, "ExperimentJobQueue", {
+            computeEnvironments: [
+                {
+                    computeEnvironment: this.computeEnvironment,
+                    order: 1,
+                },
+            ],
+        });
+
+        // Create Job Definition (Fargate with small compute)
+        this.jobDefinition = new batch.EcsJobDefinition(this, "ExperimentJobDef", {
+            container: new batch.EcsFargateContainerDefinition(this, "ExperimentContainer", {
+                image: ecs.ContainerImage.fromDockerImageAsset(this.batchImage),
+                memory: cdk.Size.mebibytes(2048), // 2GB
+                cpu: 1, // 1 vCPU
+                jobRole,
+                executionRole,
+                fargatePlatformVersion: ecs.FargatePlatformVersion.LATEST,
+                environment: {
+                    EXPERIMENTS_TABLE_NAME: props.experimentsTableName,
+                    EXPERIMENTS_BUCKET_NAME: props.evaluationsBucketName,
+                    AWS_REGION: cdk.Aws.REGION,
+                },
+                logging: ecs.LogDriver.awsLogs({
+                    streamPrefix: "experiment",
+                    logGroup,
+                }),
+            }),
+        });
+
+        // Override the runtime platform to ARM64 using CFN escape hatch
+        const cfnJobDef = this.jobDefinition.node.defaultChild as batch.CfnJobDefinition;
+        cfnJobDef.addPropertyOverride("ContainerProperties.RuntimePlatform", {
+            CpuArchitecture: "ARM64",
+            OperatingSystemFamily: "LINUX",
+        });
+
+        // CDK NAG Suppressions
+        NagSuppressions.addResourceSuppressions(
+            jobRole,
+            [
+                {
+                    id: "AwsSolutions-IAM5",
+                    reason: "Wildcard permissions required for Bedrock model access.",
+                },
+            ],
+            true,
+        );
+
+        NagSuppressions.addResourceSuppressions(
+            executionRole,
+            [
+                {
+                    id: "AwsSolutions-IAM4",
+                    reason: "AWS managed policy required for ECS task execution.",
+                },
+                {
+                    id: "AwsSolutions-IAM5",
+                    reason: "Wildcard permissions required for ECR image pull and CloudWatch logs.",
+                },
+            ],
+            true,
+        );
+
+        // Suppress VPC flow log warning if using provided VPC
+        if (!props.vpc) {
+            NagSuppressions.addResourceSuppressions(
+                vpc,
+                [
+                    {
+                        id: "AwsSolutions-VPC7",
+                        reason: "VPC Flow Logs are enabled for the Batch VPC.",
+                    },
+                ],
+                true,
+            );
+        }
+    }
+}

--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -293,6 +293,14 @@ export interface EvaluatorConfig {
 }
 
 /**
+ * Configuration for the experiments (synthetic data generation) feature.
+ * @property supportedModels - Record mapping user-friendly model names to their Bedrock model identifiers
+ */
+export interface ExperimentsConfig {
+    supportedModels: Record<string, string>;
+}
+
+/**
  * Configuration interface for the CDK deployment.
  * This is the main configuration object that controls the entire system deployment.
  *
@@ -335,4 +343,6 @@ export interface SystemConfig {
     agentRuntimeConfig?: AgentRuntimeConfig;
 
     evaluatorConfig?: EvaluatorConfig;
+
+    experimentsConfig?: ExperimentsConfig;
 }

--- a/lib/user-interface/index.ts
+++ b/lib/user-interface/index.ts
@@ -119,6 +119,11 @@ export class UserInterface extends Construct {
                 evaluatorConfig: props.config.evaluatorConfig,
             }),
 
+            // Experiments configuration
+            ...(props.config.experimentsConfig && {
+                experimentsConfig: props.config.experimentsConfig,
+            }),
+
             // Feature flags
             knowledgeBaseIsSupported: !!props.dataBucket,
 

--- a/lib/user-interface/react-app/package-lock.json
+++ b/lib/user-interface/react-app/package-lock.json
@@ -141,7 +141,6 @@
             "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-6.16.1.tgz",
             "integrity": "sha512-WHO6yYegmnZ+K3vnYzVwy+wnxYqSkdFakBIlgm4922QXHOQYWdIl/rrTcaagrpJEGT6YlTnqx1ANIoPojNxWmw==",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-js": "5.2.0",
                 "@aws-sdk/types": "3.973.1",
@@ -1382,7 +1381,6 @@
             "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -1723,7 +1721,6 @@
             "resolved": "https://registry.npmjs.org/@cloudscape-design/components/-/components-3.0.1207.tgz",
             "integrity": "sha512-7cTx2erTJg0RZOvCA+KzTjz8NnM5cxoamK8/pNNiH5glq3jmQG+PRtbDrwyG5dzJ6Ypf0/dpnezBe483BZuXPQ==",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@cloudscape-design/collection-hooks": "^1.0.0",
                 "@cloudscape-design/component-toolkit": "^1.0.0-beta",
@@ -1818,7 +1815,6 @@
             "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
             "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@dnd-kit/accessibility": "^3.1.1",
                 "@dnd-kit/utilities": "^3.2.2",
@@ -2541,7 +2537,6 @@
             "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
             "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@fortawesome/fontawesome-common-types": "6.7.2"
             },
@@ -5053,7 +5048,6 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
             "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.2.2"
@@ -5065,7 +5059,6 @@
             "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
             "devOptional": true,
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "@types/react": "^18.0.0"
             }
@@ -5135,7 +5128,6 @@
             "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.56.0",
                 "@typescript-eslint/types": "8.56.0",
@@ -5405,7 +5397,6 @@
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -5540,7 +5531,6 @@
             "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-6.16.2.tgz",
             "integrity": "sha512-7CHwfH5QxZ0rzCws/DNy5VLVcIIZWd9iUTtV1Oj6kPzpkFhCJ2I8gTvhFdh61HLhrg2lShcPQ8cecBIQS/ZJ0A==",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-amplify/analytics": "7.0.93",
                 "@aws-amplify/api": "6.3.24",
@@ -5676,7 +5666,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -6321,7 +6310,6 @@
             "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -7206,7 +7194,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.26.10"
             },
@@ -8821,7 +8808,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -8901,7 +8887,6 @@
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -8914,7 +8899,6 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.2"
@@ -9539,7 +9523,6 @@
             "integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "chokidar": "^4.0.0",
                 "immutable": "^5.0.2",
@@ -9839,7 +9822,6 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "devOptional": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -10152,7 +10134,6 @@
             "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.4.4",
@@ -10319,7 +10300,6 @@
             "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.38.3.tgz",
             "integrity": "sha512-SH7nAaaPQx57dx6qvfcIgqKRXIh4L0A1iYEqim4s1u7c9VoCgzZc+63FY90AKU4ZzOC2cfJzTnpO4zK7fCUzzw==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/xstate"

--- a/lib/user-interface/react-app/src/API.ts
+++ b/lib/user-interface/react-app/src/API.ts
@@ -579,7 +579,6 @@ export type PublishEvaluationUpdateMutation = {
 export type CreateExperimentMutationVariables = {
   name: string,
   description?: string | null,
-  s3Path?: string | null,
   generationConfig?: string | null,
   modelId: string,
 };

--- a/lib/user-interface/react-app/src/API.ts
+++ b/lib/user-interface/react-app/src/API.ts
@@ -103,6 +103,40 @@ export type EvaluationNotification = {
   status?: string | null,
 };
 
+export enum ExperimentStatus {
+  DRAFT = "DRAFT",
+  RUNNING = "RUNNING",
+  COMPLETED = "COMPLETED",
+  FAILED = "FAILED",
+}
+
+
+export type DeleteExperimentResult = {
+  __typename: "DeleteExperimentResult",
+  experimentId?: string | null,
+  deleted: boolean,
+};
+
+export type Experiment = {
+  __typename: "Experiment",
+  experimentId: string,
+  userId: string,
+  name: string,
+  description?: string | null,
+  createdAt: string,
+  updatedAt: string,
+  status: ExperimentStatus,
+  generatedCasesS3Url?: string | null,
+  taskDescription?: string | null,
+  context?: string | null,
+  numCases?: number | null,
+  numTopics?: number | null,
+  modelId?: string | null,
+  generatedCasesCount?: number | null,
+  errorMessage?: string | null,
+  batchJobId?: string | null,
+};
+
 export type Session = {
   __typename: "Session",
   id: string,
@@ -542,6 +576,67 @@ export type PublishEvaluationUpdateMutation = {
   } | null,
 };
 
+export type CreateExperimentMutationVariables = {
+  name: string,
+  description?: string | null,
+  s3Path?: string | null,
+  generationConfig?: string | null,
+  modelId: string,
+};
+
+export type CreateExperimentMutation = {
+  createExperiment: string,
+};
+
+export type UpdateExperimentMutationVariables = {
+  experimentId: string,
+  name?: string | null,
+  description?: string | null,
+  status?: ExperimentStatus | null,
+};
+
+export type UpdateExperimentMutation = {
+  updateExperiment?: boolean | null,
+};
+
+export type DeleteExperimentMutationVariables = {
+  experimentId: string,
+};
+
+export type DeleteExperimentMutation = {
+  deleteExperiment?:  {
+    __typename: "DeleteExperimentResult",
+    experimentId?: string | null,
+    deleted: boolean,
+  } | null,
+};
+
+export type RunExperimentMutationVariables = {
+  experimentId: string,
+};
+
+export type RunExperimentMutation = {
+  runExperiment?:  {
+    __typename: "Experiment",
+    experimentId: string,
+    userId: string,
+    name: string,
+    description?: string | null,
+    createdAt: string,
+    updatedAt: string,
+    status: ExperimentStatus,
+    generatedCasesS3Url?: string | null,
+    taskDescription?: string | null,
+    context?: string | null,
+    numCases?: number | null,
+    numTopics?: number | null,
+    modelId?: string | null,
+    generatedCasesCount?: number | null,
+    errorMessage?: string | null,
+    batchJobId?: string | null,
+  } | null,
+};
+
 export type ListSessionsQueryVariables = {
 };
 
@@ -869,6 +964,65 @@ export type GetEvaluatorQuery = {
     startedAt?: string | null,
     completedAt?: string | null,
   } | null,
+};
+
+export type ListExperimentsQueryVariables = {
+};
+
+export type ListExperimentsQuery = {
+  listExperiments:  Array< {
+    __typename: "Experiment",
+    experimentId: string,
+    userId: string,
+    name: string,
+    description?: string | null,
+    createdAt: string,
+    updatedAt: string,
+    status: ExperimentStatus,
+    generatedCasesS3Url?: string | null,
+    taskDescription?: string | null,
+    context?: string | null,
+    numCases?: number | null,
+    numTopics?: number | null,
+    modelId?: string | null,
+    generatedCasesCount?: number | null,
+    errorMessage?: string | null,
+    batchJobId?: string | null,
+  } >,
+};
+
+export type GetExperimentQueryVariables = {
+  experimentId: string,
+};
+
+export type GetExperimentQuery = {
+  getExperiment?:  {
+    __typename: "Experiment",
+    experimentId: string,
+    userId: string,
+    name: string,
+    description?: string | null,
+    createdAt: string,
+    updatedAt: string,
+    status: ExperimentStatus,
+    generatedCasesS3Url?: string | null,
+    taskDescription?: string | null,
+    context?: string | null,
+    numCases?: number | null,
+    numTopics?: number | null,
+    modelId?: string | null,
+    generatedCasesCount?: number | null,
+    errorMessage?: string | null,
+    batchJobId?: string | null,
+  } | null,
+};
+
+export type GetExperimentPresignedUrlQueryVariables = {
+  s3Uri: string,
+};
+
+export type GetExperimentPresignedUrlQuery = {
+  getExperimentPresignedUrl?: string | null,
 };
 
 export type ReceiveMessagesSubscriptionVariables = {

--- a/lib/user-interface/react-app/src/API.ts
+++ b/lib/user-interface/react-app/src/API.ts
@@ -579,7 +579,7 @@ export type PublishEvaluationUpdateMutation = {
 export type CreateExperimentMutationVariables = {
   name: string,
   description?: string | null,
-  generationConfig?: string | null,
+  generationConfig: string,
   modelId: string,
 };
 

--- a/lib/user-interface/react-app/src/app.tsx
+++ b/lib/user-interface/react-app/src/app.tsx
@@ -12,14 +12,15 @@ import "./styles/app.scss";
 
 import AgentCoreManagerPage from "./pages/admin/agent-core-manager";
 import AgentCoreWizardPage from "./pages/admin/agent-core-wizard-page";
+import CreateExperimentPage from "./pages/admin/create-experiment";
 import DocumentManagerPage from "./pages/admin/documents";
 import EvaluationsManagerPage from "./pages/admin/evaluations-manager";
 import EvaluationsWizardPage from "./pages/admin/evaluations-wizard-page";
+import ExperimentsManagerPage from "./pages/admin/experiments-manager";
 import KnowledgeBaseManagerPage from "./pages/admin/kb-manager";
 import SessionPage from "./pages/chatbot/sessions";
 
 function App() {
-    // const appContext = useContext(AppContext);
     const Router = BrowserRouter;
 
     return (
@@ -38,6 +39,8 @@ function App() {
                         <Route path="/agent-core/create" element={<AgentCoreWizardPage />} />
                         <Route path="/evaluations" element={<EvaluationsManagerPage />} />
                         <Route path="/evaluations/create" element={<EvaluationsWizardPage />} />
+                        <Route path="/experiments" element={<ExperimentsManagerPage />} />
+                        <Route path="/experiments/create" element={<CreateExperimentPage />} />
                         <Route path="*" element={<NotFound />} />
                     </Routes>
                 </div>

--- a/lib/user-interface/react-app/src/common/types.ts
+++ b/lib/user-interface/react-app/src/common/types.ts
@@ -10,6 +10,10 @@ export interface EvaluatorConfigType {
     defaultRubrics?: Record<string, string>;
 }
 
+export interface ExperimentsConfigType {
+    supportedModels: Record<string, string>;
+}
+
 export interface AppConfig {
     aws_project_region: string;
     aws_cognito_identity_pool_id: string;
@@ -19,6 +23,7 @@ export interface AppConfig {
     aws_bedrock_supported_reranking_models?: Record<string, string>;
     knowledgeBaseIsSupported?: boolean;
     evaluatorConfig?: EvaluatorConfigType;
+    experimentsConfig?: ExperimentsConfigType;
 }
 
 export interface NavigationPanelState {

--- a/lib/user-interface/react-app/src/components/admin/experiments-manager.tsx
+++ b/lib/user-interface/react-app/src/components/admin/experiments-manager.tsx
@@ -1,9 +1,5 @@
-// -----------------------------------------------------------------------
 // Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-//
-// SPDX-License-Identifier: Apache-2.0
-//
-// -----------------------------------------------------------------------
+// SPDX-License-Identifier: MIT-0
 import {
     Alert,
     Box,
@@ -537,6 +533,12 @@ export default function ExperimentsManager() {
                         counter={`(${experiments.length})`}
                         actions={
                             <SpaceBetween direction="horizontal" size="xs">
+                                <Button
+                                    iconName="refresh"
+                                    onClick={loadExperiments}
+                                    loading={loading}
+                                    ariaLabel="Refresh experiments"
+                                />
                                 <Button onClick={handleDelete} disabled={selectedItems.length === 0}>
                                     Delete
                                 </Button>

--- a/lib/user-interface/react-app/src/components/admin/experiments-manager.tsx
+++ b/lib/user-interface/react-app/src/components/admin/experiments-manager.tsx
@@ -1,0 +1,592 @@
+// -----------------------------------------------------------------------
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// -----------------------------------------------------------------------
+import {
+    Alert,
+    Box,
+    Button,
+    CollectionPreferences,
+    ColumnLayout,
+    Container,
+    Header,
+    KeyValuePairs,
+    Link,
+    Pagination,
+    Popover,
+    SpaceBetween,
+    StatusIndicator,
+    Table,
+    TableProps,
+} from "@cloudscape-design/components";
+import { generateClient } from "aws-amplify/api";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import * as mutations from "../../graphql/mutations";
+import * as queries from "../../graphql/queries";
+
+interface Experiment {
+    experimentId: string;
+    userId: string;
+    name: string;
+    description?: string;
+    createdAt: string;
+    updatedAt: string;
+    status: string;
+    generatedCasesS3Url?: string;
+    taskDescription?: string;
+    context?: string;
+    numCases?: number;
+    numTopics?: number;
+    modelId?: string;
+    generatedCasesCount?: number;
+    errorMessage?: string;
+    batchJobId?: string;
+}
+
+// LocalStorage key for page size persistence
+const PAGE_SIZE_STORAGE_KEY = 'experiments-page-size';
+const DEFAULT_PAGE_SIZE = 100;
+
+/**
+ * Save page size to localStorage
+ * @param size - The page size to save
+ * Note: This function will be used in task 4 for pagination preferences
+ */
+const savePageSize = (size: number): void => {
+    try {
+        localStorage.setItem(PAGE_SIZE_STORAGE_KEY, size.toString());
+    } catch (error) {
+        // localStorage might be unavailable (private browsing, storage quota exceeded, etc.)
+        console.warn('Failed to save page size to localStorage:', error);
+    }
+};
+
+/**
+ * Load page size from localStorage
+ * @returns The saved page size, or default (100) if not found or invalid
+ * Note: This function will be used in task 4 for pagination preferences
+ */
+const loadPageSize = (): number => {
+    try {
+        const saved = localStorage.getItem(PAGE_SIZE_STORAGE_KEY);
+        if (saved) {
+            const parsed = parseInt(saved, 10);
+            // Validate that the parsed value is a valid page size option
+            if (!isNaN(parsed) && parsed > 0) {
+                return parsed;
+            }
+        }
+    } catch (error) {
+        // localStorage might be unavailable (private browsing, etc.)
+        console.warn('Failed to load page size from localStorage:', error);
+    }
+    return DEFAULT_PAGE_SIZE;
+};
+
+/**
+ * Details Tab Component
+ * Displays all experiment fields in an organized, readable format
+ * **Validates: Requirements 2.3**
+ *
+ * @param experiment - The experiment to display details for
+ */
+interface DetailsTabProps {
+    experiment: Experiment | null;
+}
+
+function DetailsTab({ experiment }: DetailsTabProps) {
+    const [presignedUrlLoading, setPresignedUrlLoading] = useState(false);
+    const [presignedUrlError, setPresignedUrlError] = useState<string | null>(null);
+    const apiClient = generateClient();
+
+    const handleViewS3File = async () => {
+        if (!experiment?.generatedCasesS3Url) return;
+
+        setPresignedUrlLoading(true);
+        setPresignedUrlError(null);
+        try {
+            const response: any = await apiClient.graphql({
+                query: queries.getExperimentPresignedUrl,
+                variables: {
+                    s3Uri: experiment.generatedCasesS3Url,
+                },
+            });
+            window.open(response.data.getExperimentPresignedUrl!, "_blank");
+        } catch (err) {
+            console.error("Error generating presigned URL:", err);
+            setPresignedUrlError("Failed to generate presigned URL");
+        } finally {
+            setPresignedUrlLoading(false);
+        }
+    };
+
+    if (!experiment) {
+        return (
+            <Box textAlign="center" padding="l">
+                <StatusIndicator type="info">No experiment selected</StatusIndicator>
+            </Box>
+        );
+    }
+
+    // Helper to format values, handling null/undefined
+    const formatValue = (value: any): string => {
+        if (value === null || value === undefined) return "-";
+        if (typeof value === "boolean") return value ? "Yes" : "No";
+        if (typeof value === "number") return value.toString();
+        if (typeof value === "string") return value || "-";
+        return "-";
+    };
+
+    // Format dates using toLocaleString()
+    const formatDate = (dateString: string | undefined): string => {
+        if (!dateString) return "-";
+        try {
+            return new Date(dateString).toLocaleString();
+        } catch {
+            return dateString;
+        }
+    };
+
+    return (
+        <SpaceBetween size="l">
+            <Container header={<Header variant="h3">Basic Information</Header>}>
+                <ColumnLayout columns={2} variant="text-grid">
+                    <KeyValuePairs
+                        columns={1}
+                        items={[
+                            {
+                                label: "Experiment ID",
+                                value: formatValue(experiment.experimentId),
+                            },
+                            {
+                                label: "Name",
+                                value: formatValue(experiment.name),
+                            },
+                            {
+                                label: "Description",
+                                value: formatValue(experiment.description),
+                            },
+                            {
+                                label: "Status",
+                                value: formatValue(experiment.status),
+                            },
+                        ]}
+                    />
+                    <KeyValuePairs
+                        columns={1}
+                        items={[
+                            {
+                                label: "User ID",
+                                value: formatValue(experiment.userId),
+                            },
+                            {
+                                label: "Created At",
+                                value: formatDate(experiment.createdAt),
+                            },
+                            {
+                                label: "Updated At",
+                                value: formatDate(experiment.updatedAt),
+                            },
+                        ]}
+                    />
+                </ColumnLayout>
+            </Container>
+
+            <Container header={<Header variant="h3">Configuration</Header>}>
+                <ColumnLayout columns={2} variant="text-grid">
+                    <KeyValuePairs
+                        columns={1}
+                        items={[
+                            {
+                                label: "Model ID",
+                                value: formatValue(experiment.modelId),
+                            },
+                            {
+                                label: "Batch Job ID",
+                                value: formatValue(experiment.batchJobId),
+                            },
+                        ]}
+                    />
+                    <KeyValuePairs
+                        columns={1}
+                        items={[
+                            {
+                                label: "Number of Cases",
+                                value: formatValue(experiment.numCases),
+                            },
+                            {
+                                label: "Number of Topics",
+                                value: formatValue(experiment.numTopics),
+                            },
+                            {
+                                label: "Generated Cases Count",
+                                value: formatValue(experiment.generatedCasesCount),
+                            },
+                        ]}
+                    />
+                </ColumnLayout>
+            </Container>
+
+            <Container header={<Header variant="h3">Task Details</Header>}>
+                <KeyValuePairs
+                    columns={1}
+                    items={[
+                        {
+                            label: "Task Description",
+                            value: formatValue(experiment.taskDescription),
+                        },
+                        {
+                            label: "Context",
+                            value: formatValue(experiment.context),
+                        },
+                    ]}
+                />
+            </Container>
+
+            <Container header={<Header variant="h3">S3 Data</Header>}>
+                <KeyValuePairs
+                    columns={1}
+                    items={[
+                        {
+                            label: "Generated Cases S3 URL",
+                            value: experiment.generatedCasesS3Url ? (
+                                presignedUrlLoading ? (
+                                    <StatusIndicator type="loading">Loading...</StatusIndicator>
+                                ) : (
+                                    <Link
+                                        href="#"
+                                        onFollow={(e) => {
+                                            e.preventDefault();
+                                            handleViewS3File();
+                                        }}
+                                        external
+                                    >
+                                        {experiment.generatedCasesS3Url}
+                                    </Link>
+                                )
+                            ) : "-",
+                        },
+                    ]}
+                />
+                {presignedUrlError && (
+                    <Box padding={{ top: "s" }}>
+                        <Alert type="error" dismissible onDismiss={() => setPresignedUrlError(null)}>
+                            {presignedUrlError}
+                        </Alert>
+                    </Box>
+                )}
+            </Container>
+
+            {experiment.errorMessage && (
+                <Container header={<Header variant="h3">Error Information</Header>}>
+                    <Alert type="error">
+                        {experiment.errorMessage}
+                    </Alert>
+                </Container>
+            )}
+        </SpaceBetween>
+    );
+}
+
+export default function ExperimentsManager() {
+    const [experiments, setExperiments] = useState<Experiment[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [selectedItems, setSelectedItems] = useState<Experiment[]>([]);
+    const [currentPageIndex, setCurrentPageIndex] = useState(1);
+    const [error, setError] = useState<string | null>(null);
+    const [sortingColumn, setSortingColumn] = useState<TableProps.SortingColumn<Experiment>>({
+        sortingField: "createdAt",
+    });
+    const [sortingDescending, setSortingDescending] = useState(true);
+    const [pageSize, setPageSize] = useState<number>(loadPageSize());
+
+    const navigate = useNavigate();
+    const apiClient = generateClient();
+
+    useEffect(() => {
+        loadExperiments();
+    }, []);
+
+    const loadExperiments = async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const result: any = await apiClient.graphql({
+                query: queries.listExperiments,
+            });
+            const experimentsList = result.data.listExperiments || [];
+
+            // Sort experiments by createdAt in descending order (newest first)
+            const sortedExperiments = [...experimentsList].sort((a, b) => {
+                const dateA = new Date(a.createdAt).getTime();
+                const dateB = new Date(b.createdAt).getTime();
+                return dateB - dateA; // Descending order
+            });
+
+            setExperiments(sortedExperiments);
+        } catch (err) {
+            console.error("Error loading experiments:", err);
+            setError("Failed to load experiments");
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleDelete = async () => {
+        if (selectedItems.length === 0) return;
+
+        setLoading(true);
+        try {
+            await Promise.all(
+                selectedItems.map((item) =>
+                    apiClient.graphql({
+                        query: mutations.deleteExperiment,
+                        variables: { experimentId: item.experimentId },
+                    }),
+                ),
+            );
+            await loadExperiments();
+            setSelectedItems([]);
+        } catch (err) {
+            console.error("Error deleting experiments:", err);
+            setError("Failed to delete experiments");
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    // Helper function to truncate text with tooltip
+    const truncateWithTooltip = (text: string | undefined, maxLength: number = 30) => {
+        if (!text) return "-";
+        if (text.length <= maxLength) return text;
+
+        return (
+            <Popover
+                dismissButton={false}
+                position="top"
+                size="small"
+                triggerType="custom"
+                content={<Box variant="small">{text}</Box>}
+            >
+                <span style={{ cursor: "help" }}>
+                    {text.substring(0, maxLength)}...
+                </span>
+            </Popover>
+        );
+    };
+
+    // Helper function to copy text to clipboard
+    const copyToClipboard = async (text: string) => {
+        try {
+            await navigator.clipboard.writeText(text);
+        } catch (err) {
+            console.error("Failed to copy to clipboard:", err);
+        }
+    };
+
+    const columnDefinitions: TableProps.ColumnDefinition<Experiment>[] = [
+        {
+            id: "experimentId",
+            header: "Experiment ID",
+            cell: (item) => truncateWithTooltip(item.experimentId, 20),
+            sortingField: "experimentId",
+        },
+        {
+            id: "name",
+            header: "Name",
+            cell: (item) => item.name,
+            sortingField: "name",
+        },
+        {
+            id: "description",
+            header: "Description",
+            cell: (item) => truncateWithTooltip(item.description, 40),
+        },
+        {
+            id: "status",
+            header: "Status",
+            cell: (item) => {
+                const statusType =
+                    item.status === "COMPLETED" ? "success" :
+                    item.status === "RUNNING" ? "in-progress" :
+                    item.status === "FAILED" ? "error" :
+                    "pending";
+                return <StatusIndicator type={statusType}>{item.status}</StatusIndicator>;
+            },
+        },
+        {
+            id: "modelId",
+            header: "Model ID",
+            cell: (item) => truncateWithTooltip(item.modelId, 25),
+        },
+        {
+            id: "generatedCasesS3Url",
+            header: "Generated Cases URL",
+            cell: (item) => {
+                if (!item.generatedCasesS3Url) return "-";
+
+                return (
+                    <SpaceBetween direction="horizontal" size="xs">
+                        {truncateWithTooltip(item.generatedCasesS3Url, 30)}
+                        <Button
+                            variant="inline-icon"
+                            iconName="copy"
+                            ariaLabel="Copy S3 URL"
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                copyToClipboard(item.generatedCasesS3Url!);
+                            }}
+                        />
+                    </SpaceBetween>
+                );
+            },
+        },
+        {
+            id: "createdAt",
+            header: "Created",
+            cell: (item) => new Date(item.createdAt).toLocaleString(),
+            sortingField: "createdAt",
+        },
+        {
+            id: "updatedAt",
+            header: "Updated",
+            cell: (item) => new Date(item.updatedAt).toLocaleString(),
+            sortingField: "updatedAt",
+        },
+    ];
+
+    const paginatedItems = experiments.slice(
+        (currentPageIndex - 1) * pageSize,
+        currentPageIndex * pageSize,
+    );
+
+    const handleSortingChange = (detail: TableProps.SortingState<Experiment>) => {
+        setSortingColumn(detail.sortingColumn);
+        setSortingDescending(detail.isDescending ?? false);
+
+        // Sort the experiments array
+        const sorted = [...experiments].sort((a, b) => {
+            const field = detail.sortingColumn.sortingField as keyof Experiment;
+            const aValue = a[field];
+            const bValue = b[field];
+
+            // Handle undefined/null values
+            if (aValue === undefined || aValue === null) return 1;
+            if (bValue === undefined || bValue === null) return -1;
+
+            // Compare values
+            let comparison = 0;
+            if (typeof aValue === 'string' && typeof bValue === 'string') {
+                comparison = aValue.localeCompare(bValue);
+            } else if (field === 'createdAt' || field === 'updatedAt') {
+                const dateA = new Date(aValue as string).getTime();
+                const dateB = new Date(bValue as string).getTime();
+                comparison = dateA - dateB;
+            } else {
+                comparison = aValue < bValue ? -1 : aValue > bValue ? 1 : 0;
+            }
+
+            return detail.isDescending ? -comparison : comparison;
+        });
+
+        setExperiments(sorted);
+        setCurrentPageIndex(1); // Reset to first page when sorting changes
+    };
+
+    const handlePageSizeChange = (newPageSize: number) => {
+        setPageSize(newPageSize);
+        savePageSize(newPageSize);
+        setCurrentPageIndex(1); // Reset to first page when page size changes
+    };
+
+    return (
+        <SpaceBetween size="l">
+            {error && (
+                <Alert type="error" dismissible onDismiss={() => setError(null)}>
+                    {error}
+                </Alert>
+            )}
+            <Table
+                columnDefinitions={columnDefinitions}
+                items={paginatedItems}
+                loading={loading}
+                loadingText="Loading experiments"
+                selectionType="multi"
+                selectedItems={selectedItems}
+                onSelectionChange={({ detail }) => setSelectedItems(detail.selectedItems)}
+                sortingColumn={sortingColumn}
+                sortingDescending={sortingDescending}
+                onSortingChange={({ detail }) => handleSortingChange(detail)}
+                empty={
+                    <Box textAlign="center" color="inherit">
+                        <b>No experiments</b>
+                        <Box padding={{ bottom: "s" }} variant="p" color="inherit">
+                            No experiments to display.
+                        </Box>
+                        <Button onClick={() => navigate("/experiments/create")}>
+                            Create experiment
+                        </Button>
+                    </Box>
+                }
+                header={
+                    <Header
+                        variant="h2"
+                        counter={`(${experiments.length})`}
+                        actions={
+                            <SpaceBetween direction="horizontal" size="xs">
+                                <Button onClick={handleDelete} disabled={selectedItems.length === 0}>
+                                    Delete
+                                </Button>
+                                <Button variant="primary" onClick={() => navigate("/experiments/create")}>
+                                    Create Experiment
+                                </Button>
+                            </SpaceBetween>
+                        }
+                    >
+                        Experiments Generated
+                    </Header>
+                }
+                pagination={
+                    <Pagination
+                        currentPageIndex={currentPageIndex}
+                        onChange={({ detail }) => setCurrentPageIndex(detail.currentPageIndex)}
+                        pagesCount={Math.ceil(experiments.length / pageSize)}
+                    />
+                }
+                preferences={
+                    <CollectionPreferences
+                        title="Preferences"
+                        confirmLabel="Confirm"
+                        cancelLabel="Cancel"
+                        preferences={{
+                            pageSize: pageSize,
+                        }}
+                        pageSizePreference={{
+                            title: "Page size",
+                            options: [
+                                { value: 10, label: "10 experiments" },
+                                { value: 25, label: "25 experiments" },
+                                { value: 50, label: "50 experiments" },
+                                { value: 100, label: "100 experiments" },
+                                { value: 200, label: "200 experiments" },
+                            ],
+                        }}
+                        onConfirm={({ detail }) => {
+                            if (detail.pageSize !== undefined) {
+                                handlePageSizeChange(detail.pageSize);
+                            }
+                        }}
+                    />
+                }
+            />
+
+            {/* Show details when exactly one experiment is selected */}
+            {selectedItems.length === 1 && (
+                <DetailsTab experiment={selectedItems[0]} />
+            )}
+        </SpaceBetween>
+    );
+}

--- a/lib/user-interface/react-app/src/components/base-app-layout.tsx
+++ b/lib/user-interface/react-app/src/components/base-app-layout.tsx
@@ -22,12 +22,13 @@ interface BaseAppLayoutProps extends AppLayoutProps {
     info?: ReactElement;
     customDrawers?: AppLayoutPropsType.Drawer[];
     drawerAction?: DrawerActionConfig;
+    splitPanel?: ReactElement;
 }
 
 export default function BaseAppLayout(props: BaseAppLayoutProps) {
     const [navigationPanelState, setNavigationPanelState] = useNavigationPanelState();
     const [activeDrawerId, setActiveDrawerId] = useState<string | null>(null);
-    const { customDrawers, drawerAction, info, ...appLayoutProps } = props;
+    const { customDrawers, drawerAction, info, splitPanel, ...appLayoutProps } = props;
 
     // Build drawers array - combine action drawer, info drawer, and custom drawers
     const allDrawers: AppLayoutPropsType.Drawer[] = [];
@@ -88,6 +89,7 @@ export default function BaseAppLayout(props: BaseAppLayoutProps) {
             drawers={allDrawers.length > 0 ? allDrawers : undefined}
             activeDrawerId={activeDrawerId}
             onDrawerChange={handleDrawerChange}
+            splitPanel={splitPanel}
             {...appLayoutProps}
         />
     );

--- a/lib/user-interface/react-app/src/components/navigation-panel.tsx
+++ b/lib/user-interface/react-app/src/components/navigation-panel.tsx
@@ -38,6 +38,12 @@ export default function NavigationPanel() {
                 href: "/evaluations",
                 info: <Icon name="check" />,
             },
+            {
+                type: "link",
+                text: "Experiments Generator",
+                href: "/experiments",
+                info: <Icon name="status-positive" />,
+            },
         ];
 
         // Only add Document Manager and Knowledge Base Manager if knowledge base is supported

--- a/lib/user-interface/react-app/src/graphql/mutations.ts
+++ b/lib/user-interface/react-app/src/graphql/mutations.ts
@@ -377,3 +377,75 @@ export const publishEvaluationUpdate = /* GraphQL */ `mutation PublishEvaluation
   APITypes.PublishEvaluationUpdateMutationVariables,
   APITypes.PublishEvaluationUpdateMutation
 >;
+export const createExperiment = /* GraphQL */ `mutation CreateExperiment(
+  $name: String!
+  $description: String
+  $s3Path: String
+  $generationConfig: String
+  $modelId: String!
+) {
+  createExperiment(
+    name: $name
+    description: $description
+    s3Path: $s3Path
+    generationConfig: $generationConfig
+    modelId: $modelId
+  )
+}
+` as GeneratedMutation<
+  APITypes.CreateExperimentMutationVariables,
+  APITypes.CreateExperimentMutation
+>;
+export const updateExperiment = /* GraphQL */ `mutation UpdateExperiment(
+  $experimentId: String!
+  $name: String
+  $description: String
+  $status: ExperimentStatus
+) {
+  updateExperiment(
+    experimentId: $experimentId
+    name: $name
+    description: $description
+    status: $status
+  )
+}
+` as GeneratedMutation<
+  APITypes.UpdateExperimentMutationVariables,
+  APITypes.UpdateExperimentMutation
+>;
+export const deleteExperiment = /* GraphQL */ `mutation DeleteExperiment($experimentId: String!) {
+  deleteExperiment(experimentId: $experimentId) {
+    experimentId
+    deleted
+    __typename
+  }
+}
+` as GeneratedMutation<
+  APITypes.DeleteExperimentMutationVariables,
+  APITypes.DeleteExperimentMutation
+>;
+export const runExperiment = /* GraphQL */ `mutation RunExperiment($experimentId: String!) {
+  runExperiment(experimentId: $experimentId) {
+    experimentId
+    userId
+    name
+    description
+    createdAt
+    updatedAt
+    status
+    generatedCasesS3Url
+    taskDescription
+    context
+    numCases
+    numTopics
+    modelId
+    generatedCasesCount
+    errorMessage
+    batchJobId
+    __typename
+  }
+}
+` as GeneratedMutation<
+  APITypes.RunExperimentMutationVariables,
+  APITypes.RunExperimentMutation
+>;

--- a/lib/user-interface/react-app/src/graphql/mutations.ts
+++ b/lib/user-interface/react-app/src/graphql/mutations.ts
@@ -380,7 +380,7 @@ export const publishEvaluationUpdate = /* GraphQL */ `mutation PublishEvaluation
 export const createExperiment = /* GraphQL */ `mutation CreateExperiment(
   $name: String!
   $description: String
-  $generationConfig: String
+  $generationConfig: String!
   $modelId: String!
 ) {
   createExperiment(

--- a/lib/user-interface/react-app/src/graphql/mutations.ts
+++ b/lib/user-interface/react-app/src/graphql/mutations.ts
@@ -380,14 +380,12 @@ export const publishEvaluationUpdate = /* GraphQL */ `mutation PublishEvaluation
 export const createExperiment = /* GraphQL */ `mutation CreateExperiment(
   $name: String!
   $description: String
-  $s3Path: String
   $generationConfig: String
   $modelId: String!
 ) {
   createExperiment(
     name: $name
     description: $description
-    s3Path: $s3Path
     generationConfig: $generationConfig
     modelId: $modelId
   )

--- a/lib/user-interface/react-app/src/graphql/queries.ts
+++ b/lib/user-interface/react-app/src/graphql/queries.ts
@@ -329,3 +329,60 @@ export const getEvaluator = /* GraphQL */ `query GetEvaluator($evaluatorId: ID!)
   APITypes.GetEvaluatorQueryVariables,
   APITypes.GetEvaluatorQuery
 >;
+export const listExperiments = /* GraphQL */ `query ListExperiments {
+  listExperiments {
+    experimentId
+    userId
+    name
+    description
+    createdAt
+    updatedAt
+    status
+    generatedCasesS3Url
+    taskDescription
+    context
+    numCases
+    numTopics
+    modelId
+    generatedCasesCount
+    errorMessage
+    batchJobId
+    __typename
+  }
+}
+` as GeneratedQuery<
+  APITypes.ListExperimentsQueryVariables,
+  APITypes.ListExperimentsQuery
+>;
+export const getExperiment = /* GraphQL */ `query GetExperiment($experimentId: String!) {
+  getExperiment(experimentId: $experimentId) {
+    experimentId
+    userId
+    name
+    description
+    createdAt
+    updatedAt
+    status
+    generatedCasesS3Url
+    taskDescription
+    context
+    numCases
+    numTopics
+    modelId
+    generatedCasesCount
+    errorMessage
+    batchJobId
+    __typename
+  }
+}
+` as GeneratedQuery<
+  APITypes.GetExperimentQueryVariables,
+  APITypes.GetExperimentQuery
+>;
+export const getExperimentPresignedUrl = /* GraphQL */ `query GetExperimentPresignedUrl($s3Uri: String!) {
+  getExperimentPresignedUrl(s3Uri: $s3Uri)
+}
+` as GeneratedQuery<
+  APITypes.GetExperimentPresignedUrlQueryVariables,
+  APITypes.GetExperimentPresignedUrlQuery
+>;

--- a/lib/user-interface/react-app/src/pages/admin/create-experiment.tsx
+++ b/lib/user-interface/react-app/src/pages/admin/create-experiment.tsx
@@ -1,0 +1,345 @@
+// -----------------------------------------------------------------------
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// -----------------------------------------------------------------------
+import {
+    Alert,
+    Box,
+    BreadcrumbGroup,
+    Button,
+    Container,
+    Form,
+    FormField,
+    Header,
+    Input,
+    RadioGroup,
+    Select,
+    SpaceBetween,
+    Textarea,
+} from "@cloudscape-design/components";
+import { generateClient } from "aws-amplify/api";
+import { useContext, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { CHATBOT_NAME } from "../../common/constants";
+import useOnFollow from "../../common/hooks/use-on-follow";
+import { AppContext } from "../../common/app-context";
+import BaseAppLayout from "../../components/base-app-layout";
+import * as mutations from "../../graphql/mutations";
+
+type DataSourceType = "s3" | "generate";
+
+export default function CreateExperimentPage() {
+    const appConfig = useContext(AppContext);
+    const [name, setName] = useState("");
+    const [description, setDescription] = useState("");
+
+    // Data source selection
+    const [dataSourceType, setDataSourceType] = useState<DataSourceType>("generate");
+
+    // S3 path field
+    const [s3Path, setS3Path] = useState("");
+
+    // Auto-generation fields
+    const [context, setContext] = useState("");
+    const [taskDescription, setTaskDescription] = useState("");
+    const [numCases, setNumCases] = useState("10");
+    const [numTopics, setNumTopics] = useState("3");
+    const [modelId, setModelId] = useState("");
+    const [modelOptions, setModelOptions] = useState<{ label: string; value: string }[]>([]);
+
+    useEffect(() => {
+        const experimentsConfig = appConfig?.experimentsConfig;
+        if (experimentsConfig?.supportedModels && appConfig) {
+            const models = Object.entries(experimentsConfig.supportedModels).map(([label, value]) => {
+                const modelValue = (value as string).replace(
+                    "[REGION-PREFIX]",
+                    appConfig.aws_project_region.split("-")[0],
+                );
+                return { label, value: modelValue };
+            });
+            setModelOptions(models);
+            if (models.length > 0) {
+                setModelId(models[0].value);
+            }
+        }
+    }, [appConfig]);
+
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const navigate = useNavigate();
+    const onFollow = useOnFollow();
+    const apiClient = generateClient();
+
+    const validateForm = (): boolean => {
+        if (!name) {
+            setError("Please provide experiment name");
+            return false;
+        }
+
+        if (!modelId) {
+            setError("Please provide a model ID");
+            return false;
+        }
+
+        if (dataSourceType === "s3") {
+            if (!s3Path) {
+                setError("Please provide an S3 path");
+                return false;
+            }
+            if (!s3Path.startsWith("s3://")) {
+                setError("S3 path must start with s3://");
+                return false;
+            }
+        } else if (dataSourceType === "generate") {
+            if (!context || !taskDescription) {
+                setError("Please provide context and task description for generation");
+                return false;
+            }
+            const cases = parseInt(numCases);
+            const topics = parseInt(numTopics);
+            if (isNaN(cases) || cases < 1 || cases > 100) {
+                setError("Number of cases must be between 1 and 100");
+                return false;
+            }
+            if (isNaN(topics) || topics < 1 || topics > 10) {
+                setError("Number of topics must be between 1 and 10");
+                return false;
+            }
+        }
+
+        return true;
+    };
+
+    const handleSubmit = async () => {
+        if (!validateForm()) {
+            return;
+        }
+
+        setLoading(true);
+        setError(null);
+
+        try {
+            const experimentData: any = {
+                name,
+                description,
+                modelId,
+            };
+
+            if (dataSourceType === "s3") {
+                experimentData.s3Path = s3Path;
+            } else if (dataSourceType === "generate") {
+                experimentData.generationConfig = JSON.stringify({
+                    context,
+                    taskDescription,
+                    numCases: parseInt(numCases),
+                    numTopics: parseInt(numTopics),
+                });
+            }
+
+            await apiClient.graphql({
+                query: mutations.createExperiment,
+                variables: experimentData,
+            });
+            navigate("/experiments");
+        } catch (err) {
+            console.error("Error creating experiment:", err);
+            setError("Failed to create experiment");
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <BaseAppLayout
+            contentType="form"
+            breadcrumbs={
+                <BreadcrumbGroup
+                    onFollow={onFollow}
+                    items={[
+                        {
+                            text: CHATBOT_NAME,
+                            href: "/",
+                        },
+                        {
+                            text: "Experiments",
+                            href: "/experiments",
+                        },
+                        {
+                            text: "Create",
+                            href: "/experiments/create",
+                        },
+                    ]}
+                />
+            }
+            content={
+                <Form
+                    actions={
+                        <SpaceBetween direction="horizontal" size="xs">
+                            <Button
+                                variant="link"
+                                onClick={() => navigate("/experiments")}
+                            >
+                                Cancel
+                            </Button>
+                            <Button
+                                variant="primary"
+                                loading={loading}
+                                onClick={handleSubmit}
+                            >
+                                Create and Run Experiment
+                            </Button>
+                        </SpaceBetween>
+                    }
+                    header={<Header variant="h1">Create Experiment</Header>}
+                >
+                    <SpaceBetween size="l">
+                        {error && (
+                            <Alert type="error" dismissible onDismiss={() => setError(null)}>
+                                {error}
+                            </Alert>
+                        )}
+
+                        <Container header={<Header variant="h2">Basic Information</Header>}>
+                            <SpaceBetween size="l">
+                                <FormField label="Name" description="A descriptive name for your experiment">
+                                    <Input
+                                        value={name}
+                                        onChange={({ detail }) => setName(detail.value)}
+                                        placeholder="Enter a name for this synthetic data generation run"
+                                    />
+                                </FormField>
+
+                                <FormField label="Description" description="Optional description">
+                                    <Textarea
+                                        value={description}
+                                        onChange={({ detail }) => setDescription(detail.value)}
+                                        placeholder="Briefly describe the purpose of this synthetic data generation"
+                                    />
+                                </FormField>
+                            </SpaceBetween>
+                        </Container>
+
+                        <Container header={<Header variant="h2">Test Data Source</Header>}>
+                            <SpaceBetween size="l">
+                                <FormField
+                                    label="Data Source Type"
+                                    description="Choose how to provide test cases"
+                                >
+                                    <RadioGroup
+                                        value={dataSourceType}
+                                        onChange={({ detail }) => setDataSourceType(detail.value as DataSourceType)}
+                                        items={[
+                                            {
+                                                value: "s3",
+                                                label: "S3 Path",
+                                                description: "Load test cases from an S3 bucket",
+                                            },
+                                            {
+                                                value: "generate",
+                                                label: "Auto-Generate",
+                                                description: "Generate test cases using Strands Experiments",
+                                            },
+                                        ]}
+                                    />
+                                </FormField>
+
+                                {dataSourceType === "s3" && (
+                                    <FormField
+                                        label="S3 Path"
+                                        description="S3 URI to the experiment JSON file"
+                                    >
+                                        <Input
+                                            value={s3Path}
+                                            onChange={({ detail }) => setS3Path(detail.value)}
+                                            placeholder="s3://your-bucket/path/to/test-cases.json"
+                                        />
+                                    </FormField>
+                                )}
+
+                                {dataSourceType === "generate" && (
+                                    <>
+                                        <FormField
+                                            label="Context"
+                                            description="Describe your agent system, tools, and capabilities"
+                                        >
+                                            <Textarea
+                                                value={context}
+                                                onChange={({ detail }) => setContext(detail.value)}
+                                                placeholder="Describe your agent system, its tools, and capabilities to guide synthetic data generation"
+                                                rows={6}
+                                            />
+                                        </FormField>
+
+                                        <FormField
+                                            label="Task Description"
+                                            description="What tasks should the test cases cover?"
+                                        >
+                                            <Textarea
+                                                value={taskDescription}
+                                                onChange={({ detail }) => setTaskDescription(detail.value)}
+                                                placeholder="Describe the types of tasks the synthetic test cases should cover"
+                                                rows={3}
+                                            />
+                                        </FormField>
+
+                                        <FormField
+                                            label="Number of Test Cases"
+                                            description="How many test cases to generate (1-100)"
+                                        >
+                                            <Input
+                                                value={numCases}
+                                                onChange={({ detail }) => setNumCases(detail.value)}
+                                                type="number"
+                                                inputMode="numeric"
+                                            />
+                                        </FormField>
+
+                                        <FormField
+                                            label="Number of Topics"
+                                            description="How many different topic categories (1-10)"
+                                        >
+                                            <Input
+                                                value={numTopics}
+                                                onChange={({ detail }) => setNumTopics(detail.value)}
+                                                type="number"
+                                                inputMode="numeric"
+                                            />
+                                        </FormField>
+                                    </>
+                                )}
+                            </SpaceBetween>
+                        </Container>
+
+                        <Container header={<Header variant="h2">Model</Header>}>
+                            <FormField
+                                label="Model ID"
+                                description="Bedrock model ID to use for generation"
+                                errorText={modelId === "" ? "Model is required" : ""}
+                            >
+                                <Select
+                                    selectedOption={modelOptions.find(opt => opt.value === modelId) || null}
+                                    onChange={({ detail }) =>
+                                        setModelId(detail.selectedOption?.value || modelId)
+                                    }
+                                    options={modelOptions}
+                                    placeholder="Select a model..."
+                                />
+                            </FormField>
+                        </Container>
+
+                        <Box>
+                            <Alert type="info">
+                                <strong>Note:</strong> {
+                                    dataSourceType === "s3" ? "The S3 file should contain a valid experiment JSON with test cases" :
+                                    "The experiment will automatically run after creation to generate synthetic test cases using AI"
+                                }
+                            </Alert>
+                        </Box>
+                    </SpaceBetween>
+                </Form>
+            }
+        />
+    );
+}

--- a/lib/user-interface/react-app/src/pages/admin/create-experiment.tsx
+++ b/lib/user-interface/react-app/src/pages/admin/create-experiment.tsx
@@ -14,7 +14,6 @@ import {
     FormField,
     Header,
     Input,
-    RadioGroup,
     Select,
     SpaceBetween,
     Textarea,
@@ -28,18 +27,10 @@ import { AppContext } from "../../common/app-context";
 import BaseAppLayout from "../../components/base-app-layout";
 import * as mutations from "../../graphql/mutations";
 
-type DataSourceType = "s3" | "generate";
-
 export default function CreateExperimentPage() {
     const appConfig = useContext(AppContext);
     const [name, setName] = useState("");
     const [description, setDescription] = useState("");
-
-    // Data source selection
-    const [dataSourceType, setDataSourceType] = useState<DataSourceType>("generate");
-
-    // S3 path field
-    const [s3Path, setS3Path] = useState("");
 
     // Auto-generation fields
     const [context, setContext] = useState("");
@@ -83,30 +74,19 @@ export default function CreateExperimentPage() {
             return false;
         }
 
-        if (dataSourceType === "s3") {
-            if (!s3Path) {
-                setError("Please provide an S3 path");
-                return false;
-            }
-            if (!s3Path.startsWith("s3://")) {
-                setError("S3 path must start with s3://");
-                return false;
-            }
-        } else if (dataSourceType === "generate") {
-            if (!context || !taskDescription) {
-                setError("Please provide context and task description for generation");
-                return false;
-            }
-            const cases = parseInt(numCases);
-            const topics = parseInt(numTopics);
-            if (isNaN(cases) || cases < 1 || cases > 100) {
-                setError("Number of cases must be between 1 and 100");
-                return false;
-            }
-            if (isNaN(topics) || topics < 1 || topics > 10) {
-                setError("Number of topics must be between 1 and 10");
-                return false;
-            }
+        if (!context || !taskDescription) {
+            setError("Please provide context and task description for generation");
+            return false;
+        }
+        const cases = parseInt(numCases);
+        const topics = parseInt(numTopics);
+        if (isNaN(cases) || cases < 1 || cases > 100) {
+            setError("Number of cases must be between 1 and 100");
+            return false;
+        }
+        if (isNaN(topics) || topics < 1 || topics > 10) {
+            setError("Number of topics must be between 1 and 10");
+            return false;
         }
 
         return true;
@@ -125,18 +105,13 @@ export default function CreateExperimentPage() {
                 name,
                 description,
                 modelId,
-            };
-
-            if (dataSourceType === "s3") {
-                experimentData.s3Path = s3Path;
-            } else if (dataSourceType === "generate") {
-                experimentData.generationConfig = JSON.stringify({
+                generationConfig: JSON.stringify({
                     context,
                     taskDescription,
                     numCases: parseInt(numCases),
                     numTopics: parseInt(numTopics),
-                });
-            }
+                }),
+            };
 
             await apiClient.graphql({
                 query: mutations.createExperiment,
@@ -221,94 +196,55 @@ export default function CreateExperimentPage() {
                             </SpaceBetween>
                         </Container>
 
-                        <Container header={<Header variant="h2">Test Data Source</Header>}>
+                        <Container header={<Header variant="h2">Test Data</Header>}>
                             <SpaceBetween size="l">
                                 <FormField
-                                    label="Data Source Type"
-                                    description="Choose how to provide test cases"
+                                    label="Context"
+                                    description="Describe your agent system, tools, and capabilities"
                                 >
-                                    <RadioGroup
-                                        value={dataSourceType}
-                                        onChange={({ detail }) => setDataSourceType(detail.value as DataSourceType)}
-                                        items={[
-                                            {
-                                                value: "s3",
-                                                label: "S3 Path",
-                                                description: "Load test cases from an S3 bucket",
-                                            },
-                                            {
-                                                value: "generate",
-                                                label: "Auto-Generate",
-                                                description: "Generate test cases using Strands Experiments",
-                                            },
-                                        ]}
+                                    <Textarea
+                                        value={context}
+                                        onChange={({ detail }) => setContext(detail.value)}
+                                        placeholder="Describe your agent system, its tools, and capabilities to guide synthetic data generation"
+                                        rows={6}
                                     />
                                 </FormField>
 
-                                {dataSourceType === "s3" && (
-                                    <FormField
-                                        label="S3 Path"
-                                        description="S3 URI to the experiment JSON file"
-                                    >
-                                        <Input
-                                            value={s3Path}
-                                            onChange={({ detail }) => setS3Path(detail.value)}
-                                            placeholder="s3://your-bucket/path/to/test-cases.json"
-                                        />
-                                    </FormField>
-                                )}
+                                <FormField
+                                    label="Task Description"
+                                    description="What tasks should the test cases cover?"
+                                >
+                                    <Textarea
+                                        value={taskDescription}
+                                        onChange={({ detail }) => setTaskDescription(detail.value)}
+                                        placeholder="Describe the types of tasks the synthetic test cases should cover"
+                                        rows={3}
+                                    />
+                                </FormField>
 
-                                {dataSourceType === "generate" && (
-                                    <>
-                                        <FormField
-                                            label="Context"
-                                            description="Describe your agent system, tools, and capabilities"
-                                        >
-                                            <Textarea
-                                                value={context}
-                                                onChange={({ detail }) => setContext(detail.value)}
-                                                placeholder="Describe your agent system, its tools, and capabilities to guide synthetic data generation"
-                                                rows={6}
-                                            />
-                                        </FormField>
+                                <FormField
+                                    label="Number of Test Cases"
+                                    description="How many test cases to generate (1-100)"
+                                >
+                                    <Input
+                                        value={numCases}
+                                        onChange={({ detail }) => setNumCases(detail.value)}
+                                        type="number"
+                                        inputMode="numeric"
+                                    />
+                                </FormField>
 
-                                        <FormField
-                                            label="Task Description"
-                                            description="What tasks should the test cases cover?"
-                                        >
-                                            <Textarea
-                                                value={taskDescription}
-                                                onChange={({ detail }) => setTaskDescription(detail.value)}
-                                                placeholder="Describe the types of tasks the synthetic test cases should cover"
-                                                rows={3}
-                                            />
-                                        </FormField>
-
-                                        <FormField
-                                            label="Number of Test Cases"
-                                            description="How many test cases to generate (1-100)"
-                                        >
-                                            <Input
-                                                value={numCases}
-                                                onChange={({ detail }) => setNumCases(detail.value)}
-                                                type="number"
-                                                inputMode="numeric"
-                                            />
-                                        </FormField>
-
-                                        <FormField
-                                            label="Number of Topics"
-                                            description="How many different topic categories (1-10)"
-                                        >
-                                            <Input
-                                                value={numTopics}
-                                                onChange={({ detail }) => setNumTopics(detail.value)}
-                                                type="number"
-                                                inputMode="numeric"
-                                            />
-                                        </FormField>
-                                    </>
-                                )}
+                                <FormField
+                                    label="Number of Topics"
+                                    description="How many different topic categories (1-10)"
+                                >
+                                    <Input
+                                        value={numTopics}
+                                        onChange={({ detail }) => setNumTopics(detail.value)}
+                                        type="number"
+                                        inputMode="numeric"
+                                    />
+                                </FormField>
                             </SpaceBetween>
                         </Container>
 
@@ -331,10 +267,7 @@ export default function CreateExperimentPage() {
 
                         <Box>
                             <Alert type="info">
-                                <strong>Note:</strong> {
-                                    dataSourceType === "s3" ? "The S3 file should contain a valid experiment JSON with test cases" :
-                                    "The experiment will automatically run after creation to generate synthetic test cases using AI"
-                                }
+                                The experiment will automatically run after creation to generate synthetic test cases using AI.
                             </Alert>
                         </Box>
                     </SpaceBetween>

--- a/lib/user-interface/react-app/src/pages/admin/create-experiment.tsx
+++ b/lib/user-interface/react-app/src/pages/admin/create-experiment.tsx
@@ -1,9 +1,5 @@
-// -----------------------------------------------------------------------
 // Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-//
-// SPDX-License-Identifier: Apache-2.0
-//
-// -----------------------------------------------------------------------
+// SPDX-License-Identifier: MIT-0
 import {
     Alert,
     Box,

--- a/lib/user-interface/react-app/src/pages/admin/experiments-manager.tsx
+++ b/lib/user-interface/react-app/src/pages/admin/experiments-manager.tsx
@@ -1,0 +1,70 @@
+// -----------------------------------------------------------------------
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// -----------------------------------------------------------------------
+import { BreadcrumbGroup, Header, HelpPanel, SpaceBetween } from "@cloudscape-design/components";
+import { useState } from "react";
+import { CHATBOT_NAME } from "../../common/constants";
+import useOnFollow from "../../common/hooks/use-on-follow";
+import ExperimentsManager from "../../components/admin/experiments-manager";
+import BaseAppLayout from "../../components/base-app-layout";
+
+export default function ExperimentsManagerPage() {
+    const [toolsOpen, setToolsOpen] = useState(false);
+    const onFollow = useOnFollow();
+
+    return (
+        <BaseAppLayout
+            contentType="table"
+            toolsOpen={toolsOpen}
+            onToolsChange={(e) => setToolsOpen(e.detail.open)}
+            breadcrumbs={
+                <BreadcrumbGroup
+                    onFollow={onFollow}
+                    items={[
+                        {
+                            text: CHATBOT_NAME,
+                            href: "/",
+                        },
+                        {
+                            text: "Experiments",
+                            href: "/experiments",
+                        },
+                    ]}
+                />
+            }
+            info={
+                <HelpPanel header={<Header variant="h3">Experiments Guide</Header>}>
+                    <SpaceBetween direction="vertical" size="l">
+                        <div>
+                            <h4>Overview</h4>
+                            <ul>
+                                <li>Create experiments to test your agent's performance</li>
+                                <li>Define test cases with expected outputs</li>
+                            </ul>
+                        </div>
+                        <div>
+                            <h4>Actions</h4>
+                            <ul>
+                                <li>Create new experiments with test cases</li>
+                                <li>Generate synthetic test cases from context</li>
+                                <li>Compare performance across runs</li>
+                            </ul>
+                        </div>
+                        <div>
+                            <h4>Tips</h4>
+                            <ul>
+                                <li>Start with a small set of test cases</li>
+                                <li>Review failed cases to improve your agent</li>
+                            </ul>
+                        </div>
+                    </SpaceBetween>
+                </HelpPanel>
+            }
+            toolsWidth={300}
+            content={<ExperimentsManager />}
+        />
+    );
+}

--- a/lib/user-interface/react-app/src/pages/admin/experiments-manager.tsx
+++ b/lib/user-interface/react-app/src/pages/admin/experiments-manager.tsx
@@ -1,9 +1,5 @@
-// -----------------------------------------------------------------------
 // Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-//
-// SPDX-License-Identifier: Apache-2.0
-//
-// -----------------------------------------------------------------------
+// SPDX-License-Identifier: MIT-0
 import { BreadcrumbGroup, Header, HelpPanel, SpaceBetween } from "@cloudscape-design/components";
 import { useState } from "react";
 import { CHATBOT_NAME } from "../../common/constants";


### PR DESCRIPTION
## Summary

Adds the Agent Experiments feature, which allows users to run batch experiments against deployed agents and evaluate their responses. 

## Changes

- New `ExperimentsBatch` CDK construct (`lib/experiments-batch/`) — provisions AWS Batch (Fargate/ARM64) with a Docker image that runs experiment jobs
- New `ExperimentOps` CDK construct (`lib/api/experiments-api.ts`) — AppSync resolvers + Lambda for CRUD and job submission
- Lambda resolver (`lib/api/functions/experiment-resolver/index.py`) — handles experiment lifecycle and Batch job dispatch
- Batch runner (`lib/experiments-batch/docker/batch_runner.py`) — executes the experiment, calls the agent, writes results to S3
- Frontend pages and components for creating and managing experiments

## Testing & Documentation

- Experiment creation, job submission, and result retrieval tested end-to-end
- Tested with all supported models
- Tested with the evaluation feature, confirmed that the generated test case works there


## Out of scope and next steps
- Terraform infrastructure for the experiments similar to - https://github.com/aws-samples/sample-agentic-chatbot-accelerator/pull/16
- Integrate the experiment generated cases s3 link as a picker directly in the evaluations page

## Relevant documents

- [AWS Batch Fargate docs](https://docs.aws.amazon.com/batch/latest/userguide/fargate.html)

