### PR TITLE
♻️ Single-Agent Wizard Cleanup & Shared Components Extraction

### DIFF
--- a/bin/config.ts
+++ b/bin/config.ts
@@ -34,14 +34,7 @@ export function getConfig(): SystemConfig {
             "Nova 2 Lite": "[REGION-PREFIX].amazon.nova-2-lite-v1:0",
         },
 
-        toolRegistry: [
-            {
-                name: "invoke_subagent",
-                description:
-                    "Invoke a sub-agent to handle specialized tasks or domain-specific queries that require dedicated processing",
-                invokesSubAgent: true,
-            },
-        ],
+        toolRegistry: [],
 
         // See docs/src/expanding-ai-tools.md#Configuration for an example
         mcpServerRegistry: [],
@@ -62,9 +55,9 @@ export function getConfig(): SystemConfig {
         evaluatorConfig: {
             // Models available for LLM-based evaluations
             supportedModels: {
-            "Claude Haiku 4.5": "[REGION-PREFIX].anthropic.claude-haiku-4-5-20251001-v1:0",
-            "Claude Sonnet 4.5": "[REGION-PREFIX].anthropic.claude-sonnet-4-5-20250929-v1:0",
-            "Nova 2 Lite": "[REGION-PREFIX].amazon.nova-2-lite-v1:0",
+                "Claude Haiku 4.5": "[REGION-PREFIX].anthropic.claude-haiku-4-5-20251001-v1:0",
+                "Claude Sonnet 4.5": "[REGION-PREFIX].anthropic.claude-sonnet-4-5-20250929-v1:0",
+                "Nova 2 Lite": "[REGION-PREFIX].amazon.nova-2-lite-v1:0",
             },
             // Score threshold (0.0-1.0) above which a test case is considered passed
             passThreshold: 0.8,

--- a/iac-terraform/modules/agent_core/agentcore_runtime.tf
+++ b/iac-terraform/modules/agent_core/agentcore_runtime.tf
@@ -78,7 +78,8 @@ resource "aws_bedrockagentcore_agent_runtime" "default" {
 
   depends_on = [
     aws_iam_role_policy.execution,
-    aws_bedrockagentcore_memory.default
+    aws_bedrockagentcore_memory.default,
+    null_resource.build_agent_image
   ]
 }
 

--- a/lib/agent-core/shared/base_constants.py
+++ b/lib/agent-core/shared/base_constants.py
@@ -8,11 +8,10 @@
 
 # Prefixes for tool names
 RETRIEVE_FROM_KB_PREFIX = "retrieve_from_kb"
-INVOKE_SUBAGENT_PREFIX = "invoke_subagent"
 
 # Tool descriptions for common tools
 TOOL_DESCRIPTIONS = {
-    INVOKE_SUBAGENT_PREFIX: "Invoke a sub-agent to handle specialized tasks or domain-specific queries that require dedicated processing",
+    # INVOKE_SUBAGENT_PREFIX: "Invoke a sub-agent to handle specialized tasks or domain-specific queries that require dedicated processing",
 }
 
 # DynamoDB scan limit for registry loading

--- a/lib/agent-core/shared/base_registry.py
+++ b/lib/agent-core/shared/base_registry.py
@@ -16,19 +16,16 @@ from __future__ import annotations
 
 import asyncio
 import functools
-import json
 import os
-import uuid
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import boto3
 from botocore.exceptions import ClientError
-from strands import ToolContext, tool
+from strands import tool
 
 from .base_constants import (
     DYNAMODB_SCAN_LIMIT,
-    INVOKE_SUBAGENT_PREFIX,
     RETRIEVE_FROM_KB_PREFIX,
 )
 from .kb_types import RetrievalConfiguration
@@ -420,105 +417,6 @@ class RetrieverTool(AbstractToolObject):
             return results[:top_k]
 
 
-class InvokeSubAgentTool(AbstractToolObject):
-    """A tool for invoking sub-agents to process specialized tasks.
-
-    This class enables delegation of specific queries to specialized sub-agents hosted on Amazon Bedrock AgentCore.
-
-    Args:
-        agent_name (str): The name identifier of the sub-agent
-        agent_role (str): Description of the sub-agent's role and capabilities
-        qualifier (str, optional): Agent version qualifier. Defaults to "DEFAULT"
-    """
-
-    def __init__(
-        self,
-        agent_name: str,
-        agent_role: str,
-        qualifier: str = "DEFAULT",
-    ) -> None:
-        self._agent_name = agent_name
-        self._agent_runtime_arn = self._fetch_agent_runtime()
-        if self._agent_runtime_arn is None:
-            raise RuntimeError(f"Agent runtime not found for agent name: {agent_name}")
-        self._qualifier = qualifier
-
-        super().__init__(
-            description=agent_role,
-            name=f"{INVOKE_SUBAGENT_PREFIX}_{agent_name}",
-            context=True,
-        )
-
-    def _fetch_agent_runtime(self) -> str | None:
-        """
-        Map agent name to runtime ARN.
-
-        Returns:
-            The agent runtime ID if found, None otherwise.
-        """
-        acc_client = get_agentcore_control_client()
-        next_token = None
-        agent_runtime_id = None
-        while True:
-            api_arguments = {"maxResults": 10}
-            if next_token:
-                api_arguments["nextToken"] = next_token
-            response = acc_client.list_agent_runtimes(**api_arguments)
-            next_token = response.get("nextToken")
-            for elem in response.get("agentRuntimes", []):
-                if elem["agentRuntimeName"] == self._agent_name:
-                    agent_runtime_id = elem["agentRuntimeId"]
-
-            if not next_token or agent_runtime_id:
-                break
-
-        return agent_runtime_id
-
-    def _tool_implementation(self, query: str, tool_context: ToolContext) -> str:
-        """Invokes a sub-agent to process the given query.
-
-        Args:
-            query (str): Stringified JSON that contains the payload specified in the tool description.
-            tool_context (ToolContext): Context containing user and session information.
-
-        Returns:
-            str: The response from the sub-agent, or an error message if the sub-agent fails.
-
-        Raises:
-            Exception: If the sub-agent encounters an error during processing.
-        """
-        ac_client = get_agentcore_client()
-        user_id = tool_context.invocation_state.get("userId", "default")
-        session_id = tool_context.invocation_state.get("sessionId", str(uuid.uuid4()))
-        session_id += f"-sa-{self._agent_name}"
-
-        try:
-            payload = json.dumps(
-                {
-                    "prompt": query,
-                    "userId": user_id,
-                }
-            ).encode()
-
-            response = ac_client.invoke_agent_runtime(
-                agentRuntimeArn=self._agent_runtime_arn,
-                runtimeSessionId=session_id,
-                runtimeUserId=user_id,
-                payload=payload,
-                qualifier=self._qualifier,
-                accountId=ACCOUNT_ID,
-            )
-            response_body = response["response"].read()
-            sub_agent_response = json.loads(response_body)
-        except ClientError as err:
-            sub_agent_response = (
-                f"Error in the sub-agent responsible for "
-                f"{self.get_tool_description()}: {str(err)}"
-            )
-
-        return sub_agent_response
-
-
 ## Tool Factory ##
 
 
@@ -557,32 +455,10 @@ class ToolFactory:
     #     """
     #     return get_weather_forecast
 
-    @staticmethod
-    def create_invoke_subagent_tool(
-        agentName: str, qualifier: str, role: str
-    ) -> Callable:
-        """Creates a tool instance for invoking a sub-agent.
-
-        Args:
-            agentName (str): Name of the sub-agent to invoke.
-            qualifier (int): The version of the Bedrock AgentCore Runtime endpoint.
-            role (str): Role assigned to the sub-agent, used for tool description
-
-        Returns:
-            Callable: A callable tool instance that can invoke the specified sub-agent.
-        """
-        tool_instance = InvokeSubAgentTool(
-            agent_name=agentName,
-            agent_role=role,
-            qualifier=qualifier,
-        )
-        return tool_instance.tool
-
 
 # Tool name to factory mapping
 TOOL_FACTORY_MAP = {
     # "get_weather_forecast": ToolFactory.create_get_weather_forecast,
-    "invoke_subagent": ToolFactory.create_invoke_subagent_tool,
 }
 
 

--- a/lib/shared/layers/python-sdk/genai_core/api_helper/types.py
+++ b/lib/shared/layers/python-sdk/genai_core/api_helper/types.py
@@ -543,6 +543,7 @@ class AgentsAsToolsConfiguration(BaseModel):
         toolParameters: Optional parameters for additional tools.
         mcpServers: Optional list of MCP server names.
         conversationManager: How to manage conversation history.
+        useMemory: Whether to create and attach AgentCore Memory to the runtime.
     """
 
     agentsAsTools: list[AgentAsToolReference] = Field(..., min_length=1)
@@ -554,6 +555,7 @@ class AgentsAsToolsConfiguration(BaseModel):
     conversationManager: EConversationManagerType = (
         EConversationManagerType.SLIDING_WINDOW
     )
+    useMemory: bool = False
 
     @model_validator(mode="after")
     def validate_tool_parameters(self):

--- a/lib/user-interface/react-app/src/components/wizard/agent-core-runtime-wizard.tsx
+++ b/lib/user-interface/react-app/src/components/wizard/agent-core-runtime-wizard.tsx
@@ -424,7 +424,6 @@ export default function AgentCoreRuntimeCreatorWizard({
                   modelOptions,
                   availableTools,
                   availableMcpServers,
-                  availableAgents,
                   knowledgeBases,
                   knowledgeBaseIsSupported,
                   isCreating,

--- a/lib/user-interface/react-app/src/components/wizard/agent-core-runtime-wizard.tsx
+++ b/lib/user-interface/react-app/src/components/wizard/agent-core-runtime-wizard.tsx
@@ -244,73 +244,6 @@ export default function AgentCoreRuntimeCreatorWizard({
         }
     }, [appConfig, config.modelInferenceParameters.modelId]);
 
-    // ----------------------------------------------------------------
-    // Tool / KB / MCP / Sub-agent actions (used by single-agent steps)
-    // ----------------------------------------------------------------
-    const addTool = (toolName: string | undefined) => {
-        if (!toolName || toolName === "retrieve_from_kb" || config.tools.includes(toolName)) return;
-        setConfig((prev) => ({
-            ...prev,
-            tools: [...prev.tools, toolName],
-            toolParameters: { ...prev.toolParameters, [toolName]: {} },
-        }));
-    };
-
-    const removeTool = (toolName: string) => {
-        setConfig((prev) => {
-            const newToolParameters = { ...prev.toolParameters };
-            delete newToolParameters[toolName];
-            return {
-                ...prev,
-                tools: prev.tools.filter((t) => t !== toolName),
-                toolParameters: newToolParameters,
-            };
-        });
-    };
-
-    const addSubAgent = (agentName: string | undefined) => {
-        if (!agentName) return;
-        const toolName = `invoke_subagent_${agentName}`;
-        if (config.tools.includes(toolName)) return;
-        setConfig((prev) => ({
-            ...prev,
-            tools: [...prev.tools, toolName],
-            toolParameters: {
-                ...prev.toolParameters,
-                [toolName]: { agentName, qualifier: "DEFAULT", role: "" },
-            },
-        }));
-    };
-
-    const addMcpServer = (serverName: string | undefined) => {
-        if (!serverName || config.mcpServers.includes(serverName)) return;
-        setConfig((prev) => ({ ...prev, mcpServers: [...prev.mcpServers, serverName] }));
-    };
-
-    const removeMcpServer = (serverName: string) => {
-        setConfig((prev) => ({
-            ...prev,
-            mcpServers: prev.mcpServers.filter((s) => s !== serverName),
-        }));
-    };
-
-    const addKnowledgeBase = (kbId: string | undefined) => {
-        if (!kbId) return;
-        const toolName = `retrieve_from_kb_${kbId}`;
-        if (config.tools.includes(toolName)) return;
-        setConfig((prev) => ({
-            ...prev,
-            tools: [...prev.tools, toolName],
-            toolParameters: {
-                ...prev.toolParameters,
-                [toolName]: {
-                    retrieval_cfg: { vectorSearchConfiguration: { numberOfResults: "5" } },
-                    kb_id: kbId,
-                },
-            },
-        }));
-    };
-
     const updateToolParameter = (toolName: string, paramPath: string, value: any) => {
         setConfig((prev) => {
             if (DANGEROUS_KEYS.has(toolName)) {
@@ -405,13 +338,9 @@ export default function AgentCoreRuntimeCreatorWizard({
     };
 
     // ----------------------------------------------------------------
-    // Derived data for single-agent steps
+    // Derived data shared across architectures
     // ----------------------------------------------------------------
     const knowledgeBaseIsSupported = appConfig?.knowledgeBaseIsSupported ?? false;
-
-    const availableKnowledgeBases = knowledgeBases
-        .filter((kb) => !config.tools.some((tool) => tool === `retrieve_from_kb_${kb.id}`))
-        .map((kb) => ({ label: kb.description || kb.name, value: kb.id }));
 
     const availableToolsOptions = availableTools
         .filter((tool) => !tool.invokesSubAgent && !config.tools.includes(tool.name))
@@ -421,59 +350,13 @@ export default function AgentCoreRuntimeCreatorWizard({
             description: tool.description || undefined,
         }));
 
-    const availableSubAgents = availableAgents
-        .filter(
-            (agent) =>
-                agent.agentName !== config.agentName &&
-                !config.tools.includes(`invoke_subagent_${agent.agentName}`),
-        )
-        .map((agent) => ({ label: agent.agentName, value: agent.agentName }));
-
     const availableMcpServersOptions = availableMcpServers
         .filter((s) => !config.mcpServers.includes(s.name))
         .map((s) => ({ label: s.name, value: s.name, description: s.description || undefined }));
 
-    const selectedMcpServersData = config.mcpServers.map((serverName) => {
-        const serverInfo = availableMcpServers.find((s) => s.name === serverName);
-        return {
-            name: serverName,
-            description: serverInfo?.description || "No description available",
-            mcpUrl: serverInfo?.mcpUrl || "",
-        };
-    });
-
-    const selectedToolsData = config.tools
-        .filter((t) => !t.startsWith("retrieve_from_kb_") && !t.startsWith("invoke_subagent_"))
-        .map((toolName) => {
-            const toolInfo = availableTools.find((t) => t.name === toolName);
-            return {
-                name: toolName,
-                description: toolInfo?.description || "No description available",
-            };
-        });
-
-    const selectedSubAgentsData = config.tools
-        .filter((t) => t.startsWith("invoke_subagent_"))
-        .map((toolName) => ({
-            toolName,
-            agentName: toolName.replace("invoke_subagent_", ""),
-            params: config.toolParameters[toolName],
-        }));
-
-    const selectedKnowledgeBasesData = config.tools
-        .filter((t) => t.startsWith("retrieve_from_kb_"))
-        .map((toolName) => {
-            const kbId = toolName.replace("retrieve_from_kb_", "");
-            const kb = knowledgeBases.find((k) => k.id === kbId);
-            const params = config.toolParameters[toolName];
-            return {
-                toolName,
-                name: kb?.name || kbId,
-                description: kb?.description || "No description available",
-                numberOfResults:
-                    params?.retrieval_cfg?.vectorSearchConfiguration?.numberOfResults || "5",
-            };
-        });
+    const availableKnowledgeBases = knowledgeBases
+        .filter((kb) => !config.tools.some((tool) => tool === `retrieve_from_kb_${kb.id}`))
+        .map((kb) => ({ label: kb.description || kb.name, value: kb.id }));
 
     const currentKbParams = selectedKbForConfig ? config.toolParameters[selectedKbForConfig] : null;
     const currentToolParams = selectedToolForConfig
@@ -539,22 +422,12 @@ export default function AgentCoreRuntimeCreatorWizard({
                   config,
                   setConfig,
                   modelOptions,
-                  availableToolsOptions,
-                  availableSubAgents,
-                  availableMcpServersOptions,
-                  availableKnowledgeBases,
-                  selectedToolsData,
-                  selectedSubAgentsData,
-                  selectedMcpServersData,
-                  selectedKnowledgeBasesData,
+                  availableTools,
+                  availableMcpServers,
+                  availableAgents,
+                  knowledgeBases,
                   knowledgeBaseIsSupported,
                   isCreating,
-                  addTool,
-                  removeTool,
-                  addSubAgent,
-                  addMcpServer,
-                  removeMcpServer,
-                  addKnowledgeBase,
                   openConfigureModal,
               })
             : architectureType === "GRAPH"

--- a/lib/user-interface/react-app/src/components/wizard/architectures/agents-as-tools-steps.tsx
+++ b/lib/user-interface/react-app/src/components/wizard/architectures/agents-as-tools-steps.tsx
@@ -573,6 +573,7 @@ export function getAgentsAsToolsSteps({
                                     {JSON.stringify(
                                         {
                                             agentName: config.agentName,
+                                            ...(config.useMemory ? { useMemory: true } : {}),
                                             architectureType: "AGENTS_AS_TOOLS",
                                             agentsAsToolsConfig: buildPreviewConfig(),
                                         },

--- a/lib/user-interface/react-app/src/components/wizard/architectures/agents-as-tools-steps.tsx
+++ b/lib/user-interface/react-app/src/components/wizard/architectures/agents-as-tools-steps.tsx
@@ -7,7 +7,6 @@ import {
     Alert,
     Box,
     Button,
-    ColumnLayout,
     Container,
     FormField,
     Header,
@@ -23,7 +22,8 @@ import {
     AgentCoreRuntimeConfiguration,
     AgentsAsToolsConfiguration,
 } from "../types";
-import { CONVERSATION_MANAGER_OPTIONS, STEP_MIN_HEIGHT } from "../wizard-utils";
+import { AdditionalToolsSection, AgentConfigSection } from "../wizard-shared-components";
+import { STEP_MIN_HEIGHT } from "../wizard-utils";
 
 export interface AgentsAsToolsStepsProps {
     config: AgentCoreRuntimeConfiguration;
@@ -83,7 +83,6 @@ export function getAgentsAsToolsSteps({
     const addAgentAsTool = (agentName: string) => {
         const agent = availableAgents.find((a) => a.agentName === agentName);
         if (!agent) return;
-        // Prevent duplicates
         if (agentsAsToolsConfig.agentsAsTools.some((a) => a.runtimeId === agent.agentRuntimeId))
             return;
 
@@ -122,7 +121,6 @@ export function getAgentsAsToolsSteps({
         });
     };
 
-    /** Resolve runtimeId back to agentName for display */
     const getAgentNameByRuntimeId = (runtimeId: string): string => {
         const agent = availableAgents.find((a) => a.agentRuntimeId === runtimeId);
         return agent?.agentName || runtimeId;
@@ -189,7 +187,7 @@ export function getAgentsAsToolsSteps({
         }));
     };
 
-    // Derive filtered tool options (exclude already-selected tools and KB tools)
+    // Derive filtered options
     const orchestratorTools = agentsAsToolsConfig.tools || [];
     const filteredToolOptions = availableToolsOptions.filter(
         (t) => !orchestratorTools.includes(t.value),
@@ -204,7 +202,22 @@ export function getAgentsAsToolsSteps({
         (s) => !orchestratorMcpServers.includes(s.value),
     );
 
-    // Build the serialization preview (clean version matching backend expectations)
+    const hasCustomTools = availableToolsOptions.length > 0;
+    const hasMcpServers = availableMcpServersOptions.length > 0;
+
+    const selectedToolsData = orchestratorTools
+        .filter((t) => !t.startsWith("retrieve_from_kb_"))
+        .map((t) => ({ name: t }));
+
+    const selectedKnowledgeBasesData = orchestratorTools
+        .filter((t) => t.startsWith("retrieve_from_kb_"))
+        .map((toolName) => {
+            const kbId = toolName.replace("retrieve_from_kb_", "");
+            const kb = availableKnowledgeBases.find((k) => k.value === kbId);
+            return { toolName, name: kb?.label || kbId };
+        });
+
+    // Build the serialization preview
     const buildPreviewConfig = () => {
         const preview: Record<string, any> = {
             agentsAsTools: agentsAsToolsConfig.agentsAsTools,
@@ -416,245 +429,89 @@ export function getAgentsAsToolsSteps({
             content: (
                 <div style={{ minHeight: STEP_MIN_HEIGHT }}>
                     <SpaceBetween direction="vertical" size="l">
-                        <Container header={<Header variant="h2">Model &amp; Instructions</Header>}>
-                            <SpaceBetween direction="vertical" size="l">
-                                <ColumnLayout columns={2} variant="text-grid">
-                                    <FormField
-                                        label="Model"
-                                        description="Select the LLM model for the orchestrator"
-                                    >
-                                        <Select
-                                            placeholder="Select a model..."
-                                            options={modelOptions}
-                                            selectedOption={
-                                                modelOptions.find(
-                                                    (m) =>
-                                                        m.value ===
-                                                        agentsAsToolsConfig.modelInferenceParameters
-                                                            .modelId,
-                                                ) || null
-                                            }
-                                            onChange={({ detail }) =>
-                                                setAgentsAsToolsConfig((prev) => ({
-                                                    ...prev,
-                                                    modelInferenceParameters: {
-                                                        ...prev.modelInferenceParameters,
-                                                        modelId: detail.selectedOption?.value || "",
-                                                    },
-                                                }))
-                                            }
-                                            filteringType="auto"
-                                        />
-                                    </FormField>
-                                    <SpaceBetween direction="vertical" size="s">
-                                        <FormField
-                                            label="Temperature"
-                                            description="Controls randomness"
-                                        >
-                                            <Input
-                                                type="number"
-                                                value={agentsAsToolsConfig.modelInferenceParameters.parameters.temperature.toString()}
-                                                onChange={({ detail }) =>
-                                                    setAgentsAsToolsConfig((prev) => ({
-                                                        ...prev,
-                                                        modelInferenceParameters: {
-                                                            ...prev.modelInferenceParameters,
-                                                            parameters: {
-                                                                ...prev.modelInferenceParameters
-                                                                    .parameters,
-                                                                temperature:
-                                                                    parseFloat(detail.value) || 0.2,
-                                                            },
-                                                        },
-                                                    }))
-                                                }
-                                            />
-                                        </FormField>
-                                        <FormField
-                                            label="Max Tokens"
-                                            description="Maximum output tokens"
-                                        >
-                                            <Input
-                                                type="number"
-                                                value={agentsAsToolsConfig.modelInferenceParameters.parameters.maxTokens.toString()}
-                                                onChange={({ detail }) =>
-                                                    setAgentsAsToolsConfig((prev) => ({
-                                                        ...prev,
-                                                        modelInferenceParameters: {
-                                                            ...prev.modelInferenceParameters,
-                                                            parameters: {
-                                                                ...prev.modelInferenceParameters
-                                                                    .parameters,
-                                                                maxTokens:
-                                                                    parseInt(detail.value) || 3000,
-                                                            },
-                                                        },
-                                                    }))
-                                                }
-                                            />
-                                        </FormField>
-                                    </SpaceBetween>
-                                </ColumnLayout>
-
-                                <FormField
-                                    label="Orchestrator Instructions"
-                                    description="System prompt that defines how the orchestrator delegates to its sub-agent tools"
-                                >
-                                    <Textarea
-                                        value={agentsAsToolsConfig.instructions}
-                                        onChange={({ detail }) =>
-                                            setAgentsAsToolsConfig((prev) => ({
-                                                ...prev,
-                                                instructions: detail.value,
-                                            }))
-                                        }
-                                        placeholder="You are an orchestrator agent. You have access to the following sub-agents as tools..."
-                                        rows={6}
-                                    />
-                                </FormField>
-
-                                <FormField label="Conversation Manager">
-                                    <Select
-                                        selectedOption={
-                                            CONVERSATION_MANAGER_OPTIONS.find(
-                                                (opt) =>
-                                                    opt.value ===
-                                                    agentsAsToolsConfig.conversationManager,
-                                            ) || null
-                                        }
-                                        onChange={({ detail }) =>
-                                            setAgentsAsToolsConfig((prev) => ({
-                                                ...prev,
-                                                conversationManager: (detail.selectedOption
-                                                    ?.value || "sliding_window") as
-                                                    | "null"
-                                                    | "sliding_window"
-                                                    | "summarizing",
-                                            }))
-                                        }
-                                        options={CONVERSATION_MANAGER_OPTIONS}
-                                    />
-                                </FormField>
-                            </SpaceBetween>
-                        </Container>
-
-                        <Container
-                            header={
-                                <Header
-                                    variant="h2"
-                                    description="Optionally add tools, knowledge bases, and MCP servers available to the orchestrator (in addition to the sub-agent tools)"
-                                >
-                                    Additional Tools (Optional)
-                                </Header>
+                        <AgentConfigSection
+                            label="Orchestrator"
+                            modelOptions={modelOptions}
+                            modelId={agentsAsToolsConfig.modelInferenceParameters.modelId}
+                            onModelChange={(modelId) =>
+                                setAgentsAsToolsConfig((prev) => ({
+                                    ...prev,
+                                    modelInferenceParameters: {
+                                        ...prev.modelInferenceParameters,
+                                        modelId,
+                                    },
+                                }))
                             }
-                        >
-                            <SpaceBetween direction="vertical" size="m">
-                                <ColumnLayout columns={knowledgeBaseIsSupported ? 3 : 2}>
-                                    <FormField label="Add Tool">
-                                        <Select
-                                            placeholder="Select a tool..."
-                                            options={filteredToolOptions}
-                                            onChange={({ detail }) =>
-                                                addOrchestratorTool(detail.selectedOption?.value)
-                                            }
-                                            selectedOption={null}
-                                            filteringType="auto"
-                                        />
-                                    </FormField>
-                                    {knowledgeBaseIsSupported && (
-                                        <FormField label="Add Knowledge Base">
-                                            <Select
-                                                placeholder="Select a KB..."
-                                                options={filteredKbOptions}
-                                                onChange={({ detail }) =>
-                                                    addOrchestratorKnowledgeBase(
-                                                        detail.selectedOption?.value,
-                                                    )
-                                                }
-                                                selectedOption={null}
-                                                filteringType="auto"
-                                            />
-                                        </FormField>
-                                    )}
-                                    <FormField label="Add MCP Server">
-                                        <Select
-                                            placeholder="Select MCP server..."
-                                            options={filteredMcpOptions}
-                                            onChange={({ detail }) =>
-                                                addOrchestratorMcpServer(
-                                                    detail.selectedOption?.value,
-                                                )
-                                            }
-                                            selectedOption={null}
-                                            filteringType="auto"
-                                        />
-                                    </FormField>
-                                </ColumnLayout>
+                            temperature={
+                                agentsAsToolsConfig.modelInferenceParameters.parameters.temperature
+                            }
+                            onTemperatureChange={(temperature) =>
+                                setAgentsAsToolsConfig((prev) => ({
+                                    ...prev,
+                                    modelInferenceParameters: {
+                                        ...prev.modelInferenceParameters,
+                                        parameters: {
+                                            ...prev.modelInferenceParameters.parameters,
+                                            temperature,
+                                        },
+                                    },
+                                }))
+                            }
+                            maxTokens={
+                                agentsAsToolsConfig.modelInferenceParameters.parameters.maxTokens
+                            }
+                            onMaxTokensChange={(maxTokens) =>
+                                setAgentsAsToolsConfig((prev) => ({
+                                    ...prev,
+                                    modelInferenceParameters: {
+                                        ...prev.modelInferenceParameters,
+                                        parameters: {
+                                            ...prev.modelInferenceParameters.parameters,
+                                            maxTokens,
+                                        },
+                                    },
+                                }))
+                            }
+                            instructions={agentsAsToolsConfig.instructions}
+                            onInstructionsChange={(instructions) =>
+                                setAgentsAsToolsConfig((prev) => ({ ...prev, instructions }))
+                            }
+                            instructionsPlaceholder="You are an orchestrator agent. You have access to the following sub-agents as tools..."
+                            conversationManager={agentsAsToolsConfig.conversationManager}
+                            onConversationManagerChange={(conversationManager) =>
+                                setAgentsAsToolsConfig((prev) => ({
+                                    ...prev,
+                                    conversationManager,
+                                }))
+                            }
+                            useMemory={config.useMemory || false}
+                            onUseMemoryChange={(useMemory) =>
+                                setConfig((prev) => ({ ...prev, useMemory }))
+                            }
+                        />
 
-                                {orchestratorTools.length > 0 && (
-                                    <Table
-                                        items={orchestratorTools.map((t) => ({ name: t }))}
-                                        columnDefinitions={[
-                                            {
-                                                id: "name",
-                                                header: "Tool Name",
-                                                cell: (item) => item.name,
-                                                isRowHeader: true,
-                                            },
-                                            {
-                                                id: "actions",
-                                                header: "Actions",
-                                                cell: (item) => (
-                                                    <Button
-                                                        variant="icon"
-                                                        iconName="close"
-                                                        onClick={() =>
-                                                            removeOrchestratorTool(item.name)
-                                                        }
-                                                    />
-                                                ),
-                                            },
-                                        ]}
-                                    />
-                                )}
-
-                                {orchestratorMcpServers.length > 0 && (
-                                    <Table
-                                        items={orchestratorMcpServers.map((s) => ({ name: s }))}
-                                        columnDefinitions={[
-                                            {
-                                                id: "name",
-                                                header: "MCP Server",
-                                                cell: (item) => item.name,
-                                                isRowHeader: true,
-                                            },
-                                            {
-                                                id: "actions",
-                                                header: "Actions",
-                                                cell: (item) => (
-                                                    <Button
-                                                        variant="icon"
-                                                        iconName="close"
-                                                        onClick={() =>
-                                                            removeOrchestratorMcpServer(item.name)
-                                                        }
-                                                    />
-                                                ),
-                                            },
-                                        ]}
-                                    />
-                                )}
-
-                                {orchestratorTools.length === 0 &&
-                                    orchestratorMcpServers.length === 0 && (
-                                        <Alert type="info">
-                                            No additional tools or MCP servers configured. The
-                                            orchestrator will only use the sub-agent tools defined
-                                            in the previous step.
-                                        </Alert>
-                                    )}
-                            </SpaceBetween>
-                        </Container>
+                        {(hasCustomTools || hasMcpServers || knowledgeBaseIsSupported) && (
+                            <AdditionalToolsSection
+                                hasCustomTools={hasCustomTools}
+                                hasMcpServers={hasMcpServers}
+                                knowledgeBaseIsSupported={knowledgeBaseIsSupported}
+                                availableToolsOptions={filteredToolOptions}
+                                availableKnowledgeBasesOptions={filteredKbOptions}
+                                availableMcpServersOptions={filteredMcpOptions}
+                                selectedTools={selectedToolsData}
+                                selectedKnowledgeBases={selectedKnowledgeBasesData}
+                                selectedMcpServers={orchestratorMcpServers.map((s) => ({
+                                    name: s,
+                                }))}
+                                onAddTool={addOrchestratorTool}
+                                onRemoveTool={removeOrchestratorTool}
+                                onAddKnowledgeBase={addOrchestratorKnowledgeBase}
+                                onAddMcpServer={addOrchestratorMcpServer}
+                                onRemoveMcpServer={removeOrchestratorMcpServer}
+                                description="Optionally add tools, knowledge bases, and MCP servers available to the orchestrator (in addition to the sub-agent tools)"
+                                emptyMessage="No additional tools or MCP servers configured. The orchestrator will only use the sub-agent tools defined in the previous step."
+                            />
+                        )}
                     </SpaceBetween>
                 </div>
             ),

--- a/lib/user-interface/react-app/src/components/wizard/architectures/single-agent-steps.tsx
+++ b/lib/user-interface/react-app/src/components/wizard/architectures/single-agent-steps.tsx
@@ -20,7 +20,7 @@ import {
     Textarea,
 } from "@cloudscape-design/components";
 import ReactMarkdown from "react-markdown";
-import { KnowledgeBase, McpServer, RuntimeSummary, Tool } from "../../../API";
+import { KnowledgeBase, McpServer, Tool } from "../../../API";
 import { AgentCoreRuntimeConfiguration } from "../types";
 import { CONVERSATION_MANAGER_OPTIONS, STEP_MIN_HEIGHT } from "../wizard-utils";
 
@@ -30,7 +30,6 @@ interface SingleAgentStepsProps {
     modelOptions: { label: string; value: string }[];
     availableTools: Tool[];
     availableMcpServers: McpServer[];
-    availableAgents: RuntimeSummary[];
     knowledgeBases: KnowledgeBase[];
     knowledgeBaseIsSupported: boolean;
     isCreating: boolean;
@@ -43,14 +42,13 @@ export function getSingleAgentSteps({
     modelOptions,
     availableTools,
     availableMcpServers,
-    availableAgents,
     knowledgeBases,
     knowledgeBaseIsSupported,
     isCreating,
     openConfigureModal,
 }: SingleAgentStepsProps) {
     // -------------------------------------------------------------------
-    // Tool / KB / MCP / Sub-agent actions
+    // Tool / KB / MCP actions
     // -------------------------------------------------------------------
     const addTool = (toolName: string | undefined) => {
         if (!toolName || toolName === "retrieve_from_kb" || config.tools.includes(toolName)) return;
@@ -71,20 +69,6 @@ export function getSingleAgentSteps({
                 toolParameters: newToolParameters,
             };
         });
-    };
-
-    const addSubAgent = (agentName: string | undefined) => {
-        if (!agentName) return;
-        const toolName = `invoke_subagent_${agentName}`;
-        if (config.tools.includes(toolName)) return;
-        setConfig((prev) => ({
-            ...prev,
-            tools: [...prev.tools, toolName],
-            toolParameters: {
-                ...prev.toolParameters,
-                [toolName]: { agentName, qualifier: "DEFAULT", role: "" },
-            },
-        }));
     };
 
     const addMcpServer = (serverName: string | undefined) => {
@@ -127,14 +111,6 @@ export function getSingleAgentSteps({
             description: tool.description || undefined,
         }));
 
-    const availableSubAgentsOptions = availableAgents
-        .filter(
-            (agent) =>
-                agent.agentName !== config.agentName &&
-                !config.tools.includes(`invoke_subagent_${agent.agentName}`),
-        )
-        .map((agent) => ({ label: agent.agentName, value: agent.agentName }));
-
     const availableMcpServersOptions = availableMcpServers
         .filter((s) => !config.mcpServers.includes(s.name))
         .map((s) => ({ label: s.name, value: s.name, description: s.description || undefined }));
@@ -152,14 +128,6 @@ export function getSingleAgentSteps({
                 description: toolInfo?.description || "No description available",
             };
         });
-
-    const selectedSubAgentsData = config.tools
-        .filter((t) => t.startsWith("invoke_subagent_"))
-        .map((toolName) => ({
-            toolName,
-            agentName: toolName.replace("invoke_subagent_", ""),
-            params: config.toolParameters[toolName],
-        }));
 
     const selectedMcpServersData = config.mcpServers.map((serverName) => {
         const serverInfo = availableMcpServers.find((s) => s.name === serverName);
@@ -397,27 +365,6 @@ export function getSingleAgentSteps({
                                 />
                             </FormField>
 
-                            <FormField
-                                label="Available Sub-Agents"
-                                description="Sub-agents that this orchestrator can invoke as tools"
-                            >
-                                <Select
-                                    placeholder={
-                                        availableSubAgentsOptions.length === 0
-                                            ? "No additional sub-agents available"
-                                            : "Select a sub-agent to add as a tool"
-                                    }
-                                    options={availableSubAgentsOptions}
-                                    disabled={availableSubAgentsOptions.length === 0}
-                                    onChange={({ detail }) => {
-                                        if (detail.selectedOption) {
-                                            addSubAgent(detail.selectedOption.value);
-                                        }
-                                    }}
-                                    selectedOption={null}
-                                />
-                            </FormField>
-
                             <Container header={<Header variant="h3">Selected Tools</Header>}>
                                 {selectedToolsData.length === 0 ? (
                                     <Alert type="info">No tools selected</Alert>
@@ -473,69 +420,6 @@ export function getSingleAgentSteps({
                                                     color="inherit"
                                                 >
                                                     Select tools from the dropdown above.
-                                                </Box>
-                                            </Box>
-                                        }
-                                    />
-                                )}
-                            </Container>
-
-                            <Container
-                                header={<Header variant="h3">Selected Sub-Agents (Tools)</Header>}
-                            >
-                                {selectedSubAgentsData.length === 0 ? (
-                                    <Alert type="info">No sub-agents selected</Alert>
-                                ) : (
-                                    <Table
-                                        columnDefinitions={[
-                                            {
-                                                id: "name",
-                                                header: "Agent Name",
-                                                cell: (item) => item.agentName,
-                                            },
-                                            {
-                                                id: "parameters",
-                                                header: "Parameters",
-                                                cell: (item) => {
-                                                    const isConfigured =
-                                                        item.params?.qualifier && item.params?.role;
-                                                    return (
-                                                        <Button
-                                                            variant="normal"
-                                                            onClick={() =>
-                                                                openConfigureModal(item.toolName)
-                                                            }
-                                                        >
-                                                            {isConfigured
-                                                                ? "Configured"
-                                                                : "Configure"}
-                                                        </Button>
-                                                    );
-                                                },
-                                            },
-                                            {
-                                                id: "actions",
-                                                header: "Actions",
-                                                cell: (item) => (
-                                                    <Button
-                                                        variant="icon"
-                                                        iconName="close"
-                                                        onClick={() => removeTool(item.toolName)}
-                                                    />
-                                                ),
-                                            },
-                                        ]}
-                                        items={selectedSubAgentsData}
-                                        loadingText="Loading sub-agents"
-                                        empty={
-                                            <Box textAlign="center" color="inherit">
-                                                <b>No sub-agents selected</b>
-                                                <Box
-                                                    padding={{ bottom: "s" }}
-                                                    variant="p"
-                                                    color="inherit"
-                                                >
-                                                    Select sub-agents from the dropdown above.
                                                 </Box>
                                             </Box>
                                         }
@@ -791,12 +675,6 @@ export function isSingleAgentStepValid(
             config.agentName.trim() !== "" &&
             agentNamePattern.test(config.agentName)
         );
-    }
-    // Step 3 = Tools Config
-    if (stepIndex === 3) {
-        return !config.tools.some((tool) => {
-            return tool.startsWith("invoke_subagent_") && !config.toolParameters[tool]?.agentName;
-        });
     }
     return true;
 }

--- a/lib/user-interface/react-app/src/components/wizard/architectures/single-agent-steps.tsx
+++ b/lib/user-interface/react-app/src/components/wizard/architectures/single-agent-steps.tsx
@@ -20,6 +20,7 @@ import {
     Textarea,
 } from "@cloudscape-design/components";
 import ReactMarkdown from "react-markdown";
+import { KnowledgeBase, McpServer, RuntimeSummary, Tool } from "../../../API";
 import { AgentCoreRuntimeConfiguration } from "../types";
 import { CONVERSATION_MANAGER_OPTIONS, STEP_MIN_HEIGHT } from "../wizard-utils";
 
@@ -27,27 +28,12 @@ interface SingleAgentStepsProps {
     config: AgentCoreRuntimeConfiguration;
     setConfig: React.Dispatch<React.SetStateAction<AgentCoreRuntimeConfiguration>>;
     modelOptions: { label: string; value: string }[];
-    availableToolsOptions: { label: string; value: string; description?: string }[];
-    availableSubAgents: { label: string; value: string }[];
-    availableMcpServersOptions: { label: string; value: string; description?: string }[];
-    availableKnowledgeBases: { label: string; value: string }[];
-    selectedToolsData: { name: string; description: string }[];
-    selectedSubAgentsData: { toolName: string; agentName: string; params: any }[];
-    selectedMcpServersData: { name: string; description: string; mcpUrl: string }[];
-    selectedKnowledgeBasesData: {
-        toolName: string;
-        name: string;
-        description: string;
-        numberOfResults: string;
-    }[];
+    availableTools: Tool[];
+    availableMcpServers: McpServer[];
+    availableAgents: RuntimeSummary[];
+    knowledgeBases: KnowledgeBase[];
     knowledgeBaseIsSupported: boolean;
     isCreating: boolean;
-    addTool: (toolName: string | undefined) => void;
-    removeTool: (toolName: string) => void;
-    addSubAgent: (agentName: string | undefined) => void;
-    addMcpServer: (serverName: string | undefined) => void;
-    removeMcpServer: (serverName: string) => void;
-    addKnowledgeBase: (kbId: string | undefined) => void;
     openConfigureModal: (toolName: string) => void;
 }
 
@@ -55,24 +41,153 @@ export function getSingleAgentSteps({
     config,
     setConfig,
     modelOptions,
-    availableToolsOptions,
-    availableSubAgents,
-    availableMcpServersOptions,
-    availableKnowledgeBases,
-    selectedToolsData,
-    selectedSubAgentsData,
-    selectedMcpServersData,
-    selectedKnowledgeBasesData,
+    availableTools,
+    availableMcpServers,
+    availableAgents,
+    knowledgeBases,
     knowledgeBaseIsSupported,
     isCreating,
-    addTool,
-    removeTool,
-    addSubAgent,
-    addMcpServer,
-    removeMcpServer,
-    addKnowledgeBase,
     openConfigureModal,
 }: SingleAgentStepsProps) {
+    // -------------------------------------------------------------------
+    // Tool / KB / MCP / Sub-agent actions
+    // -------------------------------------------------------------------
+    const addTool = (toolName: string | undefined) => {
+        if (!toolName || toolName === "retrieve_from_kb" || config.tools.includes(toolName)) return;
+        setConfig((prev) => ({
+            ...prev,
+            tools: [...prev.tools, toolName],
+            toolParameters: { ...prev.toolParameters, [toolName]: {} },
+        }));
+    };
+
+    const removeTool = (toolName: string) => {
+        setConfig((prev) => {
+            const newToolParameters = { ...prev.toolParameters };
+            delete newToolParameters[toolName];
+            return {
+                ...prev,
+                tools: prev.tools.filter((t) => t !== toolName),
+                toolParameters: newToolParameters,
+            };
+        });
+    };
+
+    const addSubAgent = (agentName: string | undefined) => {
+        if (!agentName) return;
+        const toolName = `invoke_subagent_${agentName}`;
+        if (config.tools.includes(toolName)) return;
+        setConfig((prev) => ({
+            ...prev,
+            tools: [...prev.tools, toolName],
+            toolParameters: {
+                ...prev.toolParameters,
+                [toolName]: { agentName, qualifier: "DEFAULT", role: "" },
+            },
+        }));
+    };
+
+    const addMcpServer = (serverName: string | undefined) => {
+        if (!serverName || config.mcpServers.includes(serverName)) return;
+        setConfig((prev) => ({ ...prev, mcpServers: [...prev.mcpServers, serverName] }));
+    };
+
+    const removeMcpServer = (serverName: string) => {
+        setConfig((prev) => ({
+            ...prev,
+            mcpServers: prev.mcpServers.filter((s) => s !== serverName),
+        }));
+    };
+
+    const addKnowledgeBase = (kbId: string | undefined) => {
+        if (!kbId) return;
+        const toolName = `retrieve_from_kb_${kbId}`;
+        if (config.tools.includes(toolName)) return;
+        setConfig((prev) => ({
+            ...prev,
+            tools: [...prev.tools, toolName],
+            toolParameters: {
+                ...prev.toolParameters,
+                [toolName]: {
+                    retrieval_cfg: { vectorSearchConfiguration: { numberOfResults: "5" } },
+                    kb_id: kbId,
+                },
+            },
+        }));
+    };
+
+    // -------------------------------------------------------------------
+    // Derived display data
+    // -------------------------------------------------------------------
+    const availableToolsOptions = availableTools
+        .filter((tool) => !tool.invokesSubAgent && !config.tools.includes(tool.name))
+        .map((tool) => ({
+            label: tool.name,
+            value: tool.name,
+            description: tool.description || undefined,
+        }));
+
+    const availableSubAgentsOptions = availableAgents
+        .filter(
+            (agent) =>
+                agent.agentName !== config.agentName &&
+                !config.tools.includes(`invoke_subagent_${agent.agentName}`),
+        )
+        .map((agent) => ({ label: agent.agentName, value: agent.agentName }));
+
+    const availableMcpServersOptions = availableMcpServers
+        .filter((s) => !config.mcpServers.includes(s.name))
+        .map((s) => ({ label: s.name, value: s.name, description: s.description || undefined }));
+
+    const availableKnowledgeBasesOptions = knowledgeBases
+        .filter((kb) => !config.tools.some((tool) => tool === `retrieve_from_kb_${kb.id}`))
+        .map((kb) => ({ label: kb.description || kb.name, value: kb.id }));
+
+    const selectedToolsData = config.tools
+        .filter((t) => !t.startsWith("retrieve_from_kb_") && !t.startsWith("invoke_subagent_"))
+        .map((toolName) => {
+            const toolInfo = availableTools.find((t) => t.name === toolName);
+            return {
+                name: toolName,
+                description: toolInfo?.description || "No description available",
+            };
+        });
+
+    const selectedSubAgentsData = config.tools
+        .filter((t) => t.startsWith("invoke_subagent_"))
+        .map((toolName) => ({
+            toolName,
+            agentName: toolName.replace("invoke_subagent_", ""),
+            params: config.toolParameters[toolName],
+        }));
+
+    const selectedMcpServersData = config.mcpServers.map((serverName) => {
+        const serverInfo = availableMcpServers.find((s) => s.name === serverName);
+        return {
+            name: serverName,
+            description: serverInfo?.description || "No description available",
+            mcpUrl: serverInfo?.mcpUrl || "",
+        };
+    });
+
+    const selectedKnowledgeBasesData = config.tools
+        .filter((t) => t.startsWith("retrieve_from_kb_"))
+        .map((toolName) => {
+            const kbId = toolName.replace("retrieve_from_kb_", "");
+            const kb = knowledgeBases.find((k) => k.id === kbId);
+            const params = config.toolParameters[toolName];
+            return {
+                toolName,
+                name: kb?.name || kbId,
+                description: kb?.description || "No description available",
+                numberOfResults:
+                    params?.retrieval_cfg?.vectorSearchConfiguration?.numberOfResults || "5",
+            };
+        });
+
+    // -------------------------------------------------------------------
+    // Steps
+    // -------------------------------------------------------------------
     const steps = [
         {
             title: "Basic Configuration",
@@ -288,12 +403,12 @@ export function getSingleAgentSteps({
                             >
                                 <Select
                                     placeholder={
-                                        availableSubAgents.length === 0
+                                        availableSubAgentsOptions.length === 0
                                             ? "No additional sub-agents available"
                                             : "Select a sub-agent to add as a tool"
                                     }
-                                    options={availableSubAgents}
-                                    disabled={availableSubAgents.length === 0}
+                                    options={availableSubAgentsOptions}
+                                    disabled={availableSubAgentsOptions.length === 0}
                                     onChange={({ detail }) => {
                                         if (detail.selectedOption) {
                                             addSubAgent(detail.selectedOption.value);
@@ -533,19 +648,17 @@ export function getSingleAgentSteps({
             title: "Knowledge Bases",
             content: (
                 <div style={{ minHeight: STEP_MIN_HEIGHT }}>
-                    <Container
-                        header={<Header variant="h2">Configure Knowledge Bases</Header>}
-                    >
+                    <Container header={<Header variant="h2">Configure Knowledge Bases</Header>}>
                         <SpaceBetween direction="vertical" size="l">
                             <FormField label="Available Knowledge Bases">
                                 <Select
                                     placeholder={
-                                        availableKnowledgeBases.length === 0
+                                        availableKnowledgeBasesOptions.length === 0
                                             ? "No additional knowledge bases available"
                                             : "Select a knowledge base to add"
                                     }
-                                    options={availableKnowledgeBases}
-                                    disabled={availableKnowledgeBases.length === 0}
+                                    options={availableKnowledgeBasesOptions}
+                                    disabled={availableKnowledgeBasesOptions.length === 0}
                                     onChange={({ detail }) => {
                                         if (detail.selectedOption) {
                                             addKnowledgeBase(detail.selectedOption.value);
@@ -556,9 +669,7 @@ export function getSingleAgentSteps({
                             </FormField>
 
                             <Container
-                                header={
-                                    <Header variant="h3">Selected Knowledge Bases</Header>
-                                }
+                                header={<Header variant="h3">Selected Knowledge Bases</Header>}
                             >
                                 {selectedKnowledgeBasesData.length === 0 ? (
                                     <Alert type="info">No knowledge bases selected</Alert>
@@ -612,9 +723,7 @@ export function getSingleAgentSteps({
                                                     <Button
                                                         variant="icon"
                                                         iconName="close"
-                                                        onClick={() =>
-                                                            removeTool(item.toolName)
-                                                        }
+                                                        onClick={() => removeTool(item.toolName)}
                                                     />
                                                 ),
                                             },
@@ -629,8 +738,7 @@ export function getSingleAgentSteps({
                                                     variant="p"
                                                     color="inherit"
                                                 >
-                                                    Select knowledge bases from the dropdown
-                                                    above.
+                                                    Select knowledge bases from the dropdown above.
                                                 </Box>
                                             </Box>
                                         }
@@ -687,10 +795,7 @@ export function isSingleAgentStepValid(
     // Step 3 = Tools Config
     if (stepIndex === 3) {
         return !config.tools.some((tool) => {
-            return (
-                tool.startsWith("invoke_subagent_") &&
-                !config.toolParameters[tool]?.agentName
-            );
+            return tool.startsWith("invoke_subagent_") && !config.toolParameters[tool]?.agentName;
         });
     }
     return true;

--- a/lib/user-interface/react-app/src/components/wizard/architectures/single-agent-steps.tsx
+++ b/lib/user-interface/react-app/src/components/wizard/architectures/single-agent-steps.tsx
@@ -6,23 +6,16 @@
 import {
     Alert,
     Box,
-    Button,
-    Checkbox,
     Container,
     FormField,
     Header,
-    Icon,
     Input,
-    Popover,
-    Select,
     SpaceBetween,
-    Table,
-    Textarea,
 } from "@cloudscape-design/components";
-import ReactMarkdown from "react-markdown";
 import { KnowledgeBase, McpServer, Tool } from "../../../API";
 import { AgentCoreRuntimeConfiguration } from "../types";
-import { CONVERSATION_MANAGER_OPTIONS, STEP_MIN_HEIGHT } from "../wizard-utils";
+import { AdditionalToolsSection, AgentConfigSection } from "../wizard-shared-components";
+import { STEP_MIN_HEIGHT } from "../wizard-utils";
 
 interface SingleAgentStepsProps {
     config: AgentCoreRuntimeConfiguration;
@@ -103,6 +96,9 @@ export function getSingleAgentSteps({
     // -------------------------------------------------------------------
     // Derived display data
     // -------------------------------------------------------------------
+    const hasCustomTools = availableTools.filter((t) => !t.invokesSubAgent).length > 0;
+    const hasMcpServers = availableMcpServers.length > 0;
+
     const availableToolsOptions = availableTools
         .filter((tool) => !tool.invokesSubAgent && !config.tools.includes(tool.name))
         .map((tool) => ({
@@ -121,48 +117,29 @@ export function getSingleAgentSteps({
 
     const selectedToolsData = config.tools
         .filter((t) => !t.startsWith("retrieve_from_kb_") && !t.startsWith("invoke_subagent_"))
-        .map((toolName) => {
-            const toolInfo = availableTools.find((t) => t.name === toolName);
-            return {
-                name: toolName,
-                description: toolInfo?.description || "No description available",
-            };
-        });
-
-    const selectedMcpServersData = config.mcpServers.map((serverName) => {
-        const serverInfo = availableMcpServers.find((s) => s.name === serverName);
-        return {
-            name: serverName,
-            description: serverInfo?.description || "No description available",
-            mcpUrl: serverInfo?.mcpUrl || "",
-        };
-    });
+        .map((toolName) => ({ name: toolName }));
 
     const selectedKnowledgeBasesData = config.tools
         .filter((t) => t.startsWith("retrieve_from_kb_"))
         .map((toolName) => {
             const kbId = toolName.replace("retrieve_from_kb_", "");
             const kb = knowledgeBases.find((k) => k.id === kbId);
-            const params = config.toolParameters[toolName];
-            return {
-                toolName,
-                name: kb?.name || kbId,
-                description: kb?.description || "No description available",
-                numberOfResults:
-                    params?.retrieval_cfg?.vectorSearchConfiguration?.numberOfResults || "5",
-            };
+            return { toolName, name: kb?.name || kbId };
         });
 
     // -------------------------------------------------------------------
     // Steps
     // -------------------------------------------------------------------
+    const hasToolsStep = hasCustomTools || hasMcpServers || knowledgeBaseIsSupported;
+
     const steps = [
+        // Step 1: Agent Configuration
         {
-            title: "Basic Configuration",
+            title: "Agent Configuration",
             content: (
                 <div style={{ minHeight: STEP_MIN_HEIGHT }}>
-                    <Container header={<Header variant="h2">Agent Instructions</Header>}>
-                        <SpaceBetween direction="vertical" size="l">
+                    <SpaceBetween direction="vertical" size="l">
+                        <Container header={<Header variant="h2">Agent Name</Header>}>
                             <FormField
                                 label="Agent Name"
                                 description="Enter a unique name for your agent"
@@ -177,487 +154,132 @@ export function getSingleAgentSteps({
                                 <Input
                                     value={config.agentName}
                                     onChange={({ detail }) =>
-                                        setConfig((prev) => ({ ...prev, agentName: detail.value }))
+                                        setConfig((prev) => ({
+                                            ...prev,
+                                            agentName: detail.value,
+                                        }))
                                     }
                                     placeholder="Enter agent name..."
                                     invalid={config.agentName.trim() === ""}
                                 />
                             </FormField>
-                            <FormField
-                                label="Instructions"
-                                description="Provide detailed instructions for your agent"
-                                errorText={
-                                    config.instructions.trim() === ""
-                                        ? "Instructions are required"
-                                        : ""
-                                }
-                            >
-                                <Textarea
-                                    value={config.instructions}
-                                    onChange={({ detail }) =>
-                                        setConfig((prev) => ({
-                                            ...prev,
-                                            instructions: detail.value,
-                                        }))
-                                    }
-                                    placeholder="Enter agent instructions..."
-                                    rows={8}
-                                    invalid={config.instructions.trim() === ""}
-                                />
-                            </FormField>
-                            <FormField label="Conversation Manager">
-                                <Select
-                                    selectedOption={
-                                        CONVERSATION_MANAGER_OPTIONS.find(
-                                            (opt) => opt.value === config.conversationManager,
-                                        ) || null
-                                    }
-                                    onChange={({ detail }) =>
-                                        setConfig((prev) => ({
-                                            ...prev,
-                                            conversationManager: (detail.selectedOption?.value ||
-                                                "sliding_window") as
-                                                | "null"
-                                                | "sliding_window"
-                                                | "summarizing",
-                                        }))
-                                    }
-                                    options={CONVERSATION_MANAGER_OPTIONS}
-                                />
-                            </FormField>
-                        </SpaceBetween>
-                    </Container>
+                        </Container>
+
+                        <AgentConfigSection
+                            label="Agent"
+                            modelOptions={modelOptions}
+                            modelId={config.modelInferenceParameters.modelId}
+                            onModelChange={(modelId) =>
+                                setConfig((prev) => ({
+                                    ...prev,
+                                    modelInferenceParameters: {
+                                        ...prev.modelInferenceParameters,
+                                        modelId,
+                                    },
+                                }))
+                            }
+                            temperature={config.modelInferenceParameters.parameters.temperature}
+                            onTemperatureChange={(temperature) =>
+                                setConfig((prev) => ({
+                                    ...prev,
+                                    modelInferenceParameters: {
+                                        ...prev.modelInferenceParameters,
+                                        parameters: {
+                                            ...prev.modelInferenceParameters.parameters,
+                                            temperature,
+                                        },
+                                    },
+                                }))
+                            }
+                            maxTokens={config.modelInferenceParameters.parameters.maxTokens}
+                            onMaxTokensChange={(maxTokens) =>
+                                setConfig((prev) => ({
+                                    ...prev,
+                                    modelInferenceParameters: {
+                                        ...prev.modelInferenceParameters,
+                                        parameters: {
+                                            ...prev.modelInferenceParameters.parameters,
+                                            maxTokens,
+                                        },
+                                    },
+                                }))
+                            }
+                            instructions={config.instructions}
+                            onInstructionsChange={(instructions) =>
+                                setConfig((prev) => ({ ...prev, instructions }))
+                            }
+                            conversationManager={config.conversationManager}
+                            onConversationManagerChange={(conversationManager) =>
+                                setConfig((prev) => ({ ...prev, conversationManager }))
+                            }
+                            useMemory={config.useMemory || false}
+                            onUseMemoryChange={(useMemory) =>
+                                setConfig((prev) => ({ ...prev, useMemory }))
+                            }
+                        />
+                    </SpaceBetween>
                 </div>
             ),
         },
+        // Step 2: Review (Tools step is conditionally inserted below)
         {
-            title: "Model Configuration",
+            title: "Review",
             content: (
                 <div style={{ minHeight: STEP_MIN_HEIGHT }}>
-                    <Container header={<Header variant="h2">Model & Parameters</Header>}>
-                        <SpaceBetween direction="vertical" size="l">
-                            <FormField label="Model">
-                                <Select
-                                    selectedOption={
-                                        modelOptions.find(
-                                            (opt) =>
-                                                opt.value ===
-                                                config.modelInferenceParameters.modelId,
-                                        ) || null
-                                    }
-                                    onChange={({ detail }) =>
-                                        setConfig((prev) => ({
-                                            ...prev,
-                                            modelInferenceParameters: {
-                                                ...prev.modelInferenceParameters,
-                                                modelId: detail.selectedOption?.value || "",
-                                            },
-                                        }))
-                                    }
-                                    options={modelOptions}
-                                />
-                            </FormField>
-                            <FormField label="Temperature" description="Value between 0 and 1">
-                                <Input
-                                    value={config.modelInferenceParameters.parameters.temperature.toString()}
-                                    onChange={({ detail }) => {
-                                        const value = parseFloat(detail.value) || 0;
-                                        if (value >= 0 && value <= 1) {
-                                            setConfig((prev) => ({
-                                                ...prev,
-                                                modelInferenceParameters: {
-                                                    ...prev.modelInferenceParameters,
-                                                    parameters: {
-                                                        ...prev.modelInferenceParameters.parameters,
-                                                        temperature: value,
-                                                    },
-                                                },
-                                            }));
-                                        }
-                                    }}
-                                    type="number"
-                                    step={0.05}
-                                />
-                            </FormField>
-                            <FormField label="Max Tokens" description="Value between 100 and 4000">
-                                <Input
-                                    value={config.modelInferenceParameters.parameters.maxTokens.toString()}
-                                    onChange={({ detail }) => {
-                                        const value = parseInt(detail.value) || 100;
-                                        if (value >= 100 && value <= 4000) {
-                                            setConfig((prev) => ({
-                                                ...prev,
-                                                modelInferenceParameters: {
-                                                    ...prev.modelInferenceParameters,
-                                                    parameters: {
-                                                        ...prev.modelInferenceParameters.parameters,
-                                                        maxTokens: value,
-                                                    },
-                                                },
-                                            }));
-                                        }
-                                    }}
-                                    type="number"
-                                    step={100}
-                                />
-                            </FormField>
-                        </SpaceBetween>
-                    </Container>
-                </div>
-            ),
-        },
-        {
-            title: "Memory Configuration",
-            content: (
-                <div style={{ minHeight: STEP_MIN_HEIGHT }}>
-                    <Container header={<Header variant="h2">Memory Settings</Header>}>
-                        <SpaceBetween direction="vertical" size="l">
-                            <FormField
-                                label="AgentCore Memory"
-                                description="Create an AgentCore Memory and attach it to your agent Runtime."
-                            >
-                                <Checkbox
-                                    checked={config.useMemory || false}
-                                    onChange={({ detail }) =>
-                                        setConfig((prev) => ({
-                                            ...prev,
-                                            useMemory: detail.checked,
-                                        }))
-                                    }
-                                >
-                                    Enable AgentCore Memory
-                                </Checkbox>
-                            </FormField>
-                            {config.useMemory && (
-                                <Alert type="info" header="AgentCore Memory Enabled">
-                                    AgentCore Memory will be created and attached to your agent
-                                    Runtime. This allows the agent to maintain conversation context
-                                    even when sessions are terminated (due to inactivity or reaching
-                                    max duration).
-                                </Alert>
-                            )}
-                        </SpaceBetween>
-                    </Container>
-                </div>
-            ),
-        },
-        {
-            title: "Tools Configuration",
-            content: (
-                <div style={{ minHeight: STEP_MIN_HEIGHT }}>
-                    <Container header={<Header variant="h2">Configure Tools</Header>}>
-                        <SpaceBetween direction="vertical" size="l">
-                            <FormField label="Available Tools">
-                                <Select
-                                    placeholder={
-                                        availableToolsOptions.length === 0
-                                            ? "No additional tools available"
-                                            : "Select a tool to add"
-                                    }
-                                    options={availableToolsOptions}
-                                    disabled={availableToolsOptions.length === 0}
-                                    onChange={({ detail }) => {
-                                        if (detail.selectedOption) {
-                                            addTool(detail.selectedOption.value);
-                                        }
-                                    }}
-                                    selectedOption={null}
-                                />
-                            </FormField>
-
-                            <Container header={<Header variant="h3">Selected Tools</Header>}>
-                                {selectedToolsData.length === 0 ? (
-                                    <Alert type="info">No tools selected</Alert>
-                                ) : (
-                                    <Table
-                                        columnDefinitions={[
-                                            {
-                                                id: "name",
-                                                header: "Tool Name",
-                                                cell: (item) => item.name,
-                                            },
-                                            {
-                                                id: "description",
-                                                header: "Description",
-                                                cell: (item) => (
-                                                    <Popover
-                                                        dismissButton={false}
-                                                        position="top"
-                                                        size="medium"
-                                                        triggerType="custom"
-                                                        content={
-                                                            <Box padding="xs">
-                                                                <ReactMarkdown>
-                                                                    {item.description}
-                                                                </ReactMarkdown>
-                                                            </Box>
-                                                        }
-                                                    >
-                                                        <Icon name="status-info" />
-                                                    </Popover>
-                                                ),
-                                            },
-                                            {
-                                                id: "actions",
-                                                header: "Actions",
-                                                cell: (item) => (
-                                                    <Button
-                                                        variant="icon"
-                                                        iconName="close"
-                                                        onClick={() => removeTool(item.name)}
-                                                    />
-                                                ),
-                                            },
-                                        ]}
-                                        items={selectedToolsData}
-                                        loadingText="Loading tools"
-                                        empty={
-                                            <Box textAlign="center" color="inherit">
-                                                <b>No tools selected</b>
-                                                <Box
-                                                    padding={{ bottom: "s" }}
-                                                    variant="p"
-                                                    color="inherit"
-                                                >
-                                                    Select tools from the dropdown above.
-                                                </Box>
-                                            </Box>
-                                        }
-                                    />
-                                )}
-                            </Container>
-                        </SpaceBetween>
-                    </Container>
-                </div>
-            ),
-        },
-        {
-            title: "MCP Servers Configuration",
-            content: (
-                <div style={{ minHeight: STEP_MIN_HEIGHT }}>
-                    <Container header={<Header variant="h2">Configure MCP Servers</Header>}>
-                        <SpaceBetween direction="vertical" size="l">
-                            <FormField
-                                label="Available MCP Servers"
-                                description="Model Context Protocol servers provide additional capabilities to your agent"
-                            >
-                                <Select
-                                    placeholder={
-                                        availableMcpServersOptions.length === 0
-                                            ? "No MCP servers available"
-                                            : "Select an MCP server to add"
-                                    }
-                                    options={availableMcpServersOptions}
-                                    disabled={availableMcpServersOptions.length === 0}
-                                    onChange={({ detail }) => {
-                                        if (detail.selectedOption) {
-                                            addMcpServer(detail.selectedOption.value);
-                                        }
-                                    }}
-                                    selectedOption={null}
-                                />
-                            </FormField>
-
-                            <Container header={<Header variant="h3">Selected MCP Servers</Header>}>
-                                {selectedMcpServersData.length === 0 ? (
-                                    <Alert type="info">No MCP servers selected</Alert>
-                                ) : (
-                                    <Table
-                                        columnDefinitions={[
-                                            {
-                                                id: "name",
-                                                header: "Server Name",
-                                                cell: (item) => item.name,
-                                            },
-                                            {
-                                                id: "description",
-                                                header: "Description",
-                                                cell: (item) => (
-                                                    <Popover
-                                                        dismissButton={false}
-                                                        position="top"
-                                                        size="medium"
-                                                        triggerType="custom"
-                                                        content={
-                                                            <Box padding="xs">
-                                                                <ReactMarkdown>
-                                                                    {item.description}
-                                                                </ReactMarkdown>
-                                                            </Box>
-                                                        }
-                                                    >
-                                                        <Icon name="status-info" />
-                                                    </Popover>
-                                                ),
-                                            },
-                                            {
-                                                id: "actions",
-                                                header: "Actions",
-                                                cell: (item) => (
-                                                    <Button
-                                                        variant="icon"
-                                                        iconName="close"
-                                                        onClick={() => removeMcpServer(item.name)}
-                                                    />
-                                                ),
-                                            },
-                                        ]}
-                                        items={selectedMcpServersData}
-                                        loadingText="Loading MCP servers"
-                                        empty={
-                                            <Box textAlign="center" color="inherit">
-                                                <b>No MCP servers selected</b>
-                                                <Box
-                                                    padding={{ bottom: "s" }}
-                                                    variant="p"
-                                                    color="inherit"
-                                                >
-                                                    Select MCP servers from the dropdown above.
-                                                </Box>
-                                            </Box>
-                                        }
-                                    />
-                                )}
-                            </Container>
-                        </SpaceBetween>
-                    </Container>
-                </div>
-            ),
-        },
-    ];
-
-    // Conditionally add Knowledge Bases step
-    if (knowledgeBaseIsSupported) {
-        steps.push({
-            title: "Knowledge Bases",
-            content: (
-                <div style={{ minHeight: STEP_MIN_HEIGHT }}>
-                    <Container header={<Header variant="h2">Configure Knowledge Bases</Header>}>
-                        <SpaceBetween direction="vertical" size="l">
-                            <FormField label="Available Knowledge Bases">
-                                <Select
-                                    placeholder={
-                                        availableKnowledgeBasesOptions.length === 0
-                                            ? "No additional knowledge bases available"
-                                            : "Select a knowledge base to add"
-                                    }
-                                    options={availableKnowledgeBasesOptions}
-                                    disabled={availableKnowledgeBasesOptions.length === 0}
-                                    onChange={({ detail }) => {
-                                        if (detail.selectedOption) {
-                                            addKnowledgeBase(detail.selectedOption.value);
-                                        }
-                                    }}
-                                    selectedOption={null}
-                                />
-                            </FormField>
-
-                            <Container
-                                header={<Header variant="h3">Selected Knowledge Bases</Header>}
-                            >
-                                {selectedKnowledgeBasesData.length === 0 ? (
-                                    <Alert type="info">No knowledge bases selected</Alert>
-                                ) : (
-                                    <Table
-                                        columnDefinitions={[
-                                            {
-                                                id: "name",
-                                                header: "Knowledge Base",
-                                                cell: (item) => item.name,
-                                            },
-                                            {
-                                                id: "description",
-                                                header: "Description",
-                                                cell: (item) => (
-                                                    <Popover
-                                                        dismissButton={false}
-                                                        position="top"
-                                                        size="medium"
-                                                        triggerType="custom"
-                                                        content={
-                                                            <Box padding="xs">
-                                                                <ReactMarkdown>
-                                                                    {item.description}
-                                                                </ReactMarkdown>
-                                                            </Box>
-                                                        }
-                                                    >
-                                                        <Icon name="status-info" />
-                                                    </Popover>
-                                                ),
-                                            },
-                                            {
-                                                id: "parameters",
-                                                header: "Parameters",
-                                                cell: (item) => (
-                                                    <Button
-                                                        variant="normal"
-                                                        onClick={() =>
-                                                            openConfigureModal(item.toolName)
-                                                        }
-                                                    >
-                                                        Configure
-                                                    </Button>
-                                                ),
-                                            },
-                                            {
-                                                id: "actions",
-                                                header: "Actions",
-                                                cell: (item) => (
-                                                    <Button
-                                                        variant="icon"
-                                                        iconName="close"
-                                                        onClick={() => removeTool(item.toolName)}
-                                                    />
-                                                ),
-                                            },
-                                        ]}
-                                        items={selectedKnowledgeBasesData}
-                                        loadingText="Loading knowledge bases"
-                                        empty={
-                                            <Box textAlign="center" color="inherit">
-                                                <b>No knowledge bases selected</b>
-                                                <Box
-                                                    padding={{ bottom: "s" }}
-                                                    variant="p"
-                                                    color="inherit"
-                                                >
-                                                    Select knowledge bases from the dropdown above.
-                                                </Box>
-                                            </Box>
-                                        }
-                                    />
-                                )}
-                            </Container>
-                        </SpaceBetween>
-                    </Container>
-                </div>
-            ),
-        });
-    }
-
-    // Review step
-    steps.push({
-        title: "Review",
-        content: (
-            <div style={{ minHeight: STEP_MIN_HEIGHT }}>
-                <Container header={<Header variant="h2">Review Configuration</Header>}>
-                    <SpaceBetween direction="vertical" size="m">
+                    <SpaceBetween direction="vertical" size="l">
                         {!isCreating && (
                             <Alert type="info" header="Configuration Summary">
                                 Review your agent configuration before creating.
                             </Alert>
                         )}
-                        <Box padding="m" variant="code">
-                            <pre style={{ margin: 0, overflow: "auto" }}>
-                                {JSON.stringify(config, null, 2)}
-                            </pre>
-                        </Box>
+                        <Container header={<Header variant="h2">Configuration JSON</Header>}>
+                            <Box padding="m" variant="code">
+                                <pre
+                                    style={{
+                                        margin: 0,
+                                        overflow: "auto",
+                                        maxHeight: "400px",
+                                    }}
+                                >
+                                    {JSON.stringify(config, null, 2)}
+                                </pre>
+                            </Box>
+                        </Container>
                     </SpaceBetween>
-                </Container>
-            </div>
-        ),
-    });
+                </div>
+            ),
+        },
+    ];
+
+    // Conditionally insert the Tools step before Review
+    if (hasToolsStep) {
+        steps.splice(steps.length - 1, 0, {
+            title: "Tools",
+            content: (
+                <div style={{ minHeight: STEP_MIN_HEIGHT }}>
+                    <AdditionalToolsSection
+                        title="Tools"
+                        description="Add tools, knowledge bases, and MCP servers to extend your agent's capabilities"
+                        hasCustomTools={hasCustomTools}
+                        hasMcpServers={hasMcpServers}
+                        knowledgeBaseIsSupported={knowledgeBaseIsSupported}
+                        availableToolsOptions={availableToolsOptions}
+                        availableKnowledgeBasesOptions={availableKnowledgeBasesOptions}
+                        availableMcpServersOptions={availableMcpServersOptions}
+                        selectedTools={selectedToolsData}
+                        selectedKnowledgeBases={selectedKnowledgeBasesData}
+                        selectedMcpServers={config.mcpServers.map((s) => ({ name: s }))}
+                        onAddTool={addTool}
+                        onRemoveTool={removeTool}
+                        onAddKnowledgeBase={addKnowledgeBase}
+                        onAddMcpServer={addMcpServer}
+                        onRemoveMcpServer={removeMcpServer}
+                        onConfigureKnowledgeBase={openConfigureModal}
+                    />
+                </div>
+            ),
+        });
+    }
 
     return steps;
 }
@@ -667,14 +289,17 @@ export function isSingleAgentStepValid(
     stepIndex: number,
     config: AgentCoreRuntimeConfiguration,
 ): boolean {
-    // stepIndex is relative to the architecture-specific steps (0 = Basic Config, etc.)
+    // Step 0: Agent Configuration
     if (stepIndex === 0) {
         const agentNamePattern = /^[a-zA-Z][a-zA-Z0-9_]{0,47}$/;
         return (
-            config.instructions.trim() !== "" &&
             config.agentName.trim() !== "" &&
-            agentNamePattern.test(config.agentName)
+            agentNamePattern.test(config.agentName) &&
+            config.instructions.trim() !== "" &&
+            config.modelInferenceParameters.modelId.trim() !== ""
         );
     }
+    // Step 1: Additional Tools — always valid (optional)
+    // Step 2: Review — always valid
     return true;
 }

--- a/lib/user-interface/react-app/src/components/wizard/wizard-shared-components.tsx
+++ b/lib/user-interface/react-app/src/components/wizard/wizard-shared-components.tsx
@@ -1,0 +1,383 @@
+// ----------------------------------------------------------------------
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: MIT-0
+// ----------------------------------------------------------------------
+import {
+    Alert,
+    Button,
+    Checkbox,
+    ColumnLayout,
+    Container,
+    FormField,
+    Header,
+    Input,
+    Select,
+    SpaceBetween,
+    Table,
+    Textarea,
+} from "@cloudscape-design/components";
+import { CONVERSATION_MANAGER_OPTIONS } from "./wizard-utils";
+
+// -------------------------------------------------------------------
+// AgentConfigSection — Model, Instructions, Conversation Manager, Memory
+// -------------------------------------------------------------------
+
+export interface AgentConfigSectionProps {
+    /** Label variant, e.g. "Agent" or "Orchestrator" */
+    label?: string;
+    modelOptions: { label: string; value: string }[];
+    modelId: string;
+    onModelChange: (modelId: string) => void;
+    temperature: number;
+    onTemperatureChange: (value: number) => void;
+    maxTokens: number;
+    onMaxTokensChange: (value: number) => void;
+    instructions: string;
+    onInstructionsChange: (value: string) => void;
+    instructionsPlaceholder?: string;
+    conversationManager: "null" | "sliding_window" | "summarizing";
+    onConversationManagerChange: (value: "null" | "sliding_window" | "summarizing") => void;
+    useMemory: boolean;
+    onUseMemoryChange: (checked: boolean) => void;
+}
+
+export function AgentConfigSection({
+    label = "Agent",
+    modelOptions,
+    modelId,
+    onModelChange,
+    temperature,
+    onTemperatureChange,
+    maxTokens,
+    onMaxTokensChange,
+    instructions,
+    onInstructionsChange,
+    instructionsPlaceholder,
+    conversationManager,
+    onConversationManagerChange,
+    useMemory,
+    onUseMemoryChange,
+}: AgentConfigSectionProps) {
+    return (
+        <SpaceBetween direction="vertical" size="l">
+            <Container header={<Header variant="h2">Model &amp; Instructions</Header>}>
+                <SpaceBetween direction="vertical" size="l">
+                    <ColumnLayout columns={2} variant="text-grid">
+                        <FormField
+                            label="Model"
+                            description={`Select the LLM model for the ${label.toLowerCase()}`}
+                        >
+                            <Select
+                                placeholder="Select a model..."
+                                options={modelOptions}
+                                selectedOption={
+                                    modelOptions.find((opt) => opt.value === modelId) || null
+                                }
+                                onChange={({ detail }) =>
+                                    onModelChange(detail.selectedOption?.value || "")
+                                }
+                                filteringType="auto"
+                            />
+                        </FormField>
+                        <SpaceBetween direction="vertical" size="s">
+                            <FormField label="Temperature" description="Controls randomness (0-1)">
+                                <Input
+                                    type="number"
+                                    value={temperature.toString()}
+                                    onChange={({ detail }) => {
+                                        const value = parseFloat(detail.value) || 0;
+                                        if (value >= 0 && value <= 1) {
+                                            onTemperatureChange(value);
+                                        }
+                                    }}
+                                    step={0.05}
+                                />
+                            </FormField>
+                            <FormField label="Max Tokens" description="Maximum output tokens">
+                                <Input
+                                    type="number"
+                                    value={maxTokens.toString()}
+                                    onChange={({ detail }) => {
+                                        const value = parseInt(detail.value) || 100;
+                                        if (value >= 100 && value <= 4000) {
+                                            onMaxTokensChange(value);
+                                        }
+                                    }}
+                                    step={100}
+                                />
+                            </FormField>
+                        </SpaceBetween>
+                    </ColumnLayout>
+
+                    <FormField
+                        label={`${label} Instructions`}
+                        description={`System prompt that defines the ${label.toLowerCase()}'s behavior`}
+                        errorText={instructions.trim() === "" ? "Instructions are required" : ""}
+                    >
+                        <Textarea
+                            value={instructions}
+                            onChange={({ detail }) => onInstructionsChange(detail.value)}
+                            placeholder={
+                                instructionsPlaceholder ||
+                                `Enter ${label.toLowerCase()} instructions...`
+                            }
+                            rows={6}
+                            invalid={instructions.trim() === ""}
+                        />
+                    </FormField>
+
+                    <FormField label="Conversation Manager">
+                        <Select
+                            selectedOption={
+                                CONVERSATION_MANAGER_OPTIONS.find(
+                                    (opt) => opt.value === conversationManager,
+                                ) || null
+                            }
+                            onChange={({ detail }) =>
+                                onConversationManagerChange(
+                                    (detail.selectedOption?.value || "sliding_window") as
+                                        | "null"
+                                        | "sliding_window"
+                                        | "summarizing",
+                                )
+                            }
+                            options={CONVERSATION_MANAGER_OPTIONS}
+                        />
+                    </FormField>
+                </SpaceBetween>
+            </Container>
+
+            <Container header={<Header variant="h2">Memory</Header>}>
+                <SpaceBetween direction="vertical" size="s">
+                    <Checkbox
+                        checked={useMemory}
+                        onChange={({ detail }) => onUseMemoryChange(detail.checked)}
+                    >
+                        Enable AgentCore Memory
+                    </Checkbox>
+                    {useMemory && (
+                        <Alert type="info">
+                            AgentCore Memory will be created and attached to your agent Runtime,
+                            allowing it to maintain conversation context even when sessions are
+                            terminated.
+                        </Alert>
+                    )}
+                </SpaceBetween>
+            </Container>
+        </SpaceBetween>
+    );
+}
+
+// -------------------------------------------------------------------
+// AdditionalToolsSection — Tools, Knowledge Bases, MCP Servers
+// -------------------------------------------------------------------
+
+export interface AdditionalToolsSectionProps {
+    /** Whether custom tools are available per CDK config */
+    hasCustomTools: boolean;
+    /** Whether MCP servers are available per CDK config */
+    hasMcpServers: boolean;
+    /** Whether knowledge base is supported */
+    knowledgeBaseIsSupported: boolean;
+    /** Filtered tool options (not yet selected) */
+    availableToolsOptions: { label: string; value: string; description?: string }[];
+    /** Filtered KB options (not yet selected) */
+    availableKnowledgeBasesOptions: { label: string; value: string }[];
+    /** Filtered MCP server options (not yet selected) */
+    availableMcpServersOptions: { label: string; value: string; description?: string }[];
+    /** Currently selected tool names */
+    selectedTools: { name: string }[];
+    /** Currently selected knowledge bases */
+    selectedKnowledgeBases: { toolName: string; name: string }[];
+    /** Currently selected MCP server names */
+    selectedMcpServers: { name: string }[];
+    /** Callbacks */
+    onAddTool: (toolName: string | undefined) => void;
+    onRemoveTool: (toolName: string) => void;
+    onAddKnowledgeBase: (kbId: string | undefined) => void;
+    onAddMcpServer: (serverName: string | undefined) => void;
+    onRemoveMcpServer: (serverName: string) => void;
+    /** Optional: opens a configure modal for KB parameters */
+    onConfigureKnowledgeBase?: (toolName: string) => void;
+    /** Title for the section header */
+    title?: string;
+    /** Description for the section header */
+    description?: string;
+    /** Message when nothing is selected */
+    emptyMessage?: string;
+}
+
+export function AdditionalToolsSection({
+    hasCustomTools,
+    hasMcpServers,
+    knowledgeBaseIsSupported,
+    availableToolsOptions,
+    availableKnowledgeBasesOptions,
+    availableMcpServersOptions,
+    selectedTools,
+    selectedKnowledgeBases,
+    selectedMcpServers,
+    onAddTool,
+    onRemoveTool,
+    onAddKnowledgeBase,
+    onAddMcpServer,
+    onRemoveMcpServer,
+    onConfigureKnowledgeBase,
+    title = "Additional Tools (Optional)",
+    description = "Optionally add tools, knowledge bases, and MCP servers to extend capabilities",
+    emptyMessage = "No tools configured yet. Use the dropdowns above to add tools, knowledge bases, or MCP servers.",
+}: AdditionalToolsSectionProps) {
+    const columnCount = [hasCustomTools, knowledgeBaseIsSupported, hasMcpServers].filter(
+        Boolean,
+    ).length;
+
+    return (
+        <Container
+            header={
+                <Header variant="h2" description={description}>
+                    {title}
+                </Header>
+            }
+        >
+            <SpaceBetween direction="vertical" size="m">
+                <ColumnLayout columns={columnCount || 1}>
+                    {hasCustomTools && (
+                        <FormField label="Add Tool">
+                            <Select
+                                placeholder="Select a tool..."
+                                options={availableToolsOptions}
+                                onChange={({ detail }) => onAddTool(detail.selectedOption?.value)}
+                                selectedOption={null}
+                                filteringType="auto"
+                            />
+                        </FormField>
+                    )}
+                    {knowledgeBaseIsSupported && (
+                        <FormField label="Add Knowledge Base">
+                            <Select
+                                placeholder="Select a KB..."
+                                options={availableKnowledgeBasesOptions}
+                                onChange={({ detail }) =>
+                                    onAddKnowledgeBase(detail.selectedOption?.value)
+                                }
+                                selectedOption={null}
+                                filteringType="auto"
+                            />
+                        </FormField>
+                    )}
+                    {hasMcpServers && (
+                        <FormField label="Add MCP Server">
+                            <Select
+                                placeholder="Select MCP server..."
+                                options={availableMcpServersOptions}
+                                onChange={({ detail }) =>
+                                    onAddMcpServer(detail.selectedOption?.value)
+                                }
+                                selectedOption={null}
+                                filteringType="auto"
+                            />
+                        </FormField>
+                    )}
+                </ColumnLayout>
+
+                {selectedTools.length > 0 && (
+                    <Table
+                        items={selectedTools}
+                        columnDefinitions={[
+                            {
+                                id: "name",
+                                header: "Tool Name",
+                                cell: (item) => item.name,
+                                isRowHeader: true,
+                            },
+                            {
+                                id: "actions",
+                                header: "Actions",
+                                cell: (item) => (
+                                    <Button
+                                        variant="icon"
+                                        iconName="close"
+                                        onClick={() => onRemoveTool(item.name)}
+                                    />
+                                ),
+                            },
+                        ]}
+                    />
+                )}
+
+                {selectedKnowledgeBases.length > 0 && (
+                    <Table
+                        items={selectedKnowledgeBases}
+                        columnDefinitions={[
+                            {
+                                id: "name",
+                                header: "Knowledge Base",
+                                cell: (item) => item.name,
+                                isRowHeader: true,
+                            },
+                            ...(onConfigureKnowledgeBase
+                                ? [
+                                      {
+                                          id: "configure",
+                                          header: "Parameters",
+                                          cell: (item: { toolName: string; name: string }) => (
+                                              <Button
+                                                  variant="normal"
+                                                  onClick={() =>
+                                                      onConfigureKnowledgeBase(item.toolName)
+                                                  }
+                                              >
+                                                  Configure
+                                              </Button>
+                                          ),
+                                      },
+                                  ]
+                                : []),
+                            {
+                                id: "actions",
+                                header: "Actions",
+                                cell: (item) => (
+                                    <Button
+                                        variant="icon"
+                                        iconName="close"
+                                        onClick={() => onRemoveTool(item.toolName)}
+                                    />
+                                ),
+                            },
+                        ]}
+                    />
+                )}
+
+                {selectedMcpServers.length > 0 && (
+                    <Table
+                        items={selectedMcpServers}
+                        columnDefinitions={[
+                            {
+                                id: "name",
+                                header: "MCP Server",
+                                cell: (item) => item.name,
+                                isRowHeader: true,
+                            },
+                            {
+                                id: "actions",
+                                header: "Actions",
+                                cell: (item) => (
+                                    <Button
+                                        variant="icon"
+                                        iconName="close"
+                                        onClick={() => onRemoveMcpServer(item.name)}
+                                    />
+                                ),
+                            },
+                        ]}
+                    />
+                )}
+
+                {selectedTools.length === 0 &&
+                    selectedKnowledgeBases.length === 0 &&
+                    selectedMcpServers.length === 0 && <Alert type="info">{emptyMessage}</Alert>}
+            </SpaceBetween>
+        </Container>
+    );
+}

--- a/lib/user-interface/react-app/src/pages/admin/agent-core-wizard-page.tsx
+++ b/lib/user-interface/react-app/src/pages/admin/agent-core-wizard-page.tsx
@@ -101,6 +101,7 @@ export default function AgentCoreWizardPage() {
                         agentName: fromAgentName,
                         architectureType: "AGENTS_AS_TOOLS",
                         agentsAsToolsConfig: rawConfig,
+                        useMemory: rawConfig.useMemory || false,
                         instructions: "",
                         tools: [],
                         toolParameters: {},
@@ -151,6 +152,10 @@ export default function AgentCoreWizardPage() {
             } else if (architectureType === "AGENTS_AS_TOOLS" && agentsAsToolsConfig) {
                 // Clean the config: omit empty optional fields to match backend expectations
                 const cleanConfig: Record<string, any> = { ...agentsAsToolsConfig };
+                // Include useMemory from top-level config (it lives on config, not agentsAsToolsConfig)
+                if (config.useMemory) {
+                    cleanConfig.useMemory = true;
+                }
                 if (!cleanConfig.tools || cleanConfig.tools.length === 0) {
                     delete cleanConfig.tools;
                     delete cleanConfig.toolParameters;


### PR DESCRIPTION
Refactors the agent configuration wizard by removing sub-agent support from the single-agent architecture, extracting shared UI components into a reusable module, and adding `useMemory` support to the Agents-as-Tools configuration.

## Changes

### Added
- **Shared Wizard Components** (`wizard-shared-components.tsx`) — Extracted reusable `AgentConfigSection` and tool management UI into a new shared module (383 lines), eliminating duplication across wizard architectures
- **`useMemory` option** for Agents-as-Tools — New boolean flag on `AgentsAsToolsConfiguration` to create and attach AgentCore Memory to the runtime

### Removed
- **`InvokeSubAgentTool`** class and factory from `base_registry.py` (~120 lines) — Sub-agent invocation is no longer part of the single-agent architecture
- **`INVOKE_SUBAGENT_PREFIX`** constant from `base_constants.py`
- **Default `invoke_subagent` tool** from `toolRegistry` in `config.ts`
- Sub-agent configuration UI from `single-agent-steps.tsx`

### Modified
- **`single-agent-steps.tsx`** — Simplified by removing sub-agent support and consuming shared components (816 insertions/deletions net reduction)
- **`agents-as-tools-steps.tsx`** — Refactored to use shared components, added `useMemory` toggle
- **`agent-core-runtime-wizard.tsx`** — Cleaned up to delegate to shared components
- **`agent-core-wizard-page.tsx`** — Passes `useMemory` through to Agents-as-Tools config
- **`agentcore_runtime.tf`** — Added `null_resource.build_agent_image` to `depends_on` for correct Terraform ordering

## Commits

1. `d07e773` - 🔥 rm InvokeSubAgentTool from shared module
2. `062d0ee` - ♻️ extract tool management logic from wizard and clean defaults
3. `550c0a1` - 🔥 remove sub-agent support from single-agent wizard
4. `ec1a3c5` - ♻️ extract shared wizard components for agent configuration steps
5. `438aae6` - 🐛 add useMemory option to AgentsAsTools configuration

## Impact

- **Net reduction**: 1,121 deletions vs 718 additions = **~400 fewer lines of code**
- No breaking API changes — `useMemory` defaults to `false`, empty `toolRegistry` is backward-compatible
- Terraform dependency fix prevents race condition during runtime creation

## Breaking Changes

⚠️ The `invoke_subagent` tool is removed from the default config and backend. Existing deployments using sub-agent invocation in single-agent mode must migrate to the Agents-as-Tools architecture instead.

--


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
