### PR TITLE
✨ add reasoning budget support for thinking models

### DIFF
--- a/lib/agent-core/docker-agents-as-tools/src/factory.py
+++ b/lib/agent-core/docker-agents-as-tools/src/factory.py
@@ -55,6 +55,7 @@ def create_orchestrator(
         max_tokens=configuration.modelInferenceParameters.parameters.maxTokens,
         temperature=configuration.modelInferenceParameters.parameters.temperature,
         stop_sequences=configuration.modelInferenceParameters.parameters.stopSequences,
+        reasoning_budget=configuration.modelInferenceParameters.reasoningBudget,
         enable_caching=True,
     )
 

--- a/lib/agent-core/docker-swarm/src/factory.py
+++ b/lib/agent-core/docker-swarm/src/factory.py
@@ -133,6 +133,7 @@ def _create_agent_from_definition(
         max_tokens=agent_def.modelInferenceParameters.parameters.maxTokens,
         temperature=agent_def.modelInferenceParameters.parameters.temperature,
         stop_sequences=agent_def.modelInferenceParameters.parameters.stopSequences,
+        reasoning_budget=agent_def.modelInferenceParameters.reasoningBudget,
         enable_caching=True,
     )
     tools = _initialize_tools(agent_def, mcp_client_manager, logger)

--- a/lib/agent-core/docker/src/factory.py
+++ b/lib/agent-core/docker/src/factory.py
@@ -54,6 +54,7 @@ def create_agent(
         max_tokens=configuration.modelInferenceParameters.parameters.maxTokens,
         temperature=configuration.modelInferenceParameters.parameters.temperature,
         stop_sequences=configuration.modelInferenceParameters.parameters.stopSequences,
+        reasoning_budget=configuration.modelInferenceParameters.reasoningBudget,
         enable_caching=True,
     )
 

--- a/lib/agent-core/shared/base_factory.py
+++ b/lib/agent-core/shared/base_factory.py
@@ -18,9 +18,31 @@ from strands.agent.conversation_manager import (
 from strands.models import BedrockModel
 
 from .base_constants import RETRIEVE_FROM_KB_PREFIX
+from .stream_types import ReasoningEffort
 
 if TYPE_CHECKING:
     from logging import Logger
+
+# Models that require an integer reasoning budget (minimum 1024 tokens)
+_INT_BUDGET_MODELS_ANTHROPIC = {
+    "claude-opus-4-5",
+    "claude-opus-4",
+    "claude-sonnet-4",
+    "claude-sonnet-4-5",
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5",
+    "claude-3-7-sonnet",
+}
+
+# Models that require a ReasoningEffort enum value
+_EFFORT_BUDGET_MODELS_ANTHROPIC = {
+    "claude-sonnet-4-6",
+    "claude-opus-4-6",
+}
+
+_EFFORT_BUDGET_MODELS_NOVA = {
+    "nova-2-lite",
+}
 
 
 class BaseAgentFactory:
@@ -48,6 +70,8 @@ class BaseAgentFactory:
         "anthropic.claude-3-5-haiku-20241022-v1:0",
         "anthropic.claude-haiku-4-5-20251001-v1:0",
         "anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "anthropic.claude-opus-4-6-v1",
+        "anthropic.claude-sonnet-4-6",
     )
 
     @staticmethod
@@ -57,6 +81,7 @@ class BaseAgentFactory:
         temperature: float,
         stop_sequences: list[str] | None = None,
         enable_caching: bool = True,
+        reasoning_budget: ReasoningEffort | int | None = None,
     ) -> BedrockModel:
         """Create a BedrockModel instance with optional prompt caching.
 
@@ -88,6 +113,37 @@ class BaseAgentFactory:
         ):
             model_args["cache_prompt"] = "default"
 
+        if reasoning_budget is not None:
+            reasoning_cfg: dict = {"type": "enabled"}
+            reasoning_val = (
+                reasoning_budget.value
+                if isinstance(reasoning_budget, ReasoningEffort)
+                else reasoning_budget
+            )
+
+            set_additional_args = True
+            temp_add_args = {}
+            if any(m in model_id for m in _EFFORT_BUDGET_MODELS_ANTHROPIC):
+                reasoning_key = "thinking"
+                reasoning_cfg["type"] = "adaptive"
+                temp_add_args["output_config"] = {"effort": reasoning_val}
+                del model_args["temperature"]
+                # If thinking is enabled with Anthropic models, temperature cannot be set
+            elif any(m in model_id for m in _INT_BUDGET_MODELS_ANTHROPIC):
+                reasoning_key = "thinking"
+                reasoning_cfg["budget_tokens"] = reasoning_val
+                # If thinking is enabled with Anthropic models, temperature cannot be set
+                del model_args["temperature"]
+            elif any(m in model_id for m in _EFFORT_BUDGET_MODELS_NOVA):
+                reasoning_key = "reasoningConfig"
+                reasoning_cfg["maxReasoningEffort"] = reasoning_val
+            else:
+                set_additional_args = False
+
+            if set_additional_args:
+                model_args["additional_request_fields"] = temp_add_args | {
+                    reasoning_key: reasoning_cfg
+                }
         return BedrockModel(**model_args)
 
     @staticmethod

--- a/lib/agent-core/shared/stream_types.py
+++ b/lib/agent-core/shared/stream_types.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 
 class EStreamEvent(Enum):
@@ -69,16 +69,70 @@ class InferenceConfig(BaseModel):
     stopSequences: Optional[list[str]] = None
 
 
+class ReasoningEffort(Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+# Models that require an integer reasoning budget (minimum 1024 tokens)
+_INT_BUDGET_MODELS = {
+    "claude-opus-4-5",
+    "claude-opus-4",
+    "claude-sonnet-4",
+    "claude-sonnet-4-5",
+    "claude-haiku-4-5",
+    "claude-3-7-sonnet",
+}
+
+# Models that require a ReasoningEffort enum value
+_EFFORT_BUDGET_MODELS = {
+    "nova-2-lite",
+    "claude-opus-4-6",
+    "claude-sonnet-4-6",
+}
+
+
 class ModelConfiguration(BaseModel):
     """Configuration class for model inference settings.
 
     Attributes:
         modelId (str): Identifier for the model to be used
         parameters (InferenceConfig): Configuration parameters for model inference
+        reasoningBudget (Optional[int | ReasoningEffort]): budget reserved for model reasoning,
+            default to None, that means no reasoning enabled
     """
 
     modelId: str
     parameters: InferenceConfig
+    reasoningBudget: Optional[int | ReasoningEffort] = None
+
+    @model_validator(mode="after")
+    def validate_reasoning_budget(self) -> "ModelConfiguration":
+        if self.reasoningBudget is None:
+            return self
+
+        # Check effort models FIRST — their fragments are more specific
+        # (e.g., "claude-opus-4-6" would otherwise match the broader "claude-opus-4")
+        uses_effort = any(m in self.modelId for m in _EFFORT_BUDGET_MODELS)
+        uses_int = any(m in self.modelId for m in _INT_BUDGET_MODELS)
+
+        if uses_effort:
+            if not isinstance(self.reasoningBudget, ReasoningEffort):
+                raise ValueError(
+                    f"reasoningBudget must be a ReasoningEffort value for model '{self.modelId}'"
+                )
+        elif uses_int:
+            if not isinstance(self.reasoningBudget, int) or self.reasoningBudget < 1024:
+                raise ValueError(
+                    f"reasoningBudget must be an integer >= 1024 for model '{self.modelId}'"
+                )
+        else:
+            raise ValueError(
+                f"reasoningBudget is not supported for model '{self.modelId}'"
+            )
+
+        return self
 
 
 class Token(BaseModel):

--- a/lib/shared/layers/python-sdk/genai_core/api_helper/types.py
+++ b/lib/shared/layers/python-sdk/genai_core/api_helper/types.py
@@ -197,10 +197,15 @@ class ModelConfiguration(BaseModel):
     Attributes:
         modelId (str): Identifier for the model to be used
         parameters (InferenceConfig): Configuration parameters for model inference
+        reasoningBudget (Optional[int | str]): Budget reserved for model reasoning.
+            An integer (min 1024) for token-budget models, or a string
+            ("low"/"medium"/"high") for effort-based models.
+            Default to None, meaning no reasoning enabled.
     """
 
     modelId: str
     parameters: InferenceConfig
+    reasoningBudget: Optional[int | str] = None
 
 
 class AgentConfiguration(BaseModel):

--- a/lib/user-interface/react-app/src/components/admin/agent-core/view-version-modal.tsx
+++ b/lib/user-interface/react-app/src/components/admin/agent-core/view-version-modal.tsx
@@ -11,6 +11,7 @@ import {
     Modal,
     Select,
     SpaceBetween,
+    StatusIndicator,
     Table,
     Textarea,
 } from "@cloudscape-design/components";
@@ -108,6 +109,43 @@ export default function ViewVersionModal({
         }
 
         return modelId; // fallback to showing the ID if no match found
+    };
+
+    const isThinkingEnabled = (reasoningBudget: number | string | null | undefined): boolean => {
+        return (
+            reasoningBudget !== undefined &&
+            reasoningBudget !== null &&
+            reasoningBudget !== "disabled" &&
+            reasoningBudget !== 0
+        );
+    };
+
+    const renderThinkingStatus = (reasoningBudget: number | string | null | undefined) => {
+        if (isThinkingEnabled(reasoningBudget)) {
+            const budgetLabel =
+                typeof reasoningBudget === "number"
+                    ? `${reasoningBudget} tokens`
+                    : String(reasoningBudget);
+            return (
+                <SpaceBetween direction="vertical" size="xxs">
+                    <StatusIndicator type="success">Enabled</StatusIndicator>
+                    <Box variant="awsui-key-label" display="inline">
+                        Budget:{" "}
+                        <Box display="inline" fontWeight="normal">
+                            {budgetLabel}
+                        </Box>
+                    </Box>
+                </SpaceBetween>
+            );
+        }
+        return <StatusIndicator type="stopped">Disabled</StatusIndicator>;
+    };
+
+    const renderMemoryStatus = (useMemory: boolean | undefined) => {
+        if (useMemory) {
+            return <StatusIndicator type="success">Attached</StatusIndicator>;
+        }
+        return <StatusIndicator type="stopped">Not attached</StatusIndicator>;
     };
 
     // Fetch available MCP servers when modal opens
@@ -290,6 +328,12 @@ export default function ViewVersionModal({
                                 <Box padding="m">{agentConfig.entryAgent}</Box>
                             </FormField>
 
+                            <FormField label="AgentCore Memory">
+                                <Box padding="m">
+                                    {renderMemoryStatus((agentConfig as any).useMemory)}
+                                </Box>
+                            </FormField>
+
                             {agentConfig.agents && agentConfig.agents.length > 0 && (
                                 <FormField label="Inline Agents">
                                     <Table
@@ -308,6 +352,15 @@ export default function ViewVersionModal({
                                                     getModelName(
                                                         item.modelInferenceParameters?.modelId ||
                                                             "",
+                                                    ),
+                                            },
+                                            {
+                                                id: "thinking",
+                                                header: "Thinking",
+                                                cell: (item: any) =>
+                                                    renderThinkingStatus(
+                                                        item.modelInferenceParameters
+                                                            ?.reasoningBudget,
                                                     ),
                                             },
                                             {
@@ -395,7 +448,7 @@ export default function ViewVersionModal({
                         <SpaceBetween direction="vertical" size="m">
                             <FormField label="Model Configuration">
                                 <Box padding="m">
-                                    <ColumnLayout columns={3} variant="text-grid">
+                                    <ColumnLayout columns={4} variant="text-grid">
                                         <div>
                                             <Box variant="awsui-key-label">Model</Box>
                                             <Box>
@@ -419,8 +472,21 @@ export default function ViewVersionModal({
                                                     ?.maxTokens ?? "N/A"}
                                             </Box>
                                         </div>
+                                        <div>
+                                            <Box variant="awsui-key-label">Thinking</Box>
+                                            <Box>
+                                                {renderThinkingStatus(
+                                                    agentConfig.modelInferenceParameters
+                                                        ?.reasoningBudget,
+                                                )}
+                                            </Box>
+                                        </div>
                                     </ColumnLayout>
                                 </Box>
+                            </FormField>
+
+                            <FormField label="AgentCore Memory">
+                                <Box padding="m">{renderMemoryStatus(agentConfig.useMemory)}</Box>
                             </FormField>
 
                             <FormField label="Orchestrator Instructions">
@@ -501,6 +567,12 @@ export default function ViewVersionModal({
                         <SpaceBetween direction="vertical" size="m">
                             <FormField label="Entry Point">
                                 <Box padding="m">{agentConfig.entryPoint}</Box>
+                            </FormField>
+
+                            <FormField label="AgentCore Memory">
+                                <Box padding="m">
+                                    {renderMemoryStatus((agentConfig as any).useMemory)}
+                                </Box>
                             </FormField>
 
                             {agentConfig.nodes && agentConfig.nodes.length > 0 && (
@@ -599,7 +671,7 @@ export default function ViewVersionModal({
                         <SpaceBetween direction="vertical" size="m">
                             <FormField label="Model Configuration">
                                 <Box padding="m">
-                                    <ColumnLayout columns={3} variant="text-grid">
+                                    <ColumnLayout columns={4} variant="text-grid">
                                         <div>
                                             <Box variant="awsui-key-label">Model</Box>
                                             <Box>
@@ -622,8 +694,21 @@ export default function ViewVersionModal({
                                                     .maxTokens ?? "N/A"}
                                             </Box>
                                         </div>
+                                        <div>
+                                            <Box variant="awsui-key-label">Thinking</Box>
+                                            <Box>
+                                                {renderThinkingStatus(
+                                                    agentConfig.modelInferenceParameters
+                                                        .reasoningBudget,
+                                                )}
+                                            </Box>
+                                        </div>
                                     </ColumnLayout>
                                 </Box>
+                            </FormField>
+
+                            <FormField label="AgentCore Memory">
+                                <Box padding="m">{renderMemoryStatus(agentConfig.useMemory)}</Box>
                             </FormField>
 
                             <FormField label="Agent Instructions">
@@ -689,6 +774,12 @@ export default function ViewVersionModal({
                                             },
                                         ]}
                                     />
+                                </FormField>
+                            )}
+
+                            {agentConfig.conversationManager && (
+                                <FormField label="Conversation Manager">
+                                    <Box padding="m">{agentConfig.conversationManager}</Box>
                                 </FormField>
                             )}
                         </SpaceBetween>

--- a/lib/user-interface/react-app/src/components/wizard/architectures/agents-as-tools-steps.tsx
+++ b/lib/user-interface/react-app/src/components/wizard/architectures/agents-as-tools-steps.tsx
@@ -23,7 +23,7 @@ import {
     AgentsAsToolsConfiguration,
 } from "../types";
 import { AdditionalToolsSection, AgentConfigSection } from "../wizard-shared-components";
-import { STEP_MIN_HEIGHT } from "../wizard-utils";
+import { STEP_MIN_HEIGHT, getReasoningType } from "../wizard-utils";
 
 export interface AgentsAsToolsStepsProps {
     config: AgentCoreRuntimeConfiguration;
@@ -434,13 +434,23 @@ export function getAgentsAsToolsSteps({
                             modelOptions={modelOptions}
                             modelId={agentsAsToolsConfig.modelInferenceParameters.modelId}
                             onModelChange={(modelId) =>
-                                setAgentsAsToolsConfig((prev) => ({
-                                    ...prev,
-                                    modelInferenceParameters: {
-                                        ...prev.modelInferenceParameters,
-                                        modelId,
-                                    },
-                                }))
+                                setAgentsAsToolsConfig((prev) => {
+                                    const newReasoningType = getReasoningType(modelId);
+                                    const oldReasoningType = getReasoningType(
+                                        prev.modelInferenceParameters.modelId,
+                                    );
+                                    const keepBudget =
+                                        newReasoningType !== null &&
+                                        newReasoningType === oldReasoningType;
+                                    return {
+                                        ...prev,
+                                        modelInferenceParameters: {
+                                            ...prev.modelInferenceParameters,
+                                            modelId,
+                                            ...(keepBudget ? {} : { reasoningBudget: undefined }),
+                                        },
+                                    };
+                                })
                             }
                             temperature={
                                 agentsAsToolsConfig.modelInferenceParameters.parameters.temperature
@@ -487,6 +497,18 @@ export function getAgentsAsToolsSteps({
                             useMemory={config.useMemory || false}
                             onUseMemoryChange={(useMemory) =>
                                 setConfig((prev) => ({ ...prev, useMemory }))
+                            }
+                            reasoningBudget={
+                                agentsAsToolsConfig.modelInferenceParameters.reasoningBudget
+                            }
+                            onReasoningBudgetChange={(reasoningBudget) =>
+                                setAgentsAsToolsConfig((prev) => ({
+                                    ...prev,
+                                    modelInferenceParameters: {
+                                        ...prev.modelInferenceParameters,
+                                        reasoningBudget,
+                                    },
+                                }))
                             }
                         />
 
@@ -611,7 +633,21 @@ export function isAgentsAsToolsStepValid(
     if (stepIndex === 1) {
         const hasModel = agentsAsToolsConfig.modelInferenceParameters.modelId.trim() !== "";
         const hasInstructions = agentsAsToolsConfig.instructions.trim() !== "";
-        return hasModel && hasInstructions;
+        if (!hasModel || !hasInstructions) return false;
+
+        // Validate reasoning budget if enabled
+        const budget = agentsAsToolsConfig.modelInferenceParameters.reasoningBudget;
+        if (budget !== undefined) {
+            const rType = getReasoningType(agentsAsToolsConfig.modelInferenceParameters.modelId);
+            if (rType === "int") {
+                return typeof budget === "number" && budget >= 1024;
+            }
+            if (rType === "effort") {
+                return typeof budget === "string" && ["low", "medium", "high"].includes(budget);
+            }
+            return false;
+        }
+        return true;
     }
 
     // Step 2: Review — always valid

--- a/lib/user-interface/react-app/src/components/wizard/architectures/single-agent-steps.tsx
+++ b/lib/user-interface/react-app/src/components/wizard/architectures/single-agent-steps.tsx
@@ -15,7 +15,7 @@ import {
 import { KnowledgeBase, McpServer, Tool } from "../../../API";
 import { AgentCoreRuntimeConfiguration } from "../types";
 import { AdditionalToolsSection, AgentConfigSection } from "../wizard-shared-components";
-import { STEP_MIN_HEIGHT } from "../wizard-utils";
+import { STEP_MIN_HEIGHT, getReasoningType } from "../wizard-utils";
 
 interface SingleAgentStepsProps {
     config: AgentCoreRuntimeConfiguration;
@@ -170,13 +170,24 @@ export function getSingleAgentSteps({
                             modelOptions={modelOptions}
                             modelId={config.modelInferenceParameters.modelId}
                             onModelChange={(modelId) =>
-                                setConfig((prev) => ({
-                                    ...prev,
-                                    modelInferenceParameters: {
-                                        ...prev.modelInferenceParameters,
-                                        modelId,
-                                    },
-                                }))
+                                setConfig((prev) => {
+                                    const newReasoningType = getReasoningType(modelId);
+                                    const oldReasoningType = getReasoningType(
+                                        prev.modelInferenceParameters.modelId,
+                                    );
+                                    // Clear reasoning budget if model type changed
+                                    const keepBudget =
+                                        newReasoningType !== null &&
+                                        newReasoningType === oldReasoningType;
+                                    return {
+                                        ...prev,
+                                        modelInferenceParameters: {
+                                            ...prev.modelInferenceParameters,
+                                            modelId,
+                                            ...(keepBudget ? {} : { reasoningBudget: undefined }),
+                                        },
+                                    };
+                                })
                             }
                             temperature={config.modelInferenceParameters.parameters.temperature}
                             onTemperatureChange={(temperature) =>
@@ -215,6 +226,16 @@ export function getSingleAgentSteps({
                             useMemory={config.useMemory || false}
                             onUseMemoryChange={(useMemory) =>
                                 setConfig((prev) => ({ ...prev, useMemory }))
+                            }
+                            reasoningBudget={config.modelInferenceParameters.reasoningBudget}
+                            onReasoningBudgetChange={(reasoningBudget) =>
+                                setConfig((prev) => ({
+                                    ...prev,
+                                    modelInferenceParameters: {
+                                        ...prev.modelInferenceParameters,
+                                        reasoningBudget,
+                                    },
+                                }))
                             }
                         />
                     </SpaceBetween>
@@ -292,12 +313,27 @@ export function isSingleAgentStepValid(
     // Step 0: Agent Configuration
     if (stepIndex === 0) {
         const agentNamePattern = /^[a-zA-Z][a-zA-Z0-9_]{0,47}$/;
-        return (
+        const basicValid =
             config.agentName.trim() !== "" &&
             agentNamePattern.test(config.agentName) &&
             config.instructions.trim() !== "" &&
-            config.modelInferenceParameters.modelId.trim() !== ""
-        );
+            config.modelInferenceParameters.modelId.trim() !== "";
+        if (!basicValid) return false;
+
+        // Validate reasoning budget if enabled
+        const budget = config.modelInferenceParameters.reasoningBudget;
+        if (budget !== undefined) {
+            const rType = getReasoningType(config.modelInferenceParameters.modelId);
+            if (rType === "int") {
+                return typeof budget === "number" && budget >= 1024;
+            }
+            if (rType === "effort") {
+                return typeof budget === "string" && ["low", "medium", "high"].includes(budget);
+            }
+            // Model doesn't support reasoning but budget is set — invalid
+            return false;
+        }
+        return true;
     }
     // Step 1: Additional Tools — always valid (optional)
     // Step 2: Review — always valid

--- a/lib/user-interface/react-app/src/components/wizard/types.ts
+++ b/lib/user-interface/react-app/src/components/wizard/types.ts
@@ -44,6 +44,7 @@ export interface AgentCoreRuntimeConfiguration {
             temperature: number;
             maxTokens: number;
         };
+        reasoningBudget?: number | string;
     };
     instructions: string;
     tools: string[];
@@ -72,6 +73,7 @@ export interface SwarmAgentDefinition {
     modelInferenceParameters: {
         modelId: string;
         parameters: { temperature: number; maxTokens: number };
+        reasoningBudget?: number | string;
     };
     tools: string[];
     toolParameters: { [toolName: string]: any };
@@ -136,6 +138,7 @@ export interface AgentsAsToolsConfiguration {
     modelInferenceParameters: {
         modelId: string;
         parameters: { temperature: number; maxTokens: number };
+        reasoningBudget?: number | string;
     };
     instructions: string;
     tools?: string[];

--- a/lib/user-interface/react-app/src/components/wizard/wizard-shared-components.tsx
+++ b/lib/user-interface/react-app/src/components/wizard/wizard-shared-components.tsx
@@ -17,7 +17,11 @@ import {
     Table,
     Textarea,
 } from "@cloudscape-design/components";
-import { CONVERSATION_MANAGER_OPTIONS } from "./wizard-utils";
+import {
+    CONVERSATION_MANAGER_OPTIONS,
+    REASONING_EFFORT_OPTIONS,
+    getReasoningType,
+} from "./wizard-utils";
 
 // -------------------------------------------------------------------
 // AgentConfigSection — Model, Instructions, Conversation Manager, Memory
@@ -40,6 +44,10 @@ export interface AgentConfigSectionProps {
     onConversationManagerChange: (value: "null" | "sliding_window" | "summarizing") => void;
     useMemory: boolean;
     onUseMemoryChange: (checked: boolean) => void;
+    /** Optional reasoning budget — integer (tokens) or string ("low"/"medium"/"high") */
+    reasoningBudget?: number | string;
+    /** Callback when reasoning budget changes; undefined means disabled */
+    onReasoningBudgetChange?: (value: number | string | undefined) => void;
 }
 
 export function AgentConfigSection({
@@ -58,28 +66,104 @@ export function AgentConfigSection({
     onConversationManagerChange,
     useMemory,
     onUseMemoryChange,
+    reasoningBudget,
+    onReasoningBudgetChange,
 }: AgentConfigSectionProps) {
+    const reasoningType = getReasoningType(modelId);
+    const reasoningEnabled = reasoningBudget != null;
+
     return (
         <SpaceBetween direction="vertical" size="l">
             <Container header={<Header variant="h2">Model &amp; Instructions</Header>}>
                 <SpaceBetween direction="vertical" size="l">
                     <ColumnLayout columns={2} variant="text-grid">
-                        <FormField
-                            label="Model"
-                            description={`Select the LLM model for the ${label.toLowerCase()}`}
-                        >
-                            <Select
-                                placeholder="Select a model..."
-                                options={modelOptions}
-                                selectedOption={
-                                    modelOptions.find((opt) => opt.value === modelId) || null
-                                }
-                                onChange={({ detail }) =>
-                                    onModelChange(detail.selectedOption?.value || "")
-                                }
-                                filteringType="auto"
-                            />
-                        </FormField>
+                        <SpaceBetween direction="vertical" size="s">
+                            <FormField
+                                label="Model"
+                                description={`Select the LLM model for the ${label.toLowerCase()}`}
+                            >
+                                <Select
+                                    placeholder="Select a model..."
+                                    options={modelOptions}
+                                    selectedOption={
+                                        modelOptions.find((opt) => opt.value === modelId) || null
+                                    }
+                                    onChange={({ detail }) =>
+                                        onModelChange(detail.selectedOption?.value || "")
+                                    }
+                                    filteringType="auto"
+                                />
+                            </FormField>
+
+                            {reasoningType && onReasoningBudgetChange && (
+                                <>
+                                    <Checkbox
+                                        checked={reasoningEnabled}
+                                        onChange={({ detail }) => {
+                                            if (detail.checked) {
+                                                onReasoningBudgetChange(
+                                                    reasoningType === "int" ? 1024 : "medium",
+                                                );
+                                            } else {
+                                                onReasoningBudgetChange(undefined);
+                                            }
+                                        }}
+                                    >
+                                        Enable extended thinking
+                                    </Checkbox>
+
+                                    {reasoningEnabled && reasoningType === "int" && (
+                                        <FormField
+                                            label="Reasoning Budget (tokens)"
+                                            description="Minimum 1024 tokens"
+                                            errorText={
+                                                typeof reasoningBudget === "number" &&
+                                                reasoningBudget < 1024
+                                                    ? "Budget must be at least 1024 tokens"
+                                                    : ""
+                                            }
+                                        >
+                                            <Input
+                                                type="number"
+                                                value={
+                                                    reasoningBudget != null
+                                                        ? reasoningBudget.toString()
+                                                        : ""
+                                                }
+                                                onChange={({ detail }) => {
+                                                    const val = parseInt(detail.value);
+                                                    if (!isNaN(val)) {
+                                                        onReasoningBudgetChange(val);
+                                                    }
+                                                }}
+                                                step={256}
+                                            />
+                                        </FormField>
+                                    )}
+
+                                    {reasoningEnabled && reasoningType === "effort" && (
+                                        <FormField
+                                            label="Reasoning Effort"
+                                            description="Select the reasoning effort level"
+                                        >
+                                            <Select
+                                                selectedOption={
+                                                    REASONING_EFFORT_OPTIONS.find(
+                                                        (opt) => opt.value === reasoningBudget,
+                                                    ) || null
+                                                }
+                                                onChange={({ detail }) =>
+                                                    onReasoningBudgetChange(
+                                                        detail.selectedOption?.value || "medium",
+                                                    )
+                                                }
+                                                options={REASONING_EFFORT_OPTIONS}
+                                            />
+                                        </FormField>
+                                    )}
+                                </>
+                            )}
+                        </SpaceBetween>
                         <SpaceBetween direction="vertical" size="s">
                             <FormField label="Temperature" description="Controls randomness (0-1)">
                                 <Input

--- a/lib/user-interface/react-app/src/components/wizard/wizard-utils.ts
+++ b/lib/user-interface/react-app/src/components/wizard/wizard-utils.ts
@@ -60,3 +60,44 @@ export const CONVERSATION_MANAGER_OPTIONS = [
 ];
 
 export const STEP_MIN_HEIGHT = "62vh";
+
+// ---------------------------------------------------------------------------
+// Reasoning budget helpers — keep in sync with backend _INT_BUDGET_MODELS /
+// _EFFORT_BUDGET_MODELS in stream_types.py
+// ---------------------------------------------------------------------------
+
+/** Models that require an integer reasoning budget (minimum 1024 tokens) */
+export const INT_BUDGET_MODEL_FRAGMENTS = [
+    "claude-opus-4-5",
+    "claude-opus-4",
+    "claude-sonnet-4",
+    "claude-sonnet-4-5",
+    "claude-haiku-4-5",
+    "claude-3-7-sonnet",
+];
+
+/** Models that require a ReasoningEffort enum value (low / medium / high) */
+export const EFFORT_BUDGET_MODEL_FRAGMENTS = [
+    "nova-2-lite",
+    "claude-opus-4-6",
+    "claude-sonnet-4-6",
+];
+
+export const REASONING_EFFORT_OPTIONS = [
+    { label: "Low", value: "low" },
+    { label: "Medium", value: "medium" },
+    { label: "High", value: "high" },
+];
+
+/**
+ * Determine what kind of reasoning budget a model supports.
+ * Returns "int" for token-budget models, "effort" for low/medium/high models,
+ * or null if the model does not support reasoning.
+ */
+export function getReasoningType(modelId: string): "int" | "effort" | null {
+    // Check effort models FIRST — their fragments are more specific
+    // (e.g., "claude-opus-4-6" would otherwise match the broader "claude-opus-4")
+    if (EFFORT_BUDGET_MODEL_FRAGMENTS.some((frag) => modelId.includes(frag))) return "effort";
+    if (INT_BUDGET_MODEL_FRAGMENTS.some((frag) => modelId.includes(frag))) return "int";
+    return null;
+}


### PR DESCRIPTION

*Description of changes:* Introduce configurable reasoning budget parameter across all agent factory types to enable extended thinking capabilities for supported models.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
