### PR TITLE
⚰️ remove unused INVOKE_SUBAGENT_PREFIX constant and logic

### DIFF
--- a/lib/agent-core/shared/__init__.py
+++ b/lib/agent-core/shared/__init__.py
@@ -8,7 +8,6 @@
 from .agentcore_memory import create_session_manager
 from .base_callbacks import FormatCitations
 from .base_constants import (
-    INVOKE_SUBAGENT_PREFIX,
     RETRIEVE_FROM_KB_PREFIX,
     TOOL_DESCRIPTIONS,
 )
@@ -59,7 +58,6 @@ __all__ = [
     # Base callbacks
     "FormatCitations",
     # Base constants
-    "INVOKE_SUBAGENT_PREFIX",
     "RETRIEVE_FROM_KB_PREFIX",
     "TOOL_DESCRIPTIONS",
     # Bedrock Knowledge Base Types

--- a/lib/agent-core/shared/base_constants.py
+++ b/lib/agent-core/shared/base_constants.py
@@ -10,9 +10,7 @@
 RETRIEVE_FROM_KB_PREFIX = "retrieve_from_kb"
 
 # Tool descriptions for common tools
-TOOL_DESCRIPTIONS = {
-    # INVOKE_SUBAGENT_PREFIX: "Invoke a sub-agent to handle specialized tasks or domain-specific queries that require dedicated processing",
-}
+TOOL_DESCRIPTIONS = {}
 
 # DynamoDB scan limit for registry loading
 DYNAMODB_SCAN_LIMIT = 100

--- a/lib/agent-core/shared/base_factory.py
+++ b/lib/agent-core/shared/base_factory.py
@@ -17,7 +17,7 @@ from strands.agent.conversation_manager import (
 )
 from strands.models import BedrockModel
 
-from .base_constants import INVOKE_SUBAGENT_PREFIX, RETRIEVE_FROM_KB_PREFIX
+from .base_constants import RETRIEVE_FROM_KB_PREFIX
 
 if TYPE_CHECKING:
     from logging import Logger
@@ -119,7 +119,6 @@ class BaseAgentFactory:
 
     @staticmethod
     def initialize_kb_tool(
-        tool_name: str,
         params: dict,
         available_tools: dict,
         logger: Logger,
@@ -128,7 +127,6 @@ class BaseAgentFactory:
         """Initialize a Knowledge Base retrieval tool.
 
         Args:
-            tool_name (str): Name of the KB tool
             params (dict): Tool parameters containing kb_id and retrieval_cfg
             available_tools (dict): Registry of available tools
             logger (Logger): Logger instance
@@ -169,11 +167,8 @@ class BaseAgentFactory:
         Returns:
             Any: Initialized tool instance
         """
-        record = (
-            available_tools[tool_name]
-            if tool_name in available_tools
-            else available_tools[INVOKE_SUBAGENT_PREFIX]
-        )
+        record = available_tools[tool_name]
+
         tool_factory = record["factory"]
 
         context_msg = f" for {context_name}" if context_name else ""
@@ -236,18 +231,9 @@ class BaseAgentFactory:
                     params["retrieval_cfg"]
                 )
                 tool = BaseAgentFactory.initialize_kb_tool(
-                    tool_name, params, available_tools, logger, context_name
+                    params, available_tools, logger, context_name
                 )
                 initialized_tools.append(tool)
-
-            elif tool_name in available_tools or tool_name.startswith(
-                INVOKE_SUBAGENT_PREFIX
-            ):
-                tool = BaseAgentFactory.initialize_standard_tool(
-                    tool_name, params, available_tools, logger, context_name
-                )
-                initialized_tools.append(tool)
-
             else:
                 warning_msg = f"Unknown tool '{tool_name}'"
                 if context_name:


### PR DESCRIPTION
Remove the INVOKE_SUBAGENT_PREFIX constant and all associated sub-agent invocation handling from the shared module. This simplifies the tool initialization flow in BaseAgentFactory by:

- Removing INVOKE_SUBAGENT_PREFIX from constants, exports, and imports
- Removing the fallback lookup to INVOKE_SUBAGENT_PREFIX in initialize_standard_tool
- Removing the dedicated sub-agent tool branch in initialize_tools
- Dropping the unused tool_name parameter from initialize_kb_tool
- Cleaning up empty TOOL_DESCRIPTIONS dict

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
