### PR TITLE
✨ Add graph agent wizard UI and view modal support

### DIFF
--- a/lib/user-interface/react-app/src/API.ts
+++ b/lib/user-interface/react-app/src/API.ts
@@ -40,6 +40,7 @@ export enum ResponseStatus {
 export enum ArchitectureType {
   SINGLE = "SINGLE",
   SWARM = "SWARM",
+  GRAPH = "GRAPH",
 }
 
 

--- a/lib/user-interface/react-app/src/components/admin/agent-core/view-version-modal.tsx
+++ b/lib/user-interface/react-app/src/components/admin/agent-core/view-version-modal.tsx
@@ -19,7 +19,7 @@ import { useContext, useEffect, useState } from "react";
 import { McpServer } from "../../../API";
 import { AppContext } from "../../../common/app-context";
 import { listAvailableMcpServers as listAvailableMcpServersQuery } from "../../../graphql/queries";
-import { AgentCoreRuntimeConfiguration, SwarmConfiguration } from "../../wizard/types";
+import { AgentCoreRuntimeConfiguration, GraphConfiguration, SwarmConfiguration } from "../../wizard/types";
 
 const apiClient = generateClient();
 
@@ -30,6 +30,15 @@ const isSwarmConfig = (config: any): config is SwarmConfiguration => {
         typeof config.entryAgent === "string"
     );
 };
+
+const isGraphConfig = (config: any): config is GraphConfiguration => {
+    return (
+        config &&
+        Array.isArray(config.nodes) &&
+        typeof config.entryPoint === "string"
+    );
+};
+
 
 interface VersionInfo {
     version: string;
@@ -365,6 +374,90 @@ export default function ViewVersionModal({
                             {agentConfig.conversationManager && (
                                 <FormField label="Conversation Manager">
                                     <Box padding="m">{agentConfig.conversationManager}</Box>
+                                </FormField>
+                            )}
+                        </SpaceBetween>
+                    ) : isGraphConfig(agentConfig) ? (
+                        <SpaceBetween direction="vertical" size="m">
+                            <FormField label="Entry Point">
+                                <Box padding="m">{agentConfig.entryPoint}</Box>
+                            </FormField>
+
+                            {agentConfig.nodes && agentConfig.nodes.length > 0 && (
+                                <FormField label="Graph Nodes">
+                                    <Table
+                                        items={agentConfig.nodes}
+                                        columnDefinitions={[
+                                            {
+                                                id: "id",
+                                                header: "Node ID",
+                                                cell: (item: any) => item.id,
+                                                isRowHeader: true,
+                                            },
+                                            {
+                                                id: "agentName",
+                                                header: "Agent",
+                                                cell: (item: any) => item.agentName,
+                                            },
+                                            {
+                                                id: "endpointName",
+                                                header: "Endpoint",
+                                                cell: (item: any) => item.endpointName || "DEFAULT",
+                                            },
+                                            {
+                                                id: "label",
+                                                header: "Label",
+                                                cell: (item: any) => item.label || "-",
+                                            },
+                                        ]}
+                                    />
+                                </FormField>
+                            )}
+
+                            {agentConfig.edges && agentConfig.edges.length > 0 && (
+                                <FormField label="Graph Edges">
+                                    <Table
+                                        items={agentConfig.edges}
+                                        columnDefinitions={[
+                                            {
+                                                id: "source",
+                                                header: "Source",
+                                                cell: (item: any) => item.source,
+                                                isRowHeader: true,
+                                            },
+                                            {
+                                                id: "target",
+                                                header: "Target",
+                                                cell: (item: any) => item.target,
+                                            },
+                                            {
+                                                id: "condition",
+                                                header: "Condition",
+                                                cell: (item: any) => item.condition || "Unconditional",
+                                            },
+                                        ]}
+                                    />
+                                </FormField>
+                            )}
+
+                            {agentConfig.orchestrator && (
+                                <FormField label="Orchestrator Settings">
+                                    <Box padding="m">
+                                        <ColumnLayout columns={3} variant="text-grid">
+                                            <div>
+                                                <Box variant="awsui-key-label">Max Iterations</Box>
+                                                <Box>{agentConfig.orchestrator.maxIterations ?? "N/A"}</Box>
+                                            </div>
+                                            <div>
+                                                <Box variant="awsui-key-label">Execution Timeout</Box>
+                                                <Box>{agentConfig.orchestrator.executionTimeoutSeconds ?? "N/A"}s</Box>
+                                            </div>
+                                            <div>
+                                                <Box variant="awsui-key-label">Node Timeout</Box>
+                                                <Box>{agentConfig.orchestrator.nodeTimeoutSeconds ?? "N/A"}s</Box>
+                                            </div>
+                                        </ColumnLayout>
+                                    </Box>
                                 </FormField>
                             )}
                         </SpaceBetween>

--- a/lib/user-interface/react-app/src/components/wizard/agent-core-runtime-wizard.tsx
+++ b/lib/user-interface/react-app/src/components/wizard/agent-core-runtime-wizard.tsx
@@ -30,11 +30,13 @@ import {
     listKnowledgeBases as listKnowledgeBasesQuery,
     listRuntimeAgents as listRuntimeAgentsQuery,
 } from "../../graphql/queries";
+import { getGraphAgentSteps, isGraphStepValid } from "./architectures/graph-agent-steps";
 import { getSingleAgentSteps, isSingleAgentStepValid } from "./architectures/single-agent-steps";
 import { getSwarmAgentSteps, isSwarmStepValid } from "./architectures/swarm-agent-steps";
 import {
     AgentCoreRuntimeConfiguration,
     ArchitectureType,
+    GraphConfiguration,
     SearchType,
     SwarmConfiguration,
 } from "./types";
@@ -87,6 +89,19 @@ export default function AgentCoreRuntimeCreatorWizard({
                 nodeTimeoutSeconds: 60,
             },
             conversationManager: "sliding_window",
+        },
+    );
+    const [graphConfig, setGraphConfig] = useState<GraphConfiguration>(
+        initialData?.graphConfig || {
+            nodes: [],
+            edges: [],
+            entryPoint: "",
+            stateSchema: {},
+            orchestrator: {
+                maxIterations: 50,
+                executionTimeoutSeconds: 300,
+                nodeTimeoutSeconds: 60,
+            },
         },
     );
 
@@ -471,6 +486,12 @@ export default function AgentCoreRuntimeCreatorWizard({
                                         description:
                                             "Multiple specialized agents that collaborate via handoffs",
                                     },
+                                    {
+                                        value: "GRAPH",
+                                        label: "Graph",
+                                        description:
+                                            "Compose existing agents into a stateful LangGraph workflow with directed edges and conditional routing",
+                                    },
                                 ]}
                             />
                         </FormField>
@@ -504,36 +525,46 @@ export default function AgentCoreRuntimeCreatorWizard({
                   addKnowledgeBase,
                   openConfigureModal,
               })
-            : getSwarmAgentSteps({
-                  config,
-                  setConfig,
-                  swarmConfig,
-                  setSwarmConfig,
-                  availableAgents,
-                  isCreating,
-                  architectureType,
-                  addAgentReference,
-                  removeAgentReference,
-                  updateAgentReferenceEndpoint,
-                  getSwarmAgentNames,
-              });
+            : architectureType === "GRAPH"
+              ? getGraphAgentSteps({
+                    config,
+                    setConfig,
+                    graphConfig,
+                    setGraphConfig,
+                    availableAgents,
+                    isCreating,
+                })
+              : getSwarmAgentSteps({
+                    config,
+                    setConfig,
+                    swarmConfig,
+                    setSwarmConfig,
+                    availableAgents,
+                    isCreating,
+                    architectureType,
+                    addAgentReference,
+                    removeAgentReference,
+                    updateAgentReferenceEndpoint,
+                    getSwarmAgentNames,
+                });
 
     const steps = isNewVersion
         ? [...architectureSpecificSteps]
         : [architectureStep, ...architectureSpecificSteps];
 
     const isStepValid = (stepIndex: number) => {
+        const getArchStepValidity = (archStepIndex: number) => {
+            if (architectureType === "SINGLE") return isSingleAgentStepValid(archStepIndex, config);
+            if (architectureType === "GRAPH") return isGraphStepValid(archStepIndex, config, graphConfig);
+            return isSwarmStepValid(archStepIndex, config, swarmConfig);
+        };
+
         if (!isNewVersion) {
             if (stepIndex === 0) return true; // Architecture type step
-            const archStepIndex = stepIndex - 1;
-            return architectureType === "SINGLE"
-                ? isSingleAgentStepValid(archStepIndex, config)
-                : isSwarmStepValid(archStepIndex, config, swarmConfig);
+            return getArchStepValidity(stepIndex - 1);
         }
         // New version: no architecture step offset
-        return architectureType === "SINGLE"
-            ? isSingleAgentStepValid(stepIndex, config)
-            : isSwarmStepValid(stepIndex, config, swarmConfig);
+        return getArchStepValidity(stepIndex);
     };
 
     // ----------------------------------------------------------------
@@ -559,6 +590,7 @@ export default function AgentCoreRuntimeCreatorWizard({
                     ...config,
                     architectureType,
                     ...(architectureType === "SWARM" ? { swarmConfig } : {}),
+                    ...(architectureType === "GRAPH" ? { graphConfig } : {}),
                 })
             }
             steps={steps.map((step) => ({

--- a/lib/user-interface/react-app/src/components/wizard/architectures/graph-agent-steps.tsx
+++ b/lib/user-interface/react-app/src/components/wizard/architectures/graph-agent-steps.tsx
@@ -1,0 +1,337 @@
+// ----------------------------------------------------------------------
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: MIT-0
+// ----------------------------------------------------------------------
+import {
+    Alert,
+    Box,
+    ColumnLayout,
+    Container,
+    FormField,
+    Header,
+    Input,
+    SpaceBetween,
+} from "@cloudscape-design/components";
+import { RuntimeSummary } from "../../../API";
+import { AgentCoreRuntimeConfiguration, GraphConfiguration } from "../types";
+import { STEP_MIN_HEIGHT } from "../wizard-utils";
+import GraphDesigner from "./graph-designer";
+
+export interface GraphAgentStepsProps {
+    config: AgentCoreRuntimeConfiguration;
+    setConfig: React.Dispatch<React.SetStateAction<AgentCoreRuntimeConfiguration>>;
+    graphConfig: GraphConfiguration;
+    setGraphConfig: React.Dispatch<React.SetStateAction<GraphConfiguration>>;
+    availableAgents: RuntimeSummary[];
+    isCreating: boolean;
+}
+
+export function getGraphAgentSteps({
+    config,
+    setConfig,
+    graphConfig,
+    setGraphConfig,
+    availableAgents,
+    isCreating,
+}: GraphAgentStepsProps) {
+    // Build a simple visual minimap of the graph for the review step
+    const renderMinimap = () => {
+        if (graphConfig.nodes.length === 0) {
+            return <Box color="text-status-inactive">No nodes to display.</Box>;
+        }
+
+        const nodeMap = new Map(
+            graphConfig.nodes.map((n) => [n.id, n.label || n.id]),
+        );
+
+        return (
+            <div
+                style={{
+                    padding: "16px",
+                    background: "#fafafa",
+                    borderRadius: "8px",
+                    border: "1px solid #eaeded",
+                    fontFamily: "monospace",
+                    fontSize: "13px",
+                    lineHeight: "1.8",
+                    overflow: "auto",
+                }}
+            >
+                <div style={{ marginBottom: "8px", fontWeight: "bold" }}>
+                    Entry: [{graphConfig.entryPoint}]
+                </div>
+                {graphConfig.edges.map((edge, i) => (
+                    <div key={i} style={{ paddingLeft: "8px" }}>
+                        [{nodeMap.get(edge.source) || edge.source}]
+                        {edge.condition ? " - - → " : " ———→ "}
+                        [{edge.target === "__end__"
+                            ? "END"
+                            : nodeMap.get(edge.target) || edge.target}]
+                        {edge.condition && (
+                            <span style={{ color: "#687078" }}>
+                                {" "}
+                                if: {edge.condition}
+                            </span>
+                        )}
+                    </div>
+                ))}
+                {graphConfig.edges.length === 0 && (
+                    <div style={{ color: "#687078" }}>No edges defined.</div>
+                )}
+            </div>
+        );
+    };
+
+    return [
+        // Step 1: Graph Design
+        {
+            title: "Graph Design",
+            content: (
+                <div style={{ minHeight: STEP_MIN_HEIGHT }}>
+                    <SpaceBetween direction="vertical" size="l">
+                        <Container
+                            header={<Header variant="h2">Agent Name</Header>}
+                        >
+                            <FormField
+                                label="Agent Name"
+                                description="Enter a unique name for your graph agent"
+                                errorText={
+                                    config.agentName.trim() === ""
+                                        ? "Agent name is required"
+                                        : !/^[a-zA-Z][a-zA-Z0-9_]{0,47}$/.test(
+                                                config.agentName,
+                                            )
+                                          ? "Agent name must start with a letter and contain only letters, numbers, and underscores (max 48 characters)"
+                                          : ""
+                                }
+                            >
+                                <Input
+                                    value={config.agentName}
+                                    onChange={({ detail }) =>
+                                        setConfig((prev) => ({
+                                            ...prev,
+                                            agentName: detail.value,
+                                        }))
+                                    }
+                                    placeholder="Enter agent name..."
+                                    invalid={config.agentName.trim() === ""}
+                                />
+                            </FormField>
+                        </Container>
+
+                        <GraphDesigner
+                            graphConfig={graphConfig}
+                            setGraphConfig={setGraphConfig}
+                            availableAgents={availableAgents}
+                            currentAgentName={config.agentName}
+                        />
+                    </SpaceBetween>
+                </div>
+            ),
+        },
+        // Step 2: Orchestrator Settings
+        {
+            title: "Orchestrator Settings",
+            content: (
+                <div style={{ minHeight: STEP_MIN_HEIGHT }}>
+                    <Container
+                        header={
+                            <Header variant="h2">Orchestrator Settings</Header>
+                        }
+                    >
+                        <SpaceBetween direction="vertical" size="l">
+                            <ColumnLayout columns={2} variant="text-grid">
+                                <FormField
+                                    label="Max Iterations"
+                                    description="Maximum total iterations (recursion limit)"
+                                >
+                                    <Input
+                                        type="number"
+                                        value={graphConfig.orchestrator.maxIterations.toString()}
+                                        onChange={({ detail }) =>
+                                            setGraphConfig((prev) => ({
+                                                ...prev,
+                                                orchestrator: {
+                                                    ...prev.orchestrator,
+                                                    maxIterations:
+                                                        parseInt(
+                                                            detail.value,
+                                                        ) || 50,
+                                                },
+                                            }))
+                                        }
+                                    />
+                                </FormField>
+                                <FormField
+                                    label="Execution Timeout (s)"
+                                    description="Total execution timeout in seconds"
+                                    errorText={
+                                        graphConfig.orchestrator
+                                            .executionTimeoutSeconds <= 0
+                                            ? "Must be greater than 0"
+                                            : ""
+                                    }
+                                >
+                                    <Input
+                                        type="number"
+                                        value={graphConfig.orchestrator.executionTimeoutSeconds.toString()}
+                                        onChange={({ detail }) =>
+                                            setGraphConfig((prev) => ({
+                                                ...prev,
+                                                orchestrator: {
+                                                    ...prev.orchestrator,
+                                                    executionTimeoutSeconds:
+                                                        parseFloat(
+                                                            detail.value,
+                                                        ) || 300,
+                                                },
+                                            }))
+                                        }
+                                    />
+                                </FormField>
+                                <FormField
+                                    label="Node Timeout (s)"
+                                    description="Per-node timeout in seconds"
+                                    errorText={
+                                        graphConfig.orchestrator
+                                            .nodeTimeoutSeconds >
+                                        graphConfig.orchestrator
+                                            .executionTimeoutSeconds
+                                            ? "Node timeout must not exceed execution timeout"
+                                            : graphConfig.orchestrator
+                                                    .nodeTimeoutSeconds <= 0
+                                              ? "Must be greater than 0"
+                                              : ""
+                                    }
+                                >
+                                    <Input
+                                        type="number"
+                                        value={graphConfig.orchestrator.nodeTimeoutSeconds.toString()}
+                                        onChange={({ detail }) =>
+                                            setGraphConfig((prev) => ({
+                                                ...prev,
+                                                orchestrator: {
+                                                    ...prev.orchestrator,
+                                                    nodeTimeoutSeconds:
+                                                        parseFloat(
+                                                            detail.value,
+                                                        ) || 60,
+                                                },
+                                            }))
+                                        }
+                                    />
+                                </FormField>
+                            </ColumnLayout>
+                        </SpaceBetween>
+                    </Container>
+                </div>
+            ),
+        },
+        // Step 3: Review
+        {
+            title: "Review",
+            content: (
+                <div style={{ minHeight: STEP_MIN_HEIGHT }}>
+                    <SpaceBetween direction="vertical" size="l">
+                        {!isCreating && (
+                            <Alert type="info" header="Configuration Summary">
+                                Review your graph agent configuration before
+                                creating.
+                            </Alert>
+                        )}
+
+                        <Container
+                            header={<Header variant="h2">Graph Minimap</Header>}
+                        >
+                            {renderMinimap()}
+                        </Container>
+
+                        <Container
+                            header={
+                                <Header variant="h2">
+                                    Configuration JSON
+                                </Header>
+                            }
+                        >
+                            <Box padding="m" variant="code">
+                                <pre
+                                    style={{
+                                        margin: 0,
+                                        overflow: "auto",
+                                        maxHeight: "400px",
+                                    }}
+                                >
+                                    {JSON.stringify(
+                                        {
+                                            agentName: config.agentName,
+                                            architectureType: "GRAPH",
+                                            graphConfig,
+                                        },
+                                        null,
+                                        2,
+                                    )}
+                                </pre>
+                            </Box>
+                        </Container>
+                    </SpaceBetween>
+                </div>
+            ),
+        },
+    ];
+}
+
+/** Validate a graph step */
+export function isGraphStepValid(
+    stepIndex: number,
+    config: AgentCoreRuntimeConfiguration,
+    graphConfig: GraphConfiguration,
+): boolean {
+    const agentNamePattern = /^[a-zA-Z][a-zA-Z0-9_]{0,47}$/;
+
+    // Step 0: Graph Design
+    if (stepIndex === 0) {
+        const hasAgentName =
+            config.agentName.trim() !== "" &&
+            agentNamePattern.test(config.agentName);
+        const hasNodes = graphConfig.nodes.length > 0;
+        const hasEntryPoint =
+            graphConfig.entryPoint.trim() !== "" &&
+            graphConfig.nodes.some((n) => n.id === graphConfig.entryPoint);
+        // All edge references must be valid
+        const nodeIds = new Set(graphConfig.nodes.map((n) => n.id));
+        nodeIds.add("__end__");
+        const edgesValid = graphConfig.edges.every(
+            (e) => nodeIds.has(e.source) && nodeIds.has(e.target),
+        );
+        // Non-terminal nodes must have outgoing edges
+        const nodesWithOutgoing = new Set(
+            graphConfig.edges.map((e) => e.source),
+        );
+        const allNodesHaveEdges = graphConfig.nodes.every((n) =>
+            nodesWithOutgoing.has(n.id),
+        );
+        return (
+            hasAgentName &&
+            hasNodes &&
+            hasEntryPoint &&
+            edgesValid &&
+            allNodesHaveEdges
+        );
+    }
+
+    // Step 1: Orchestrator Settings
+    if (stepIndex === 1) {
+        const { orchestrator } = graphConfig;
+        return (
+            orchestrator.maxIterations >= 1 &&
+            orchestrator.executionTimeoutSeconds > 0 &&
+            orchestrator.nodeTimeoutSeconds > 0 &&
+            orchestrator.nodeTimeoutSeconds <=
+                orchestrator.executionTimeoutSeconds
+        );
+    }
+
+    // Step 2: Review — always valid
+    return true;
+}

--- a/lib/user-interface/react-app/src/components/wizard/architectures/graph-designer.tsx
+++ b/lib/user-interface/react-app/src/components/wizard/architectures/graph-designer.tsx
@@ -1,0 +1,700 @@
+// ----------------------------------------------------------------------
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: MIT-0
+// ----------------------------------------------------------------------
+import React from "react";
+import {
+    Alert,
+    Box,
+    Button,
+    ColumnLayout,
+    Container,
+    FormField,
+    Header,
+    Input,
+    Select,
+    SpaceBetween,
+    Table,
+    Toggle,
+} from "@cloudscape-design/components";
+import { RuntimeSummary } from "../../../API";
+import {
+    GraphConfiguration,
+    GraphEdgeDefinition,
+    GraphNodeDefinition,
+} from "../types";
+
+interface GraphDesignerProps {
+    graphConfig: GraphConfiguration;
+    setGraphConfig: React.Dispatch<React.SetStateAction<GraphConfiguration>>;
+    availableAgents: RuntimeSummary[];
+    currentAgentName: string;
+}
+
+export default function GraphDesigner({
+    graphConfig,
+    setGraphConfig,
+    availableAgents,
+    currentAgentName,
+}: GraphDesignerProps) {
+    // Filter out the current agent being created to prevent self-referencing
+    const selectableAgents = availableAgents.filter(
+        (a) => a.agentName !== currentAgentName,
+    );
+
+    // ----------------------------------------------------------------
+    // Node management
+    // ----------------------------------------------------------------
+    const addNode = (agentName: string) => {
+        const agent = selectableAgents.find((a) => a.agentName === agentName);
+        if (!agent) return;
+
+        const existingCount = graphConfig.nodes.filter(
+            (n) => n.agentName === agentName,
+        ).length;
+        const nodeId = existingCount > 0
+            ? `${agentName}_${existingCount + 1}`
+            : agentName;
+
+        const newNode: GraphNodeDefinition = {
+            id: nodeId,
+            agentName,
+            endpointName: "DEFAULT",
+            label: nodeId,
+        };
+
+        setGraphConfig((prev) => ({
+            ...prev,
+            nodes: [...prev.nodes, newNode],
+        }));
+    };
+
+    const removeNode = (nodeId: string) => {
+        setGraphConfig((prev) => ({
+            ...prev,
+            nodes: prev.nodes.filter((n) => n.id !== nodeId),
+            edges: prev.edges.filter(
+                (e) => e.source !== nodeId && e.target !== nodeId,
+            ),
+            entryPoint: prev.entryPoint === nodeId ? "" : prev.entryPoint,
+        }));
+    };
+
+    const updateNodeEndpoint = (nodeId: string, endpointName: string) => {
+        setGraphConfig((prev) => ({
+            ...prev,
+            nodes: prev.nodes.map((n) =>
+                n.id === nodeId ? { ...n, endpointName } : n,
+            ),
+        }));
+    };
+
+    const updateNodeLabel = (nodeId: string, label: string) => {
+        setGraphConfig((prev) => ({
+            ...prev,
+            nodes: prev.nodes.map((n) =>
+                n.id === nodeId ? { ...n, label } : n,
+            ),
+        }));
+    };
+
+    // ----------------------------------------------------------------
+    // Edge management
+    // ----------------------------------------------------------------
+    const [newEdgeSource, setNewEdgeSource] = React.useState<string>("");
+    const [newEdgeTarget, setNewEdgeTarget] = React.useState<string>("");
+    const [newEdgeCondition, setNewEdgeCondition] = React.useState<string>("");
+    const [newEdgeIsConditional, setNewEdgeIsConditional] = React.useState(false);
+
+    const nodeIdOptions = graphConfig.nodes.map((n) => ({
+        label: n.label || n.id,
+        value: n.id,
+        description: n.agentName,
+    }));
+
+    const targetOptions = [
+        ...nodeIdOptions,
+        { label: "__end__", value: "__end__", description: "Terminal node" },
+    ];
+
+    const addEdge = () => {
+        if (!newEdgeSource || !newEdgeTarget) return;
+        // Prevent duplicate edges
+        const exists = graphConfig.edges.some(
+            (e) => e.source === newEdgeSource && e.target === newEdgeTarget,
+        );
+        if (exists) return;
+
+        const edge: GraphEdgeDefinition = {
+            source: newEdgeSource,
+            target: newEdgeTarget,
+            ...(newEdgeIsConditional && newEdgeCondition.trim()
+                ? { condition: newEdgeCondition.trim() }
+                : {}),
+        };
+
+        setGraphConfig((prev) => ({
+            ...prev,
+            edges: [...prev.edges, edge],
+        }));
+        setNewEdgeSource("");
+        setNewEdgeTarget("");
+        setNewEdgeCondition("");
+        setNewEdgeIsConditional(false);
+    };
+
+    const removeEdge = (index: number) => {
+        setGraphConfig((prev) => ({
+            ...prev,
+            edges: prev.edges.filter((_, i) => i !== index),
+        }));
+    };
+
+    // ----------------------------------------------------------------
+    // State schema management
+    // ----------------------------------------------------------------
+    const [newFieldName, setNewFieldName] = React.useState("");
+    const [newFieldType, setNewFieldType] = React.useState("str");
+
+    const stateSchemaEntries = Object.entries(graphConfig.stateSchema);
+
+    const addSchemaField = () => {
+        if (!newFieldName.trim()) return;
+        if (graphConfig.stateSchema[newFieldName.trim()] !== undefined) return;
+        setGraphConfig((prev) => ({
+            ...prev,
+            stateSchema: {
+                ...prev.stateSchema,
+                [newFieldName.trim()]: newFieldType,
+            },
+        }));
+        setNewFieldName("");
+        setNewFieldType("str");
+    };
+
+    const removeSchemaField = (fieldName: string) => {
+        setGraphConfig((prev) => {
+            const { [fieldName]: _, ...rest } = prev.stateSchema;
+            return { ...prev, stateSchema: rest };
+        });
+    };
+
+    // ----------------------------------------------------------------
+    // Validation helpers
+    // ----------------------------------------------------------------
+    const getValidationErrors = (): string[] => {
+        const errors: string[] = [];
+        if (graphConfig.nodes.length === 0) {
+            errors.push("At least one node is required.");
+        }
+        if (graphConfig.nodes.length > 0 && !graphConfig.entryPoint) {
+            errors.push(
+                "An entry point is required. Select one node as the graph entry point.",
+            );
+        }
+        if (
+            graphConfig.entryPoint &&
+            !graphConfig.nodes.some((n) => n.id === graphConfig.entryPoint)
+        ) {
+            errors.push(
+                `Entry point '${graphConfig.entryPoint}' does not match any node in the graph.`,
+            );
+        }
+        // Check non-terminal nodes have outgoing edges
+        const nodesWithOutgoing = new Set(graphConfig.edges.map((e) => e.source));
+        const terminalTargets = new Set(
+            graphConfig.edges
+                .filter((e) => e.target === "__end__")
+                .map((e) => e.source),
+        );
+        for (const node of graphConfig.nodes) {
+            if (!nodesWithOutgoing.has(node.id) && !terminalTargets.has(node.id)) {
+                errors.push(
+                    `Node '${node.id}' has no outgoing edges and is not terminal.`,
+                );
+            }
+        }
+        return errors;
+    };
+
+    // Detect unconditional cycles (warning, non-blocking)
+    const getWarnings = (): string[] => {
+        const warnings: string[] = [];
+        // Simple cycle detection on unconditional edges only
+        const unconditionalEdges = graphConfig.edges.filter((e) => !e.condition);
+        const adjacency: Record<string, string[]> = {};
+        for (const edge of unconditionalEdges) {
+            if (!adjacency[edge.source]) adjacency[edge.source] = [];
+            adjacency[edge.source].push(edge.target);
+        }
+        const visited = new Set<string>();
+        const inStack = new Set<string>();
+        const detectCycle = (nodeId: string): boolean => {
+            if (inStack.has(nodeId)) return true;
+            if (visited.has(nodeId)) return false;
+            visited.add(nodeId);
+            inStack.add(nodeId);
+            for (const neighbor of adjacency[nodeId] || []) {
+                if (neighbor !== "__end__" && detectCycle(neighbor)) return true;
+            }
+            inStack.delete(nodeId);
+            return false;
+        };
+        for (const nodeId of Object.keys(adjacency)) {
+            if (detectCycle(nodeId)) {
+                warnings.push(
+                    "Warning: Potential infinite loop detected. Consider adding a conditional edge to break the cycle.",
+                );
+                break;
+            }
+        }
+        return warnings;
+    };
+
+    const validationErrors = getValidationErrors();
+    const warnings = getWarnings();
+
+    // Helper to get endpoint options for an agent
+    const getEndpointOptions = (agentName: string) => {
+        const agent = availableAgents.find((a) => a.agentName === agentName);
+        const options: { label: string; value: string }[] = [];
+        if (agent?.qualifierToVersion) {
+            try {
+                const qtv = JSON.parse(agent.qualifierToVersion);
+                if (qtv && typeof qtv === "object") {
+                    options.push(
+                        ...Object.keys(qtv).map((key) => ({
+                            label: key,
+                            value: key,
+                        })),
+                    );
+                }
+            } catch {
+                // ignore parse errors
+            }
+        }
+        if (!options.some((o) => o.value === "DEFAULT")) {
+            options.unshift({ label: "DEFAULT", value: "DEFAULT" });
+        }
+        return options;
+    };
+
+    return (
+        <SpaceBetween direction="vertical" size="l">
+            {/* Nodes Section */}
+            <Container header={<Header variant="h2">Graph Nodes</Header>}>
+                <SpaceBetween direction="vertical" size="m">
+                    <FormField
+                        label="Add Node"
+                        description="Select an existing agent to add as a graph node"
+                    >
+                        <Select
+                            placeholder="Select an agent..."
+                            options={selectableAgents.map((a) => ({
+                                label: a.agentName,
+                                value: a.agentName,
+                                description: a.architectureType || undefined,
+                            }))}
+                            onChange={({ detail }) => {
+                                if (detail.selectedOption?.value) {
+                                    addNode(detail.selectedOption.value);
+                                }
+                            }}
+                            selectedOption={null}
+                            filteringType="auto"
+                        />
+                    </FormField>
+                    {graphConfig.nodes.length === 0 ? (
+                        <Alert type="info">
+                            No nodes added yet. Select an agent above to add a
+                            node.
+                        </Alert>
+                    ) : (
+                        <Table
+                            items={graphConfig.nodes}
+                            columnDefinitions={[
+                                {
+                                    id: "id",
+                                    header: "Node ID",
+                                    cell: (item) => item.id,
+                                    isRowHeader: true,
+                                },
+                                {
+                                    id: "label",
+                                    header: "Label",
+                                    cell: (item) => (
+                                        <Input
+                                            value={item.label || ""}
+                                            onChange={({ detail }) =>
+                                                updateNodeLabel(
+                                                    item.id,
+                                                    detail.value,
+                                                )
+                                            }
+                                            placeholder={item.id}
+                                        />
+                                    ),
+                                },
+                                {
+                                    id: "agentName",
+                                    header: "Agent",
+                                    cell: (item) => {
+                                        const agent = availableAgents.find(
+                                            (a) =>
+                                                a.agentName === item.agentName,
+                                        );
+                                        return (
+                                            <SpaceBetween
+                                                direction="horizontal"
+                                                size="xs"
+                                            >
+                                                <span>{item.agentName}</span>
+                                                {agent?.architectureType && (
+                                                    <Box
+                                                        color="text-status-info"
+                                                        fontSize="body-s"
+                                                    >
+                                                        (
+                                                        {
+                                                            agent.architectureType
+                                                        }
+                                                        )
+                                                    </Box>
+                                                )}
+                                            </SpaceBetween>
+                                        );
+                                    },
+                                },
+                                {
+                                    id: "endpoint",
+                                    header: "Endpoint",
+                                    cell: (item) => {
+                                        const options = getEndpointOptions(
+                                            item.agentName,
+                                        );
+                                        return (
+                                            <Select
+                                                expandToViewport
+                                                selectedOption={
+                                                    options.find(
+                                                        (o) =>
+                                                            o.value ===
+                                                            item.endpointName,
+                                                    ) || {
+                                                        label: item.endpointName,
+                                                        value: item.endpointName,
+                                                    }
+                                                }
+                                                onChange={({ detail }) =>
+                                                    updateNodeEndpoint(
+                                                        item.id,
+                                                        detail.selectedOption
+                                                            ?.value ||
+                                                            "DEFAULT",
+                                                    )
+                                                }
+                                                options={options}
+                                            />
+                                        );
+                                    },
+                                },
+                                {
+                                    id: "entryPoint",
+                                    header: "Entry Point",
+                                    cell: (item) => (
+                                        <Button
+                                            variant={
+                                                graphConfig.entryPoint ===
+                                                item.id
+                                                    ? "primary"
+                                                    : "normal"
+                                            }
+                                            onClick={() =>
+                                                setGraphConfig((prev) => ({
+                                                    ...prev,
+                                                    entryPoint: item.id,
+                                                }))
+                                            }
+                                        >
+                                            {graphConfig.entryPoint === item.id
+                                                ? "✓ Entry"
+                                                : "Set"}
+                                        </Button>
+                                    ),
+                                },
+                                {
+                                    id: "actions",
+                                    header: "Actions",
+                                    cell: (item) => (
+                                        <Button
+                                            variant="icon"
+                                            iconName="close"
+                                            onClick={() =>
+                                                removeNode(item.id)
+                                            }
+                                        />
+                                    ),
+                                },
+                            ]}
+                        />
+                    )}
+                </SpaceBetween>
+            </Container>
+
+            {/* Edges Section */}
+            <Container header={<Header variant="h2">Graph Edges</Header>}>
+                <SpaceBetween direction="vertical" size="m">
+                    <ColumnLayout columns={newEdgeIsConditional ? 4 : 3}>
+                        <FormField label="Source Node">
+                            <Select
+                                placeholder="Select source..."
+                                options={nodeIdOptions}
+                                selectedOption={
+                                    newEdgeSource
+                                        ? nodeIdOptions.find(
+                                              (o) =>
+                                                  o.value === newEdgeSource,
+                                          ) || null
+                                        : null
+                                }
+                                onChange={({ detail }) =>
+                                    setNewEdgeSource(
+                                        detail.selectedOption?.value || "",
+                                    )
+                                }
+                            />
+                        </FormField>
+                        <FormField label="Target Node">
+                            <Select
+                                placeholder="Select target..."
+                                options={targetOptions}
+                                selectedOption={
+                                    newEdgeTarget
+                                        ? targetOptions.find(
+                                              (o) =>
+                                                  o.value === newEdgeTarget,
+                                          ) || null
+                                        : null
+                                }
+                                onChange={({ detail }) =>
+                                    setNewEdgeTarget(
+                                        detail.selectedOption?.value || "",
+                                    )
+                                }
+                            />
+                        </FormField>
+                        {newEdgeIsConditional && (
+                            <FormField label="Condition Expression">
+                                <Input
+                                    value={newEdgeCondition}
+                                    onChange={({ detail }) =>
+                                        setNewEdgeCondition(detail.value)
+                                    }
+                                    placeholder="e.g. approved, rejected, done"
+                                />
+                            </FormField>
+                        )}
+                        <FormField label=" ">
+                            <SpaceBetween direction="horizontal" size="xs">
+                                <Toggle
+                                    checked={newEdgeIsConditional}
+                                    onChange={({ detail }) =>
+                                        setNewEdgeIsConditional(detail.checked)
+                                    }
+                                >
+                                    Conditional
+                                </Toggle>
+                                <Button
+                                    onClick={addEdge}
+                                    disabled={
+                                        !newEdgeSource || !newEdgeTarget
+                                    }
+                                >
+                                    Add Edge
+                                </Button>
+                            </SpaceBetween>
+                        </FormField>
+                    </ColumnLayout>
+                    {graphConfig.edges.length === 0 ? (
+                        <Alert type="info">
+                            No edges defined yet. Add edges to connect your
+                            nodes.
+                        </Alert>
+                    ) : (
+                        <Table
+                            items={graphConfig.edges.map((e, i) => ({
+                                ...e,
+                                _index: i,
+                            }))}
+                            columnDefinitions={[
+                                {
+                                    id: "source",
+                                    header: "Source",
+                                    cell: (item) => {
+                                        const node = graphConfig.nodes.find(
+                                            (n) => n.id === item.source,
+                                        );
+                                        return node?.label || item.source;
+                                    },
+                                    isRowHeader: true,
+                                },
+                                {
+                                    id: "arrow",
+                                    header: "",
+                                    cell: (item) =>
+                                        item.condition ? "- - →" : "———→",
+                                    width: 60,
+                                },
+                                {
+                                    id: "target",
+                                    header: "Target",
+                                    cell: (item) => {
+                                        if (item.target === "__end__")
+                                            return "__end__";
+                                        const node = graphConfig.nodes.find(
+                                            (n) => n.id === item.target,
+                                        );
+                                        return node?.label || item.target;
+                                    },
+                                },
+                                {
+                                    id: "condition",
+                                    header: "Condition",
+                                    cell: (item) =>
+                                        item.condition || (
+                                            <Box color="text-status-inactive">
+                                                Unconditional
+                                            </Box>
+                                        ),
+                                },
+                                {
+                                    id: "actions",
+                                    header: "Actions",
+                                    cell: (item) => (
+                                        <Button
+                                            variant="icon"
+                                            iconName="close"
+                                            onClick={() =>
+                                                removeEdge(item._index)
+                                            }
+                                        />
+                                    ),
+                                },
+                            ]}
+                        />
+                    )}
+                </SpaceBetween>
+            </Container>
+
+            {/* State Schema Section */}
+            <Container header={<Header variant="h2">State Schema</Header>}>
+                <SpaceBetween direction="vertical" size="m">
+                    <Box color="text-body-secondary">
+                        Define the shared state fields that flow through the
+                        graph and are accessible by all nodes.
+                    </Box>
+                    <ColumnLayout columns={3}>
+                        <FormField label="Field Name">
+                            <Input
+                                value={newFieldName}
+                                onChange={({ detail }) =>
+                                    setNewFieldName(detail.value)
+                                }
+                                placeholder="e.g. messages"
+                            />
+                        </FormField>
+                        <FormField label="Field Type">
+                            <Select
+                                selectedOption={{
+                                    label: newFieldType,
+                                    value: newFieldType,
+                                }}
+                                onChange={({ detail }) =>
+                                    setNewFieldType(
+                                        detail.selectedOption?.value || "str",
+                                    )
+                                }
+                                options={[
+                                    { label: "str", value: "str" },
+                                    { label: "int", value: "int" },
+                                    { label: "float", value: "float" },
+                                    { label: "bool", value: "bool" },
+                                    { label: "list", value: "list" },
+                                    { label: "dict", value: "dict" },
+                                ]}
+                            />
+                        </FormField>
+                        <FormField label=" ">
+                            <Button
+                                onClick={addSchemaField}
+                                disabled={!newFieldName.trim()}
+                            >
+                                Add Field
+                            </Button>
+                        </FormField>
+                    </ColumnLayout>
+                    {stateSchemaEntries.length === 0 ? (
+                        <Alert type="info">
+                            No state fields defined. The graph will use a
+                            default messages-only state.
+                        </Alert>
+                    ) : (
+                        <Table
+                            items={stateSchemaEntries.map(([name, type]) => ({
+                                name,
+                                type,
+                            }))}
+                            columnDefinitions={[
+                                {
+                                    id: "name",
+                                    header: "Field Name",
+                                    cell: (item) => item.name,
+                                    isRowHeader: true,
+                                },
+                                {
+                                    id: "type",
+                                    header: "Type",
+                                    cell: (item) => item.type,
+                                },
+                                {
+                                    id: "actions",
+                                    header: "Actions",
+                                    cell: (item) => (
+                                        <Button
+                                            variant="icon"
+                                            iconName="close"
+                                            onClick={() =>
+                                                removeSchemaField(item.name)
+                                            }
+                                        />
+                                    ),
+                                },
+                            ]}
+                        />
+                    )}
+                </SpaceBetween>
+            </Container>
+
+            {/* Validation Messages */}
+            {validationErrors.length > 0 && (
+                <Alert type="error" header="Validation Errors">
+                    <ul style={{ margin: 0, paddingLeft: "1.2em" }}>
+                        {validationErrors.map((err, i) => (
+                            <li key={i}>{err}</li>
+                        ))}
+                    </ul>
+                </Alert>
+            )}
+            {warnings.length > 0 && (
+                <Alert type="warning" header="Warnings">
+                    <ul style={{ margin: 0, paddingLeft: "1.2em" }}>
+                        {warnings.map((w, i) => (
+                            <li key={i}>{w}</li>
+                        ))}
+                    </ul>
+                </Alert>
+            )}
+        </SpaceBetween>
+    );
+}

--- a/lib/user-interface/react-app/src/pages/admin/agent-core-wizard-page.tsx
+++ b/lib/user-interface/react-app/src/pages/admin/agent-core-wizard-page.tsx
@@ -57,6 +57,11 @@ export default function AgentCoreWizardPage() {
                     (Array.isArray(rawConfig.agents) || Array.isArray(rawConfig.agentReferences)) &&
                     typeof rawConfig.entryAgent === "string";
 
+                const isGraph =
+                    rawConfig &&
+                    Array.isArray(rawConfig.nodes) &&
+                    typeof rawConfig.entryPoint === "string";
+
                 if (isSwarm) {
                     setInitialData({
                         agentName: fromAgentName,
@@ -67,6 +72,21 @@ export default function AgentCoreWizardPage() {
                         toolParameters: {},
                         mcpServers: [],
                         conversationManager: rawConfig.conversationManager || "sliding_window",
+                        modelInferenceParameters: {
+                            modelId: "",
+                            parameters: { temperature: 0.2, maxTokens: 3000 },
+                        },
+                    });
+                } else if (isGraph) {
+                    setInitialData({
+                        agentName: fromAgentName,
+                        architectureType: "GRAPH",
+                        graphConfig: rawConfig,
+                        instructions: "",
+                        tools: [],
+                        toolParameters: {},
+                        mcpServers: [],
+                        conversationManager: "sliding_window",
                         modelInferenceParameters: {
                             modelId: "",
                             parameters: { temperature: 0.2, maxTokens: 3000 },
@@ -95,11 +115,13 @@ export default function AgentCoreWizardPage() {
         setIsCreating(true);
         setError(null); // Clear previous errors
         try {
-            const { agentName, architectureType, swarmConfig, ...singleConfigValues } = config;
+            const { agentName, architectureType, swarmConfig, graphConfig, ...singleConfigValues } = config;
 
             let configValue: string;
             if (architectureType === "SWARM" && swarmConfig) {
                 configValue = JSON.stringify(swarmConfig);
+            } else if (architectureType === "GRAPH" && graphConfig) {
+                configValue = JSON.stringify(graphConfig);
             } else {
                 configValue = JSON.stringify(singleConfigValues);
             }


### PR DESCRIPTION
Add GRAPH architecture option to the agent creation wizard with a visual graph designer for composing existing agents into LangGraph workflows. Includes graph node/edge management, orchestrator settings, review step, and graph config view in the version modal.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
