### PR TITLE
✨ Add support for external MCP servers with UI-based registration

### DIFF
--- a/docs/src/expanding-ai-tools.md
+++ b/docs/src/expanding-ai-tools.md
@@ -90,7 +90,125 @@ The system automatically constructs the full MCP URL during CDK deployment:
 - **Gateway**: `https://{gatewayId}.gateway.bedrock-agentcore.{region}.amazonaws.com/mcp`
 
 
+#### Registering MCP Servers via the UI
+
+In addition to the `config.yaml` approach above, you can register MCP servers directly from the UI. You can either use the **MCP Server Registry** page (accessible from the AgentCore Manager via the "Manage MCPs" button) or click **"Register new MCP server"** in the Additional Tools section of the Agent Factory wizard.
+
+Every server requires:
+- **Name** — unique identifier (alphanumeric, hyphens, underscores, max 64 chars)
+- **Auth Type** — how the agent runtime authenticates to the server
+
+**Authentication types:**
+
+| Auth Type | Description | Use When |
+|-----------|-------------|----------|
+| **SigV4** | AWS IAM Signature V4 authentication | Server is hosted on AWS (AgentCore Runtime or Gateway) — **recommended** |
+| **None**  | No authentication — requests sent without credentials | Server is a trusted, public, read-only endpoint |
+
+**Fields by auth type:**
+
+| Field | SigV4 | None |
+|-------|-------|------|
+| **Name** | ✅ Required | ✅ Required |
+| **Hosting type** (Runtime / Gateway) | ✅ Required | — |
+| **Runtime ID** | ✅ Required (if Runtime) | — |
+| **Qualifier** | Optional, defaults to `DEFAULT` (if Runtime) | — |
+| **Gateway ID** | ✅ Required (if Gateway) | — |
+| **Endpoint URL** | Auto-constructed from IDs | ✅ Required (`https://` prefix) |
+| **Description** | Optional | Optional |
+
+> **Note:** When using SigV4 authentication, you do **not** provide a URL directly. Instead, you provide the Runtime ID or Gateway ID and the system automatically constructs the full MCP endpoint URL (same as the `config.yaml` approach).
+
+**Example — AgentCore Runtime MCP Server (AuthType: SigV4):**
+
+- **Name:** `my-runtime-mcp`
+- **Auth Type:** SigV4
+- **Hosting type:** AgentCore Runtime
+- **Runtime ID:** `mcp_server_iam-abcd9876`
+- **Qualifier:** `DEFAULT` *(optional)*
+- **Description:** Custom MCP server deployed on AgentCore Runtime
+
+**Example — AgentCore Gateway MCP Server (AuthType: SigV4):**
+
+- **Name:** `my-gateway-mcp`
+- **Auth Type:** SigV4
+- **Hosting type:** AgentCore Gateway
+- **Gateway ID:** `test-xywz1234`
+- **Description:** Custom MCP server deployed on AgentCore Gateway
+
+**Example — AWS Knowledge MCP Server (AuthType: NONE):**
+
+The [AWS Knowledge MCP Server](https://github.com/awslabs/mcp/tree/main/src/aws-knowledge-mcp-server) is a read-only MCP server that provides access to AWS documentation, regional availability data, and content recommendations. Since it only exposes read-only public data, it can be registered with `AuthType: NONE`:
+
+- **Name:** `aws-knowledge`
+- **URL:** `https://knowledge-mcp.global.api.aws`
+- **Auth Type:** NONE
+- **Description:** AWS documentation search, regional availability, and content recommendations
+
+> **⚠️ Security considerations for AuthType: NONE**
+>
+> Registering a server with no authentication means the agent runtime will send requests **without any credentials**. Only use `NONE` for servers that:
+>
+> - Expose **read-only** data you trust (documentation, public datasets, weather, exchange rates)
+> - Do **not** have write access to databases, cloud resources, or internal APIs
+> - Are endpoints you **control** or **explicitly trust**
+>
+> Misconfigured MCP servers exposed without authentication have been [found in the wild](https://www.trendmicro.com/en_us/research/25/d/mcp-security.html) with write access to sensitive resources. **Always prefer SigV4 authentication when the server supports it.**
+
+
+#### Sample Agent Instructions for AWS Knowledge MCP
+
+Once the AWS Knowledge MCP server is registered (see example above), create a **single agent** in the Agent Factory with the following instructions to test it end-to-end.
+
+**Recommended settings:**
+- **Model:** Nova 2 Lite (or Sonnet 4.6 for more detailed answers)
+- **Temperature:** 0.2
+- **Max Tokens:** 3000
+- **MCP Servers:** select `aws-knowledge` in the Additional Tools step
+
+**Agent instructions (paste into the Instructions field):**
+
+```
+You are an AWS Solutions Architect assistant with access to the official AWS documentation through the AWS Knowledge MCP server.
+
+When a user asks about AWS services, features, configurations, or best practices:
+
+1. ALWAYS use the aws___search_documentation tool first to find relevant, up-to-date information. Choose the appropriate topic(s):
+   - "general" for architecture, best practices, tutorials
+   - "reference_documentation" for API/SDK/CLI details
+   - "troubleshooting" for errors and debugging
+   - "current_awareness" for new features and announcements
+   - "cdk_docs" or "cdk_constructs" for CDK questions
+   - "cloudformation" for CloudFormation templates
+
+2. If the search results reference a specific documentation page, use aws___read_documentation to fetch the full content for detailed answers.
+
+3. Use aws___recommend to suggest related documentation the user might find helpful.
+
+4. For region-specific questions, use aws___get_regional_availability to check service availability.
+
+Your responses should:
+- Cite the documentation URL for every claim
+- Include code examples when available from the docs
+- Be concise but thorough
+- Clearly distinguish between what the docs say vs. your general knowledge
+- If the docs don't cover something, say so explicitly
+
+Never make up AWS service limits, pricing, or feature availability — always verify via the tools.
+```
+
+**Test prompts to try:**
+- *"What are the best practices for S3 bucket security?"*
+- *"How do I set up a Lambda function with a DynamoDB trigger using CDK in TypeScript?"*
+- *"Is Amazon Bedrock available in eu-west-1?"*
+- *"What's new with Amazon ECS in 2025?"*
+- *"I'm getting an AccessDenied error on S3 GetObject, how do I fix it?"*
+
+
 ### Function-Based Tools
+
+> **ℹ️ Note:** The recommended way to add tools to agents is through **MCP servers** (see above). Function-based and object-based tools are a legacy approach kept for quick prototyping. For production workloads, prefer MCP-based tools.
+
 Simple tools implemented as decorated Python functions:
 
 ```python

--- a/lib/agent-core/functions/mcp-seeder/index.py
+++ b/lib/agent-core/functions/mcp-seeder/index.py
@@ -38,11 +38,15 @@ def compose_mcp_url(server: dict) -> str:
     """Compose the MCP URL for a server at runtime with resolved region/account.
 
     Args:
-        server: Server config dict with name, description, and either runtimeId or gatewayId
+        server: Server config dict with name, description, and either runtimeId, gatewayId, or url
 
     Returns:
         The composed MCP URL endpoint
     """
+    # Direct URL — for external/public Streamable HTTP servers
+    if "url" in server and server["url"]:
+        return server["url"]
+
     qualifier = server.get("qualifier", "DEFAULT")
 
     if "runtimeId" in server and server["runtimeId"]:
@@ -75,6 +79,7 @@ def transform_server_for_db(server: dict) -> dict:
             "McpServerName": server["McpServerName"],
             "McpUrl": server.get("McpUrl", ""),
             "Description": server.get("Description", ""),
+            "AuthType": server.get("AuthType", "SIGV4"),
         }
 
     # New format - need to compose URL
@@ -82,6 +87,7 @@ def transform_server_for_db(server: dict) -> dict:
         "McpServerName": server["name"],
         "McpUrl": compose_mcp_url(server),
         "Description": server.get("description", ""),
+        "AuthType": server.get("authType", "SIGV4"),
     }
 
 
@@ -288,6 +294,10 @@ def _validate_server(raw_server: dict) -> bool:
     Returns:
         True if the resource exists, False otherwise
     """
+    # Direct URL — no AgentCore validation needed for external servers
+    if "url" in raw_server and raw_server["url"]:
+        return True
+
     qualifier = raw_server.get("qualifier", "DEFAULT")
 
     if "runtimeId" in raw_server and raw_server["runtimeId"]:
@@ -301,7 +311,7 @@ def _validate_server(raw_server: dict) -> bool:
         return True
 
     logger.warning(
-        "Server config missing both runtimeId and gatewayId",
+        "Server config missing runtimeId, gatewayId, and url",
         extra={"server": raw_server},
     )
     return False

--- a/lib/agent-core/functions/mcp-seeder/index.py
+++ b/lib/agent-core/functions/mcp-seeder/index.py
@@ -88,6 +88,7 @@ def transform_server_for_db(server: dict) -> dict:
         "McpUrl": compose_mcp_url(server),
         "Description": server.get("description", ""),
         "AuthType": server.get("authType", "SIGV4"),
+        "Source": "CDK",
     }
 
 

--- a/lib/agent-core/index.ts
+++ b/lib/agent-core/index.ts
@@ -173,6 +173,8 @@ export class AcaAgentCoreContainer extends Construct {
                         ...("runtimeId" in server && { runtimeId: server.runtimeId }),
                         ...("gatewayId" in server && { gatewayId: server.gatewayId }),
                         ...("qualifier" in server && { qualifier: server.qualifier }),
+                        ...("url" in server && { url: server.url }),
+                        ...("authType" in server && { authType: server.authType }),
                     })),
                 ),
                 configHash: mcpConfigHash, // Forces update when config changes

--- a/lib/agent-core/shared/base_registry.py
+++ b/lib/agent-core/shared/base_registry.py
@@ -545,12 +545,20 @@ def load_mcps_from_dynamodb(
             mcp_server_name = item.get("McpServerName", "")
             mcp_url = item.get("McpUrl", "")
 
-            # Optionally filter by region
-            if filter_by_region:
+            auth_type = item.get("AuthType", "SIGV4")
+
+            # Optionally filter by region (skip for external servers with no auth)
+            if filter_by_region and auth_type != "NONE":
                 if REGION_NAME and REGION_NAME in mcp_url:
-                    mcp_servers[mcp_server_name] = {"McpUrl": mcp_url}
+                    mcp_servers[mcp_server_name] = {
+                        "McpUrl": mcp_url,
+                        "AuthType": auth_type,
+                    }
             else:
-                mcp_servers[mcp_server_name] = {"McpUrl": mcp_url}
+                mcp_servers[mcp_server_name] = {
+                    "McpUrl": mcp_url,
+                    "AuthType": auth_type,
+                }
 
         # Check if there are more items to scan
         if "LastEvaluatedKey" not in response:

--- a/lib/agent-core/shared/mcp_client.py
+++ b/lib/agent-core/shared/mcp_client.py
@@ -9,6 +9,7 @@ import os
 from logging import Logger
 from typing import Any
 
+from mcp.client.streamable_http import streamablehttp_client
 from mcp_proxy_for_aws.client import aws_iam_streamablehttp_client
 from strands.tools.mcp.mcp_client import MCPClient
 
@@ -104,31 +105,40 @@ class MCPClientManager:
             )
 
         try:
-            mcp_url = available_mcps[mcp_server_name]["McpUrl"]
+            config = available_mcps[mcp_server_name]
+            mcp_url = config["McpUrl"]
+            auth_type = config.get("AuthType", "SIGV4")
+
             self.logger.info(
-                f"Initializing {mcp_server_name} MCP server with URL: {mcp_url}"
+                f"Initializing {mcp_server_name} MCP server with URL: {mcp_url}, AuthType: {auth_type}"
             )
 
-            region = os.environ.get("AWS_REGION")
-            if not region:
-                raise ValueError(
-                    "AWS_REGION environment variable is required for MCP client authentication"
+            if auth_type == "NONE":
+                # Plain Streamable HTTP — for public/external servers (no SigV4)
+                mcp_client = MCPClient(
+                    lambda url=mcp_url: streamablehttp_client(url=url),
+                    prefix=mcp_server_name,
                 )
+            else:
+                # IAM auth via mcp-proxy-for-aws for AgentCore-hosted servers
+                region = os.environ.get("AWS_REGION")
+                if not region:
+                    raise ValueError(
+                        "AWS_REGION environment variable is required for MCP client authentication"
+                    )
 
-            # Use mcp-proxy-for-aws for AWS IAM authentication
-            # Credentials are automatically refreshed for long-running processes
-            mcp_client = MCPClient(
-                lambda url=mcp_url, rgn=region: aws_iam_streamablehttp_client(
-                    endpoint=url,
-                    aws_region=rgn,
-                    aws_service="bedrock-agentcore",
-                ),
-                prefix=mcp_server_name,
-            )
+                mcp_client = MCPClient(
+                    lambda url=mcp_url, rgn=region: aws_iam_streamablehttp_client(
+                        endpoint=url,
+                        aws_region=rgn,
+                        aws_service="bedrock-agentcore",
+                    ),
+                    prefix=mcp_server_name,
+                )
 
             self.logger.info(
                 f"Initialized the MCP Server named [{mcp_server_name}]",
-                extra={"mcpUrl": mcp_url},
+                extra={"mcpUrl": mcp_url, "authType": auth_type},
             )
             return mcp_client
         except Exception as e:

--- a/lib/api/functions/http-api-handler/routes/ai_tools.py
+++ b/lib/api/functions/http-api-handler/routes/ai_tools.py
@@ -6,6 +6,7 @@
 import os
 import re
 from typing import Mapping, Sequence
+from urllib.parse import quote
 
 import boto3
 from aws_lambda_powertools import Logger, Tracer
@@ -20,9 +21,13 @@ logger = Logger(service="graphQL-strandsCfgRoute")
 # -------------------------------------------------------------------- #
 TOOL_TABLE = boto3.resource("dynamodb").Table(os.environ["TOOL_REGISTRY_TABLE"])  # type: ignore
 MCP_SERVER_TABLE = boto3.resource("dynamodb").Table(os.environ["MCP_SERVER_REGISTRY_TABLE"])  # type: ignore
+BEDROCK_AGENTCORE = boto3.client(
+    "bedrock-agentcore-control", region_name=os.environ["REGION_NAME"]
+)
 
 # ----------------------- Environment Variables ---------------------- #
 REGION_NAME = os.environ["REGION_NAME"]
+AWS_ACCOUNT_ID = os.environ["AWS_ACCOUNT_ID"]
 # -------------------------------------------------------------------- #
 
 # Valid MCP server name pattern: alphanumeric, hyphens, underscores
@@ -71,10 +76,61 @@ def list_mcp_servers(user_id: str) -> Sequence[Mapping]:
                     "mcpUrl": mcp_url,
                     "description": elem.get("Description", ""),
                     "authType": auth_type,
+                    "source": elem.get("Source", "CDK"),
                 }
             )
 
     return results
+
+
+# ---- URL Composition (mirrors mcp-seeder/index.py logic) ---- #
+def _compose_mcp_url(
+    *,
+    runtime_id: str | None = None,
+    gateway_id: str | None = None,
+    qualifier: str = "DEFAULT",
+    mcp_url: str | None = None,
+) -> str:
+    """Compose the MCP endpoint URL from runtimeId/gatewayId or pass-through a direct URL."""
+    if mcp_url:
+        return mcp_url
+
+    if runtime_id:
+        runtime_arn = f"arn:aws:bedrock-agentcore:{REGION_NAME}:{AWS_ACCOUNT_ID}:runtime/{runtime_id}"
+        encoded_arn = quote(runtime_arn, safe="")
+        return f"https://bedrock-agentcore.{REGION_NAME}.amazonaws.com/runtimes/{encoded_arn}/invocations?qualifier={qualifier}"
+
+    if gateway_id:
+        return f"https://{gateway_id}.gateway.bedrock-agentcore.{REGION_NAME}.amazonaws.com/mcp"
+
+    raise ValueError("Must provide runtimeId, gatewayId, or mcpUrl")
+
+
+def _validate_agentcore_resource(
+    runtime_id: str | None, gateway_id: str | None, qualifier: str
+) -> bool:
+    """Validate that the AgentCore runtime endpoint or gateway exists."""
+    try:
+        if runtime_id:
+            BEDROCK_AGENTCORE.get_agent_runtime_endpoint(
+                agentRuntimeId=runtime_id, endpointName=qualifier
+            )
+            return True
+        if gateway_id:
+            BEDROCK_AGENTCORE.get_gateway(gatewayIdentifier=gateway_id)
+            return True
+    except ClientError as err:
+        if err.response["Error"]["Code"] == "ResourceNotFoundException":
+            logger.warning(
+                "AgentCore resource not found",
+                extra={
+                    "runtimeId": runtime_id,
+                    "gatewayId": gateway_id,
+                },
+            )
+            return False
+        raise
+    return False
 
 
 # ---- Mutations ---- #
@@ -84,13 +140,21 @@ def list_mcp_servers(user_id: str) -> Sequence[Mapping]:
 def register_mcp_server(
     user_id: str,
     name: str,
-    mcpUrl: str,
     authType: str,
+    runtimeId: str | None = None,
+    gatewayId: str | None = None,
+    qualifier: str | None = None,
+    mcpUrl: str | None = None,
     description: str | None = None,
 ) -> Mapping:
     logger.info(
         f"User ID {user_id} is registering MCP server: {name}",
-        extra={"mcpUrl": mcpUrl, "authType": authType},
+        extra={
+            "authType": authType,
+            "runtimeId": runtimeId,
+            "gatewayId": gatewayId,
+            "mcpUrl": mcpUrl,
+        },
     )
 
     # Validate name
@@ -101,8 +165,32 @@ def register_mcp_server(
     if authType not in VALID_AUTH_TYPES:
         return {"id": name, "status": "INVALID_CONFIG"}
 
-    # Validate URL
-    if not mcpUrl.startswith("https://"):
+    effective_qualifier = qualifier or "DEFAULT"
+
+    # Auth-specific validation
+    if authType == "SIGV4":
+        # Must provide exactly one of runtimeId or gatewayId
+        if not runtimeId and not gatewayId:
+            return {"id": name, "status": "INVALID_CONFIG"}
+        if runtimeId and gatewayId:
+            return {"id": name, "status": "INVALID_CONFIG"}
+        # Validate the AgentCore resource exists
+        if not _validate_agentcore_resource(runtimeId, gatewayId, effective_qualifier):
+            return {"id": name, "status": "INVALID_CONFIG"}
+    elif authType == "NONE":
+        # Must provide a direct URL
+        if not mcpUrl or not mcpUrl.startswith("https://"):
+            return {"id": name, "status": "INVALID_CONFIG"}
+
+    try:
+        # Compose the final URL
+        computed_url = _compose_mcp_url(
+            runtime_id=runtimeId,
+            gateway_id=gatewayId,
+            qualifier=effective_qualifier,
+            mcp_url=mcpUrl if authType == "NONE" else None,
+        )
+    except ValueError:
         return {"id": name, "status": "INVALID_CONFIG"}
 
     try:
@@ -114,9 +202,10 @@ def register_mcp_server(
         MCP_SERVER_TABLE.put_item(
             Item={
                 "McpServerName": name,
-                "McpUrl": mcpUrl,
+                "McpUrl": computed_url,
                 "AuthType": authType,
                 "Description": description or "",
+                "Source": "UI",
             }
         )
         return {"id": name, "status": "SUCCESSFUL"}
@@ -132,6 +221,17 @@ def delete_mcp_server(user_id: str, name: str) -> Mapping:
     logger.info(f"User ID {user_id} is deleting MCP server: {name}")
 
     try:
+        # Only allow deletion of UI-registered servers
+        existing = MCP_SERVER_TABLE.get_item(Key={"McpServerName": name})
+        item = existing.get("Item")
+        if not item:
+            return {"id": name, "status": "INVALID_CONFIG"}
+
+        source = item.get("Source", "CDK")
+        if source != "UI":
+            logger.warning(f"Refusing to delete CDK-managed MCP server: {name}")
+            return {"id": name, "status": "INVALID_CONFIG"}
+
         MCP_SERVER_TABLE.delete_item(Key={"McpServerName": name})
         return {"id": name, "status": "SUCCESSFUL"}
     except ClientError as e:

--- a/lib/api/functions/http-api-handler/routes/ai_tools.py
+++ b/lib/api/functions/http-api-handler/routes/ai_tools.py
@@ -4,11 +4,13 @@
 # SPDX-License-Identifier: MIT-0
 # ---------------------------------------------------------------------------- #
 import os
+import re
 from typing import Mapping, Sequence
 
 import boto3
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler.graphql_appsync.router import Router
+from botocore.exceptions import ClientError
 from genai_core.api_helper.auth import fetch_user_id
 
 # ------------------------- Lambda Powertools ------------------------ #
@@ -22,6 +24,10 @@ MCP_SERVER_TABLE = boto3.resource("dynamodb").Table(os.environ["MCP_SERVER_REGIS
 # ----------------------- Environment Variables ---------------------- #
 REGION_NAME = os.environ["REGION_NAME"]
 # -------------------------------------------------------------------- #
+
+# Valid MCP server name pattern: alphanumeric, hyphens, underscores
+MCP_SERVER_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
+VALID_AUTH_TYPES = {"SIGV4", "NONE"}
 
 
 # ---- Queries ---- #
@@ -51,15 +57,83 @@ def list_mcp_servers(user_id: str) -> Sequence[Mapping]:
 
     response = MCP_SERVER_TABLE.scan(Limit=100)  # assuming no more than 100 MCP servers
 
-    return [
-        {
-            "name": elem.get("McpServerName", ""),
-            "mcpUrl": elem.get("McpUrl", ""),
-            "description": elem.get("Description", ""),
-        }
-        for elem in response.get("Items", [])
-        if REGION_NAME
-        in elem.get(
-            "McpUrl", ""
-        )  # only display mcp servers that are in the same region as the stack
-    ]
+    results = []
+    for elem in response.get("Items", []):
+        auth_type = elem.get("AuthType", "SIGV4")
+        mcp_url = elem.get("McpUrl", "")
+
+        # Show external servers (NONE auth) regardless of region;
+        # filter SigV4 servers to current region only
+        if auth_type == "NONE" or REGION_NAME in mcp_url:
+            results.append(
+                {
+                    "name": elem.get("McpServerName", ""),
+                    "mcpUrl": mcp_url,
+                    "description": elem.get("Description", ""),
+                    "authType": auth_type,
+                }
+            )
+
+    return results
+
+
+# ---- Mutations ---- #
+@router.resolver(field_name="registerMcpServer")
+@tracer.capture_method
+@fetch_user_id(router)
+def register_mcp_server(
+    user_id: str,
+    name: str,
+    mcpUrl: str,
+    authType: str,
+    description: str | None = None,
+) -> Mapping:
+    logger.info(
+        f"User ID {user_id} is registering MCP server: {name}",
+        extra={"mcpUrl": mcpUrl, "authType": authType},
+    )
+
+    # Validate name
+    if not MCP_SERVER_NAME_PATTERN.match(name):
+        return {"id": name, "status": "INVALID_NAME"}
+
+    # Validate auth type
+    if authType not in VALID_AUTH_TYPES:
+        return {"id": name, "status": "INVALID_CONFIG"}
+
+    # Validate URL
+    if not mcpUrl.startswith("https://"):
+        return {"id": name, "status": "INVALID_CONFIG"}
+
+    try:
+        # Check if already exists
+        existing = MCP_SERVER_TABLE.get_item(Key={"McpServerName": name})
+        if "Item" in existing:
+            return {"id": name, "status": "ALREADY_EXISTS"}
+
+        MCP_SERVER_TABLE.put_item(
+            Item={
+                "McpServerName": name,
+                "McpUrl": mcpUrl,
+                "AuthType": authType,
+                "Description": description or "",
+            }
+        )
+        return {"id": name, "status": "SUCCESSFUL"}
+    except ClientError as e:
+        logger.error(f"Failed to register MCP server: {e}")
+        return {"id": name, "status": "SERVICE_ERROR"}
+
+
+@router.resolver(field_name="deleteMcpServer")
+@tracer.capture_method
+@fetch_user_id(router)
+def delete_mcp_server(user_id: str, name: str) -> Mapping:
+    logger.info(f"User ID {user_id} is deleting MCP server: {name}")
+
+    try:
+        MCP_SERVER_TABLE.delete_item(Key={"McpServerName": name})
+        return {"id": name, "status": "SUCCESSFUL"}
+    except ClientError as e:
+        logger.error(f"Failed to delete MCP server: {e}")
+        return {"id": name, "status": "SERVICE_ERROR"}

--- a/lib/api/http-api-backend.ts
+++ b/lib/api/http-api-backend.ts
@@ -95,11 +95,18 @@ export class HttpApiBackend extends Construct {
         // when registering SigV4 MCP servers via the UI
         lambdaResolver.addToRolePolicy(
             new iam.PolicyStatement({
-                actions: [
-                    "bedrock-agentcore:GetAgentRuntimeEndpoint",
-                    "bedrock-agentcore:GetGateway",
+                actions: ["bedrock-agentcore:GetAgentRuntimeEndpoint"],
+                resources: [
+                    `arn:aws:bedrock-agentcore:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:runtime/*`,
                 ],
-                resources: ["*"],
+            }),
+        );
+        lambdaResolver.addToRolePolicy(
+            new iam.PolicyStatement({
+                actions: ["bedrock-agentcore:GetGateway"],
+                resources: [
+                    `arn:aws:bedrock-agentcore:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:gateway/*`,
+                ],
             }),
         );
 

--- a/lib/api/http-api-backend.ts
+++ b/lib/api/http-api-backend.ts
@@ -8,6 +8,7 @@ import * as cdk from "aws-cdk-lib";
 import * as appsync from "aws-cdk-lib/aws-appsync";
 import * as cognito from "aws-cdk-lib/aws-cognito";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+import * as iam from "aws-cdk-lib/aws-iam";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as logs from "aws-cdk-lib/aws-logs";
 import { NagSuppressions } from "cdk-nag";
@@ -65,6 +66,7 @@ export class HttpApiBackend extends Construct {
             TOOL_REGISTRY_TABLE: props.toolRegistryTable.tableName,
             MCP_SERVER_REGISTRY_TABLE: props.mcpServerRegistryTable.tableName,
             REGION_NAME: cdk.Aws.REGION,
+            AWS_ACCOUNT_ID: cdk.Aws.ACCOUNT_ID,
         };
 
         const lambdaResolver = new lambda.Function(this, "HttpApiResolver", {
@@ -88,6 +90,18 @@ export class HttpApiBackend extends Construct {
         props.experimentsTable.grantReadWriteData(lambdaResolver);
         props.toolRegistryTable.grantReadData(lambdaResolver);
         props.mcpServerRegistryTable.grantReadWriteData(lambdaResolver);
+
+        // Allow Lambda to validate AgentCore runtime endpoints and gateways
+        // when registering SigV4 MCP servers via the UI
+        lambdaResolver.addToRolePolicy(
+            new iam.PolicyStatement({
+                actions: [
+                    "bedrock-agentcore:GetAgentRuntimeEndpoint",
+                    "bedrock-agentcore:GetGateway",
+                ],
+                resources: ["*"],
+            }),
+        );
 
         const schema = parse(readFileSync("lib/api/schema/schema.graphql", "utf8"));
 

--- a/lib/api/http-api-backend.ts
+++ b/lib/api/http-api-backend.ts
@@ -87,7 +87,7 @@ export class HttpApiBackend extends Construct {
         props.favoriteRuntimeTable.grantReadWriteData(lambdaResolver);
         props.experimentsTable.grantReadWriteData(lambdaResolver);
         props.toolRegistryTable.grantReadData(lambdaResolver);
-        props.mcpServerRegistryTable.grantReadData(lambdaResolver);
+        props.mcpServerRegistryTable.grantReadWriteData(lambdaResolver);
 
         const schema = parse(readFileSync("lib/api/schema/schema.graphql", "utf8"));
 

--- a/lib/api/schema/schema.graphql
+++ b/lib/api/schema/schema.graphql
@@ -86,10 +86,16 @@ type Tool @aws_cognito_user_pools {
     invokesSubAgent: Boolean!
 }
 
+enum McpAuthType {
+    SIGV4
+    NONE
+}
+
 type McpServer @aws_cognito_user_pools {
     name: String!
     mcpUrl: String!
     description: String!
+    authType: McpAuthType!
 }
 
 type RuntimeSummary @aws_cognito_user_pools {
@@ -232,6 +238,9 @@ type Mutation {
     deleteEvaluator(evaluatorId: ID!): Boolean @aws_cognito_user_pools
     runEvaluation(evaluatorId: ID!): Evaluator @aws_cognito_user_pools
     publishEvaluationUpdate(evaluatorId: String!, status: String!): EvaluationNotification @aws_iam
+    # MCP Server Registry
+    registerMcpServer(name: String!, mcpUrl: String!, authType: McpAuthType!, description: String): AdminOpsResult @aws_cognito_user_pools
+    deleteMcpServer(name: String!): AdminOpsResult @aws_cognito_user_pools
     # Experiments
     createExperiment(name: String!, description: String, generationConfig: String!, modelId: String!): String! @aws_cognito_user_pools
     updateExperiment(experimentId: String!, name: String, description: String, status: ExperimentStatus): Boolean @aws_cognito_user_pools

--- a/lib/api/schema/schema.graphql
+++ b/lib/api/schema/schema.graphql
@@ -96,6 +96,7 @@ type McpServer @aws_cognito_user_pools {
     mcpUrl: String!
     description: String!
     authType: McpAuthType!
+    source: String!
 }
 
 type RuntimeSummary @aws_cognito_user_pools {
@@ -239,7 +240,7 @@ type Mutation {
     runEvaluation(evaluatorId: ID!): Evaluator @aws_cognito_user_pools
     publishEvaluationUpdate(evaluatorId: String!, status: String!): EvaluationNotification @aws_iam
     # MCP Server Registry
-    registerMcpServer(name: String!, mcpUrl: String!, authType: McpAuthType!, description: String): AdminOpsResult @aws_cognito_user_pools
+    registerMcpServer(name: String!, authType: McpAuthType!, runtimeId: String, gatewayId: String, qualifier: String, mcpUrl: String, description: String): AdminOpsResult @aws_cognito_user_pools
     deleteMcpServer(name: String!): AdminOpsResult @aws_cognito_user_pools
     # Experiments
     createExperiment(name: String!, description: String, generationConfig: String!, modelId: String!): String! @aws_cognito_user_pools

--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -190,11 +190,26 @@ interface McpServerGateway extends McpServerBase {
 }
 
 /**
+ * MCP server configuration for direct URL-based servers (e.g. public Streamable HTTP endpoints).
+ * @property url - The direct Streamable HTTP endpoint URL
+ * @property authType - Authentication type: "SIGV4" for IAM auth, "NONE" for unauthenticated
+ */
+interface McpServerUrl extends McpServerBase {
+    url: string;
+    authType: "SIGV4" | "NONE";
+    runtimeId?: never;
+    gatewayId?: never;
+}
+
+/**
  * Union type for MCP server configuration.
  * MCP servers provide external capabilities and resources to agents.
- * Must specify exactly one of runtimeId (for AgentCore Runtime) or gatewayId (for AgentCore Gateway).
+ * Must specify exactly one of:
+ * - runtimeId (for AgentCore Runtime)
+ * - gatewayId (for AgentCore Gateway)
+ * - url (for direct Streamable HTTP endpoint)
  */
-export type McpServer = McpServerRuntime | McpServerGateway;
+export type McpServer = McpServerRuntime | McpServerGateway | McpServerUrl;
 
 /**
  * Interface defining configuration properties for the ingestion Lambda function.

--- a/lib/user-interface/react-app/src/API.ts
+++ b/lib/user-interface/react-app/src/API.ts
@@ -105,6 +105,12 @@ export type EvaluationNotification = {
   status?: string | null,
 };
 
+export enum McpAuthType {
+  SIGV4 = "SIGV4",
+  NONE = "NONE",
+}
+
+
 export enum ExperimentStatus {
   DRAFT = "DRAFT",
   RUNNING = "RUNNING",
@@ -201,6 +207,8 @@ export type McpServer = {
   name: string,
   mcpUrl: string,
   description: string,
+  authType: McpAuthType,
+  source: string,
 };
 
 export type RuntimeSummary = {
@@ -578,6 +586,36 @@ export type PublishEvaluationUpdateMutation = {
   } | null,
 };
 
+export type RegisterMcpServerMutationVariables = {
+  name: string,
+  authType: McpAuthType,
+  runtimeId?: string | null,
+  gatewayId?: string | null,
+  qualifier?: string | null,
+  mcpUrl?: string | null,
+  description?: string | null,
+};
+
+export type RegisterMcpServerMutation = {
+  registerMcpServer?:  {
+    __typename: "AdminOpsResult",
+    id?: string | null,
+    status: ResponseStatus,
+  } | null,
+};
+
+export type DeleteMcpServerMutationVariables = {
+  name: string,
+};
+
+export type DeleteMcpServerMutation = {
+  deleteMcpServer?:  {
+    __typename: "AdminOpsResult",
+    id?: string | null,
+    status: ResponseStatus,
+  } | null,
+};
+
 export type CreateExperimentMutationVariables = {
   name: string,
   description?: string | null,
@@ -815,6 +853,8 @@ export type ListAvailableMcpServersQuery = {
     name: string,
     mcpUrl: string,
     description: string,
+    authType: McpAuthType,
+    source: string,
   } > | null,
 };
 

--- a/lib/user-interface/react-app/src/app.tsx
+++ b/lib/user-interface/react-app/src/app.tsx
@@ -18,6 +18,7 @@ import EvaluationsManagerPage from "./pages/admin/evaluations-manager";
 import EvaluationsWizardPage from "./pages/admin/evaluations-wizard-page";
 import ExperimentsManagerPage from "./pages/admin/experiments-manager";
 import KnowledgeBaseManagerPage from "./pages/admin/kb-manager";
+import McpServerManagerPage from "./pages/admin/mcp-server-manager-page";
 import SessionPage from "./pages/chatbot/sessions";
 
 function App() {
@@ -37,6 +38,7 @@ function App() {
                         <Route path="/knowledgebase" element={<KnowledgeBaseManagerPage />} />
                         <Route path="/agent-core" element={<AgentCoreManagerPage />} />
                         <Route path="/agent-core/create" element={<AgentCoreWizardPage />} />
+                        <Route path="/agent-core/mcp-servers" element={<McpServerManagerPage />} />
                         <Route path="/evaluations" element={<EvaluationsManagerPage />} />
                         <Route path="/evaluations/create" element={<EvaluationsWizardPage />} />
                         <Route path="/experiments" element={<ExperimentsManagerPage />} />

--- a/lib/user-interface/react-app/src/components/admin/agent-core-runtime-manager.tsx
+++ b/lib/user-interface/react-app/src/components/admin/agent-core-runtime-manager.tsx
@@ -583,6 +583,13 @@ export default function AgentCoreEndpointManager(props: AgentManagerProps) {
                                         Refresh
                                     </Button>
                                     <Button
+                                        iconName="settings"
+                                        variant="inline-link"
+                                        onClick={() => navigate("/agent-core/mcp-servers")}
+                                    >
+                                        Manage MCPs
+                                    </Button>
+                                    <Button
                                         disabled={
                                             selectedItems.length !== 1 ||
                                             selectedItems[0].status.toLowerCase() !== "ready"

--- a/lib/user-interface/react-app/src/components/admin/agent-core/mcp-server-manager.tsx
+++ b/lib/user-interface/react-app/src/components/admin/agent-core/mcp-server-manager.tsx
@@ -1,0 +1,289 @@
+// -----------------------------------------------------------------------
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: MIT-0
+// -----------------------------------------------------------------------
+import {
+    Box,
+    Button,
+    Container,
+    Header,
+    Popover,
+    SpaceBetween,
+    StatusIndicator,
+    Table,
+} from "@cloudscape-design/components";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { generateClient } from "aws-amplify/api";
+import { McpServer, ResponseStatus } from "../../../API";
+import { deleteMcpServer as deleteMcpServerMutation } from "../../../graphql/mutations";
+import {
+    getRuntimeConfigurationByVersion as getRuntimeConfigurationByVersionQuery,
+    listAgentVersions as listAgentVersionsQuery,
+    listAvailableMcpServers as listAvailableMcpServersQuery,
+    listRuntimeAgents as listRuntimeAgentsQuery,
+} from "../../../graphql/queries";
+import { RegisterMcpServerModal } from "../../wizard/register-mcp-server-modal";
+
+export interface McpServerManagerProps {
+    readonly toolsOpen: boolean;
+}
+
+interface McpServerWithUsage extends McpServer {
+    usedByAgents: string[];
+}
+
+export default function McpServerManager(_props: McpServerManagerProps) {
+    const navigate = useNavigate();
+    const apiClient = useMemo(() => generateClient(), []);
+
+    const [mcpServers, setMcpServers] = useState<McpServerWithUsage[]>([]);
+    const [isLoading, setIsLoading] = useState(false);
+    const [isDeleting, setIsDeleting] = useState<string | null>(null);
+    const [showRegisterModal, setShowRegisterModal] = useState(false);
+
+    const fetchMcpServersWithUsage = useCallback(async () => {
+        setIsLoading(true);
+        try {
+            // Fetch MCP servers and agents in parallel
+            const [mcpResult, agentsResult] = await Promise.all([
+                apiClient.graphql({ query: listAvailableMcpServersQuery }),
+                apiClient.graphql({ query: listRuntimeAgentsQuery }),
+            ]);
+
+            const servers = mcpResult.data?.listAvailableMcpServers || [];
+            const agents = agentsResult.data?.listRuntimeAgents || [];
+
+            // Build usage map: for each agent, fetch latest config and extract mcpServers
+            const usageMap: Record<string, string[]> = {};
+            servers.forEach((s) => {
+                usageMap[s.name] = [];
+            });
+
+            // For each agent, get the latest version's config
+            await Promise.all(
+                agents
+                    .filter((a) => a.status?.toLowerCase() === "ready")
+                    .map(async (agent) => {
+                        try {
+                            const versionsResult = await apiClient.graphql({
+                                query: listAgentVersionsQuery,
+                                variables: { agentRuntimeId: agent.agentRuntimeId },
+                            });
+                            const versions = (versionsResult.data?.listAgentVersions || [])
+                                .filter((v): v is string => v !== null)
+                                .sort((a, b) => parseInt(b) - parseInt(a));
+
+                            if (versions.length === 0) return;
+
+                            const configResult = await apiClient.graphql({
+                                query: getRuntimeConfigurationByVersionQuery,
+                                variables: {
+                                    agentName: agent.agentName,
+                                    agentVersion: versions[0],
+                                },
+                            });
+
+                            const config = JSON.parse(
+                                configResult.data?.getRuntimeConfigurationByVersion || "{}",
+                            );
+                            const agentMcps: string[] = config.mcpServers || [];
+
+                            agentMcps.forEach((mcpName) => {
+                                if (usageMap[mcpName]) {
+                                    usageMap[mcpName].push(agent.agentName);
+                                }
+                            });
+                        } catch {
+                            // Skip agents we can't read config for
+                        }
+                    }),
+            );
+
+            const serversWithUsage: McpServerWithUsage[] = servers.map((s) => ({
+                ...s,
+                usedByAgents: usageMap[s.name] || [],
+            }));
+
+            setMcpServers(serversWithUsage);
+        } catch (error) {
+            console.error("Failed to fetch MCP servers:", error);
+        } finally {
+            setIsLoading(false);
+        }
+    }, [apiClient]);
+
+    useEffect(() => {
+        fetchMcpServersWithUsage();
+    }, [fetchMcpServersWithUsage]);
+
+    const handleDelete = async (serverName: string) => {
+        setIsDeleting(serverName);
+        try {
+            const result = await apiClient.graphql({
+                query: deleteMcpServerMutation,
+                variables: { name: serverName },
+            });
+            if (result.data?.deleteMcpServer?.status === ResponseStatus.SUCCESSFUL) {
+                await fetchMcpServersWithUsage();
+            }
+        } catch (error) {
+            console.error("Failed to delete MCP server:", error);
+        } finally {
+            setIsDeleting(null);
+        }
+    };
+
+    return (
+        <>
+            <Container header="MCP Server Registry">
+                <Table
+                    items={mcpServers}
+                    loading={isLoading}
+                    loadingText="Loading MCP servers..."
+                    stickyHeader
+                    resizableColumns
+                    header={
+                        <Header
+                            variant="awsui-h1-sticky"
+                            description="Register, view, and manage MCP servers. Agents can connect to these servers for additional tools."
+                            actions={
+                                <SpaceBetween direction="horizontal" size="s">
+                                    <Button
+                                        iconName="add-plus"
+                                        variant="inline-link"
+                                        onClick={() => setShowRegisterModal(true)}
+                                    >
+                                        Register MCP Server
+                                    </Button>
+                                    <Button
+                                        iconName="refresh"
+                                        variant="inline-link"
+                                        onClick={fetchMcpServersWithUsage}
+                                    >
+                                        Refresh
+                                    </Button>
+                                    <Button
+                                        iconName="arrow-left"
+                                        variant="inline-link"
+                                        onClick={() => navigate("/agent-core")}
+                                    >
+                                        Go back
+                                    </Button>
+                                </SpaceBetween>
+                            }
+                        >
+                            MCP Servers ({mcpServers.length})
+                        </Header>
+                    }
+                    empty={
+                        <Box textAlign="center" color="inherit" padding="l">
+                            <Box variant="strong">No MCP servers registered</Box>
+                            <Box variant="p" padding={{ bottom: "s" }}>
+                                Register an MCP server to make it available for agents.
+                            </Box>
+                            <Button onClick={() => setShowRegisterModal(true)}>
+                                Register MCP Server
+                            </Button>
+                        </Box>
+                    }
+                    columnDefinitions={[
+                        {
+                            id: "name",
+                            header: "Name",
+                            cell: (item) => (
+                                <Popover
+                                    header="Endpoint URL"
+                                    content={
+                                        <Box
+                                            fontSize="body-s"
+                                            color="text-body-secondary"
+                                            variant="code"
+                                        >
+                                            {item.mcpUrl}
+                                        </Box>
+                                    }
+                                    dismissButton={false}
+                                    position="right"
+                                    size="large"
+                                >
+                                    <strong style={{ cursor: "pointer" }}>{item.name}</strong>
+                                </Popover>
+                            ),
+                            isRowHeader: true,
+                            width: 220,
+                        },
+                        {
+                            id: "authType",
+                            header: "Auth",
+                            cell: (item) => (
+                                <StatusIndicator
+                                    type={item.authType === "SIGV4" ? "success" : "info"}
+                                >
+                                    {item.authType === "SIGV4" ? "IAM (SigV4)" : "None"}
+                                </StatusIndicator>
+                            ),
+                            width: 120,
+                        },
+                        {
+                            id: "source",
+                            header: "Source",
+                            cell: (item) =>
+                                item.source === "UI" ? "Registered (UI)" : "Config (Admin)",
+                            width: 170,
+                        },
+                        {
+                            id: "description",
+                            header: "Description",
+                            cell: (item) => (
+                                <span style={{ whiteSpace: "pre-wrap" }}>
+                                    {item.description || "—"}
+                                </span>
+                            ),
+                            width: 280,
+                        },
+                        {
+                            id: "usedBy",
+                            header: "Used By Agents",
+                            cell: (item) =>
+                                item.usedByAgents.length > 0 ? item.usedByAgents.join(", ") : "—",
+                            width: 200,
+                        },
+                        {
+                            id: "actions",
+                            header: "Actions",
+                            cell: (item) =>
+                                item.source === "UI" ? (
+                                    <Button
+                                        variant="inline-link"
+                                        iconName="remove"
+                                        loading={isDeleting === item.name}
+                                        disabled={item.usedByAgents.length > 0}
+                                        onClick={() => handleDelete(item.name)}
+                                    >
+                                        Delete
+                                    </Button>
+                                ) : (
+                                    <Box color="text-status-inactive" fontSize="body-s">
+                                        Managed by Admin
+                                    </Box>
+                                ),
+                            width: 140,
+                        },
+                    ]}
+                />
+            </Container>
+
+            <RegisterMcpServerModal
+                visible={showRegisterModal}
+                onDismiss={() => setShowRegisterModal(false)}
+                onSuccess={() => {
+                    setShowRegisterModal(false);
+                    fetchMcpServersWithUsage();
+                }}
+            />
+        </>
+    );
+}

--- a/lib/user-interface/react-app/src/components/wizard/register-mcp-server-modal.tsx
+++ b/lib/user-interface/react-app/src/components/wizard/register-mcp-server-modal.tsx
@@ -1,0 +1,318 @@
+// ----------------------------------------------------------------------
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: MIT-0
+// ----------------------------------------------------------------------
+import {
+    Alert,
+    Box,
+    Button,
+    FormField,
+    Input,
+    Modal,
+    RadioGroup,
+    Select,
+    SpaceBetween,
+    Textarea,
+} from "@cloudscape-design/components";
+import { generateClient } from "aws-amplify/api";
+import { useContext, useState } from "react";
+import { McpAuthType, ResponseStatus } from "../../API";
+import { AppContext } from "../../common/app-context";
+import { registerMcpServer as registerMcpServerMutation } from "../../graphql/mutations";
+
+const AUTH_TYPE_OPTIONS = [
+    { label: "SigV4 (IAM auth) — recommended", value: McpAuthType.SIGV4 },
+    { label: "None (public endpoint)", value: McpAuthType.NONE },
+];
+
+type HostingType = "runtime" | "gateway";
+
+export interface RegisterMcpServerModalProps {
+    visible: boolean;
+    onDismiss: () => void;
+    onSuccess: () => void;
+}
+
+export function RegisterMcpServerModal({
+    visible,
+    onDismiss,
+    onSuccess,
+}: RegisterMcpServerModalProps) {
+    const appContext = useContext(AppContext);
+    const [name, setName] = useState("");
+    const [authType, setAuthType] = useState(AUTH_TYPE_OPTIONS[0]);
+    const [hostingType, setHostingType] = useState<HostingType>("runtime");
+    const [runtimeId, setRuntimeId] = useState("");
+    const [gatewayId, setGatewayId] = useState("");
+    const [qualifier, setQualifier] = useState("");
+    const [url, setUrl] = useState("");
+    const [description, setDescription] = useState("");
+    const [submitting, setSubmitting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const apiClient = generateClient();
+
+    const nameValid = /^[a-zA-Z0-9_-]{1,64}$/.test(name);
+    const isSigV4 = authType.value === McpAuthType.SIGV4;
+    const isNone = authType.value === McpAuthType.NONE;
+
+    // Validation
+    const sigv4Valid =
+        isSigV4 &&
+        ((hostingType === "runtime" && runtimeId.trim().length > 0) ||
+            (hostingType === "gateway" && gatewayId.trim().length > 0));
+    const noneValid = isNone && url.startsWith("https://");
+    const canSubmit = nameValid && (sigv4Valid || noneValid) && !submitting;
+
+    const resetForm = () => {
+        setName("");
+        setAuthType(AUTH_TYPE_OPTIONS[0]);
+        setHostingType("runtime");
+        setRuntimeId("");
+        setGatewayId("");
+        setQualifier("");
+        setUrl("");
+        setDescription("");
+        setError(null);
+    };
+
+    const handleDismiss = () => {
+        resetForm();
+        onDismiss();
+    };
+
+    const handleSubmit = async () => {
+        if (!appContext || !canSubmit) return;
+        setSubmitting(true);
+        setError(null);
+
+        try {
+            const result = await apiClient.graphql({
+                query: registerMcpServerMutation,
+                variables: {
+                    name,
+                    authType: authType.value as McpAuthType,
+                    description: description || undefined,
+                    runtimeId: isSigV4 && hostingType === "runtime" ? runtimeId.trim() : undefined,
+                    gatewayId: isSigV4 && hostingType === "gateway" ? gatewayId.trim() : undefined,
+                    qualifier:
+                        isSigV4 && hostingType === "runtime" && qualifier.trim()
+                            ? qualifier.trim()
+                            : undefined,
+                    mcpUrl: isNone ? url : undefined,
+                },
+            });
+
+            const status = result.data?.registerMcpServer?.status;
+            if (status === ResponseStatus.SUCCESSFUL) {
+                resetForm();
+                onSuccess();
+            } else if (status === ResponseStatus.ALREADY_EXISTS) {
+                setError(`An MCP server named "${name}" already exists.`);
+            } else if (status === ResponseStatus.INVALID_NAME) {
+                setError(
+                    "Invalid server name. Use only letters, numbers, hyphens, and underscores (max 64 chars).",
+                );
+            } else if (status === ResponseStatus.INVALID_CONFIG) {
+                setError(
+                    isSigV4
+                        ? "Invalid configuration. The AgentCore runtime or gateway was not found. Please verify the ID and try again."
+                        : "Invalid configuration. URL must start with https://.",
+                );
+            } else {
+                setError(`Registration failed with status: ${status}`);
+            }
+        } catch (e: unknown) {
+            if (e instanceof Error) {
+                setError(`Error: ${e.message}`);
+            } else if (
+                typeof e === "object" &&
+                e !== null &&
+                "errors" in e &&
+                Array.isArray((e as { errors: { message: string }[] }).errors)
+            ) {
+                const messages = (e as { errors: { message: string }[] }).errors
+                    .map((err) => err.message)
+                    .join("; ");
+                setError(`Error: ${messages}`);
+            } else {
+                setError(`Error: ${JSON.stringify(e)}`);
+            }
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    return (
+        <Modal
+            visible={visible}
+            onDismiss={handleDismiss}
+            header="Register MCP Server"
+            footer={
+                <Box float="right">
+                    <SpaceBetween direction="horizontal" size="xs">
+                        <Button variant="link" onClick={handleDismiss}>
+                            Cancel
+                        </Button>
+                        <Button
+                            variant="primary"
+                            onClick={handleSubmit}
+                            loading={submitting}
+                            disabled={!canSubmit}
+                        >
+                            Register
+                        </Button>
+                    </SpaceBetween>
+                </Box>
+            }
+        >
+            <SpaceBetween size="l">
+                {error && <Alert type="error">{error}</Alert>}
+
+                <FormField
+                    label="Server name"
+                    description="Unique identifier (alphanumeric, hyphens, underscores, max 64 chars)"
+                    errorText={name.length > 0 && !nameValid ? "Invalid name format" : undefined}
+                >
+                    <Input
+                        value={name}
+                        onChange={({ detail }) => setName(detail.value)}
+                        placeholder="my-mcp-server"
+                    />
+                </FormField>
+
+                <FormField
+                    label="Authentication type"
+                    description="How the agent runtime authenticates to this server"
+                >
+                    <Select
+                        selectedOption={authType}
+                        options={AUTH_TYPE_OPTIONS}
+                        onChange={({ detail }) =>
+                            setAuthType(detail.selectedOption as typeof authType)
+                        }
+                    />
+                </FormField>
+
+                {/* ---- SigV4 fields ---- */}
+                {isSigV4 && (
+                    <>
+                        <FormField label="Hosting type">
+                            <RadioGroup
+                                value={hostingType}
+                                onChange={({ detail }) =>
+                                    setHostingType(detail.value as HostingType)
+                                }
+                                items={[
+                                    {
+                                        value: "runtime",
+                                        label: "AgentCore Runtime",
+                                        description:
+                                            "MCP server hosted on Bedrock AgentCore Runtime",
+                                    },
+                                    {
+                                        value: "gateway",
+                                        label: "AgentCore Gateway",
+                                        description:
+                                            "MCP server hosted on Bedrock AgentCore Gateway",
+                                    },
+                                ]}
+                            />
+                        </FormField>
+
+                        {hostingType === "runtime" && (
+                            <>
+                                <FormField
+                                    label="Runtime ID"
+                                    description="The runtime identifier from your AgentCore deployment (e.g. mcp_server_iam-abcd9876)"
+                                    errorText={
+                                        runtimeId.length > 0 && runtimeId.trim().length === 0
+                                            ? "Runtime ID is required"
+                                            : undefined
+                                    }
+                                >
+                                    <Input
+                                        value={runtimeId}
+                                        onChange={({ detail }) => setRuntimeId(detail.value)}
+                                        placeholder="mcp_server_iam-abcd9876"
+                                    />
+                                </FormField>
+                                <FormField
+                                    label="Qualifier (optional)"
+                                    description='Endpoint qualifier, defaults to "DEFAULT" if not specified'
+                                >
+                                    <Input
+                                        value={qualifier}
+                                        onChange={({ detail }) => setQualifier(detail.value)}
+                                        placeholder="DEFAULT"
+                                    />
+                                </FormField>
+                            </>
+                        )}
+
+                        {hostingType === "gateway" && (
+                            <FormField
+                                label="Gateway ID"
+                                description="The gateway identifier from your AgentCore deployment (e.g. test-xywz1234)"
+                                errorText={
+                                    gatewayId.length > 0 && gatewayId.trim().length === 0
+                                        ? "Gateway ID is required"
+                                        : undefined
+                                }
+                            >
+                                <Input
+                                    value={gatewayId}
+                                    onChange={({ detail }) => setGatewayId(detail.value)}
+                                    placeholder="test-xywz1234"
+                                />
+                            </FormField>
+                        )}
+                    </>
+                )}
+
+                {/* ---- NONE fields ---- */}
+                {isNone && (
+                    <>
+                        <Alert type="warning">
+                            <strong>No authentication</strong> — the agent will connect to this
+                            server without credentials. Only use this for trusted, read-only
+                            endpoints (e.g., public documentation servers like the AWS Knowledge MCP
+                            Server, weather data, or package registries). Do not register
+                            unauthenticated servers that have write access to databases, cloud
+                            resources, or internal APIs.
+                        </Alert>
+
+                        <FormField
+                            label="Endpoint URL"
+                            description="Streamable HTTP endpoint (must start with https://)"
+                            errorText={
+                                url.length > 0 && !url.startsWith("https://")
+                                    ? "URL must start with https://"
+                                    : undefined
+                            }
+                        >
+                            <Input
+                                value={url}
+                                onChange={({ detail }) => setUrl(detail.value)}
+                                placeholder="https://knowledge-mcp.global.api.aws"
+                            />
+                        </FormField>
+                    </>
+                )}
+
+                <FormField
+                    label="Description"
+                    description="Optional description of the server's capabilities"
+                >
+                    <Textarea
+                        value={description}
+                        onChange={({ detail }) => setDescription(detail.value)}
+                        placeholder="Provides weather data tools..."
+                        rows={2}
+                    />
+                </FormField>
+            </SpaceBetween>
+        </Modal>
+    );
+}

--- a/lib/user-interface/react-app/src/components/wizard/wizard-shared-components.tsx
+++ b/lib/user-interface/react-app/src/components/wizard/wizard-shared-components.tsx
@@ -309,7 +309,7 @@ export function AdditionalToolsSection({
     onRemoveMcpServer,
     onConfigureKnowledgeBase,
     title = "Additional Tools (Optional)",
-    description = "Optionally add tools, knowledge bases, and MCP servers to extend capabilities",
+    description = "Optionally add tools, knowledge bases, and MCP servers to extend capabilities. Use 'Manage MCPs' on the AgentCore Manager page to register or delete MCP servers.",
     emptyMessage = "No tools configured yet. Use the dropdowns above to add tools, knowledge bases, or MCP servers.",
 }: AdditionalToolsSectionProps) {
     const columnCount = [hasCustomTools, knowledgeBaseIsSupported, hasMcpServers].filter(
@@ -451,6 +451,7 @@ export function AdditionalToolsSection({
                                         variant="icon"
                                         iconName="close"
                                         onClick={() => onRemoveMcpServer(item.name)}
+                                        ariaLabel="Remove from agent"
                                     />
                                 ),
                             },

--- a/lib/user-interface/react-app/src/graphql/mutations.ts
+++ b/lib/user-interface/react-app/src/graphql/mutations.ts
@@ -377,6 +377,44 @@ export const publishEvaluationUpdate = /* GraphQL */ `mutation PublishEvaluation
   APITypes.PublishEvaluationUpdateMutationVariables,
   APITypes.PublishEvaluationUpdateMutation
 >;
+export const registerMcpServer = /* GraphQL */ `mutation RegisterMcpServer(
+  $name: String!
+  $authType: McpAuthType!
+  $runtimeId: String
+  $gatewayId: String
+  $qualifier: String
+  $mcpUrl: String
+  $description: String
+) {
+  registerMcpServer(
+    name: $name
+    authType: $authType
+    runtimeId: $runtimeId
+    gatewayId: $gatewayId
+    qualifier: $qualifier
+    mcpUrl: $mcpUrl
+    description: $description
+  ) {
+    id
+    status
+    __typename
+  }
+}
+` as GeneratedMutation<
+  APITypes.RegisterMcpServerMutationVariables,
+  APITypes.RegisterMcpServerMutation
+>;
+export const deleteMcpServer = /* GraphQL */ `mutation DeleteMcpServer($name: String!) {
+  deleteMcpServer(name: $name) {
+    id
+    status
+    __typename
+  }
+}
+` as GeneratedMutation<
+  APITypes.DeleteMcpServerMutationVariables,
+  APITypes.DeleteMcpServerMutation
+>;
 export const createExperiment = /* GraphQL */ `mutation CreateExperiment(
   $name: String!
   $description: String

--- a/lib/user-interface/react-app/src/graphql/queries.ts
+++ b/lib/user-interface/react-app/src/graphql/queries.ts
@@ -169,6 +169,8 @@ export const listAvailableMcpServers = /* GraphQL */ `query ListAvailableMcpServ
     name
     mcpUrl
     description
+    authType
+    source
     __typename
   }
 }

--- a/lib/user-interface/react-app/src/pages/admin/mcp-server-manager-page.tsx
+++ b/lib/user-interface/react-app/src/pages/admin/mcp-server-manager-page.tsx
@@ -1,0 +1,92 @@
+// -----------------------------------------------------------------------
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: MIT-0
+// -----------------------------------------------------------------------
+import { BreadcrumbGroup, Header, HelpPanel, SpaceBetween } from "@cloudscape-design/components";
+import { useState } from "react";
+import { CHATBOT_NAME } from "../../common/constants";
+import useOnFollow from "../../common/hooks/use-on-follow";
+import McpServerManager from "../../components/admin/agent-core/mcp-server-manager";
+import BaseAppLayout from "../../components/base-app-layout";
+
+export default function McpServerManagerPage() {
+    const [toolsOpen, setToolsOpen] = useState(false);
+    const onFollow = useOnFollow();
+
+    return (
+        <BaseAppLayout
+            contentType="table"
+            toolsOpen={toolsOpen}
+            onToolsChange={(e) => setToolsOpen(e.detail.open)}
+            breadcrumbs={
+                <BreadcrumbGroup
+                    onFollow={onFollow}
+                    items={[
+                        {
+                            text: CHATBOT_NAME,
+                            href: "/",
+                        },
+                        {
+                            text: "AgentCore Manager",
+                            href: "/agent-core",
+                        },
+                        {
+                            text: "MCP Servers",
+                            href: "/agent-core/mcp-servers",
+                        },
+                    ]}
+                />
+            }
+            info={
+                <HelpPanel header={<Header variant="h3">MCP Server Registry</Header>}>
+                    <SpaceBetween direction="vertical" size="l">
+                        <div>
+                            <h4>Overview</h4>
+                            <p>
+                                MCP (Model Context Protocol) servers provide additional tools and
+                                capabilities that agents can use during conversations.
+                            </p>
+                        </div>
+                        <div>
+                            <h4>Actions</h4>
+                            <ul>
+                                <li>
+                                    <strong>Register</strong> — Add a new MCP server (AgentCore
+                                    Runtime, Gateway, or public endpoint)
+                                </li>
+                                <li>
+                                    <strong>Delete</strong> — Remove a UI-registered server (only if
+                                    not in use by any agent)
+                                </li>
+                                <li>
+                                    <strong>Used By</strong> — Shows which agents reference each
+                                    server in their latest configuration
+                                </li>
+                            </ul>
+                        </div>
+                        <div>
+                            <h4>Tips</h4>
+                            <ul>
+                                <li>
+                                    Use SigV4 authentication for AgentCore-hosted servers (Runtime
+                                    or Gateway)
+                                </li>
+                                <li>
+                                    Only use &quot;None&quot; auth for trusted, read-only public
+                                    endpoints
+                                </li>
+                                <li>
+                                    CDK-managed servers cannot be deleted from the UI — update your
+                                    infrastructure config instead
+                                </li>
+                            </ul>
+                        </div>
+                    </SpaceBetween>
+                </HelpPanel>
+            }
+            toolsWidth={300}
+            content={<McpServerManager toolsOpen={toolsOpen} />}
+        />
+    );
+}

--- a/uv.lock
+++ b/uv.lock
@@ -23,6 +23,7 @@ dev = [
     { name = "ipykernel" },
     { name = "isort" },
     { name = "langgraph" },
+    { name = "mcp-proxy-for-aws" },
     { name = "opensearch-py" },
     { name = "pre-commit" },
     { name = "pydantic" },
@@ -45,6 +46,7 @@ dev = [
     { name = "ipykernel", specifier = ">=6.29.5" },
     { name = "isort", specifier = ">=5.13.2" },
     { name = "langgraph", specifier = ">=1.0.10" },
+    { name = "mcp-proxy-for-aws", specifier = ">=1.1.6" },
     { name = "opensearch-py", specifier = ">=2.8.0" },
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pydantic", specifier = ">=2.10.5" },
@@ -166,6 +168,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -233,6 +244,18 @@ wheels = [
 ]
 
 [[package]]
+name = "authlib"
+version = "1.6.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/98/00d3dd826d46959ad8e32af2dbb2398868fd9fd0683c26e56d0789bd0e68/authlib-1.6.9.tar.gz", hash = "sha256:d8f2421e7e5980cc1ddb4e32d3f5fa659cfaf60d8eaf3281ebed192e4ab74f04", size = 165134, upload-time = "2026-03-02T07:44:01.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/23/b65f568ed0c22f1efacb744d2db1a33c8068f384b8c9b482b52ebdbc3ef6/authlib-1.6.9-py2.py3-none-any.whl", hash = "sha256:f08b4c14e08f0861dc18a32357b33fbcfd2ea86cfe3fe149484b4d764c4a0ac3", size = 244197, upload-time = "2026-03-02T07:44:00.307Z" },
+]
+
+[[package]]
 name = "aws-lambda-powertools"
 version = "3.22.0"
 source = { registry = "https://pypi.org/simple" }
@@ -255,6 +278,28 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/54/b2/455c0bfcbd772dafd4c9e93c4b713e36790abf9ccbca9b8e661968b29798/aws-requests-auth-0.4.3.tar.gz", hash = "sha256:33593372018b960a31dbbe236f89421678b885c35f0b6a7abfae35bb77e069b2", size = 10096, upload-time = "2020-05-27T23:10:34.742Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/11/5dc8be418e1d54bed15eaf3a7461797e5ebb9e6a34869ad750561f35fa5b/aws_requests_auth-0.4.3-py2.py3-none-any.whl", hash = "sha256:646bc37d62140ea1c709d20148f5d43197e6bd2d63909eb36fa4bb2345759977", size = 6838, upload-time = "2020-05-27T23:10:33.658Z" },
+]
+
+[[package]]
+name = "awscrt"
+version = "0.29.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/90/f985002a50859ea39841e66bc816c224b623c03f943b34bfe08fee17165c/awscrt-0.29.2.tar.gz", hash = "sha256:c78d81b1308d42fda1eb21d27fcf26579137b821043e528550f2cfc6c09ab9ff", size = 38013553, upload-time = "2025-12-04T00:16:36.777Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/7f/9d7b3d3f72369f80730ee5a0e964a1cd6ccf83d8c117a4d1df629e3ed6f9/awscrt-0.29.2-cp311-abi3-macosx_10_15_universal2.whl", hash = "sha256:3ff819a542acc5f11c46223204362c6b065031df0e4a37bf1ce2fc233a7145e4", size = 3407922, upload-time = "2025-12-04T00:15:49.071Z" },
+    { url = "https://files.pythonhosted.org/packages/17/f2/3e61a4683ff8e9bc59871214e833bf3f67e9f08b1884aae9e1166ef06ac3/awscrt-0.29.2-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:aa3d2f7fc0218a04707384afd871a8c3e97251185038eb921ae2fae4f61b7d90", size = 3817179, upload-time = "2025-12-04T00:15:50.965Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/13/a7366b0465b998b1d05f8b3a05e5897a431ec101b9a389be6058fbbe5e26/awscrt-0.29.2-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4f86d5a1a3c6d817dc0087d4e25abae1a7a1dd678d31fbcd226a15515719bdac", size = 4091388, upload-time = "2025-12-04T00:15:52.182Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/90/a34b1b29612d91baad1273ea1d4e31ab3a90e2db4e516345329fecfbaeb2/awscrt-0.29.2-cp311-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:a6451a730c961b73b57dccdcf8599bf8058740053b531d3724efbf3a89e2d191", size = 3719628, upload-time = "2025-12-04T00:15:53.356Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/94/2d93803e93cff7da0f5c9b6422b9f919d86db83640cdfbae569bdf22e606/awscrt-0.29.2-cp311-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:66a82b0960d281e14e7bfb95e9d6934cbc8e949b3f3e829709736b14bf0e6760", size = 3945694, upload-time = "2025-12-04T00:15:54.879Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/26/e2517fe8eb2f565ba52274a59f301bc6fac25494e0d28b6257fde237190a/awscrt-0.29.2-cp311-abi3-win32.whl", hash = "sha256:c1c243a7d7b9ed9c1e10acfb44eaab81b88eec24b50915ce3db45a8ffa4f2edb", size = 3959540, upload-time = "2025-12-04T00:15:57.138Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/49/bc9f3bcf2d49c58b97dd357f617c8331c1be02e5907316eb0ac39096941d/awscrt-0.29.2-cp311-abi3-win_amd64.whl", hash = "sha256:cd7349596f8f7b05805e047d29bfceb2304f5f0277fe0088e13ea8fe41ac3064", size = 4092749, upload-time = "2025-12-04T00:15:58.414Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/41/a564e4537c8e56259d9a9a86239d6b89448a742a5a5769b8cb81e2db7b26/awscrt-0.29.2-cp313-abi3-macosx_10_15_universal2.whl", hash = "sha256:2377b9adf0db47fcf74ad6c89afcd901f6cf97f24ba4f0e5e352f5ffe12affef", size = 3406616, upload-time = "2025-12-04T00:15:59.966Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/f2/4f88475ea7a9e4954871ebe188bfc9b5d29a60e1101e50a984afde904c3b/awscrt-0.29.2-cp313-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e0cb67ce813577679dab7ab56cc8bb16a546328589db87a55f7b52314f54504f", size = 3809168, upload-time = "2025-12-04T00:16:01.288Z" },
+    { url = "https://files.pythonhosted.org/packages/22/6f/f08b3b646198d9a5fb45bc411e6a102ec976efc4acc34c01ac86cf557216/awscrt-0.29.2-cp313-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cb7d44ed31baeb1b5720674a0249f48d8d6e548ea544ddfb93000b6bff559f34", size = 4084414, upload-time = "2025-12-04T00:16:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/40/fd45b53bfc5486a31080a767947396f717534dde0ace1c9ee48b96c079b9/awscrt-0.29.2-cp313-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:e455776fd0a04929c586a66e590c6eb6f2ca08b96ec13323bfb087ee17fd6e99", size = 3710752, upload-time = "2025-12-04T00:16:04.777Z" },
+    { url = "https://files.pythonhosted.org/packages/53/25/179278c03b84e09332ef4a7770878b93b43f10564b6a94a82faa8d9329e6/awscrt-0.29.2-cp313-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:70fd197fe83b78c25c2c57293466808df6f63287a480984834b4af7b9d18d4c0", size = 3939687, upload-time = "2025-12-04T00:16:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/5c/8330d3f8f5f080a85dc79c376c7125f24579dfb9c4e200224292062a36bb/awscrt-0.29.2-cp313-abi3-win32.whl", hash = "sha256:b3c46e4808ce7cfb6a63878e45b30b3410f5c314e352396d1210380787cafee2", size = 3954574, upload-time = "2025-12-04T00:16:07.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/8f/630f3083d07a75e258aae67c0d06c7ed69098d4ca85550e9cd344d3f613d/awscrt-0.29.2-cp313-abi3-win_amd64.whl", hash = "sha256:74f8944e04bfc1508cce784b75927b4fb9895ff6a57310abb523c4b446b4f34f", size = 4085860, upload-time = "2025-12-04T00:16:08.752Z" },
 ]
 
 [[package]]
@@ -393,6 +438,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/67/c9/6ce745d4233aeb3abdb18205739b394f7955087f7603cb324a797adbf8d2/botocore-1.42.26.tar.gz", hash = "sha256:1c8855e3e811f015d930ccfe8751d4be295aae0562133d14b6f0b247cd6fd8d3", size = 14882582, upload-time = "2026-01-12T20:36:29.382Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/43/5993eab2114c0de7bbc21985b745aafe3b912f98fc63726c2a54680bb69d/botocore-1.42.26-py3-none-any.whl", hash = "sha256:71171c2d09ac07739f4efce398b15a4a8bc8769c17fb3bc99625e43ed11ad8b7", size = 14554661, upload-time = "2026-01-12T20:36:26.891Z" },
+]
+
+[package.optional-dependencies]
+crt = [
+    { name = "awscrt" },
 ]
 
 [[package]]
@@ -595,6 +645,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
 name = "cloudsplaining"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -649,6 +708,14 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/13/37ea7805ae3057992e96ecb1cffa2fa35c2ef4498543b846f90dd2348d8f/contextlib2-21.6.0.tar.gz", hash = "sha256:ab1e2bfe1d01d968e1b7e8d9023bc51ef3509bba217bb730cee3827e1ee82869", size = 43795, upload-time = "2021-06-27T06:54:40.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/56/6d6872f79d14c0cb02f1646cbb4592eef935857c0951a105874b7b62a0c3/contextlib2-21.6.0-py2.py3-none-any.whl", hash = "sha256:3fbdb64466afd23abaf6c977627b75b6139a5a3e8ce38405c5b413aed7a0471f", size = 13277, upload-time = "2021-06-27T06:54:20.972Z" },
+]
+
+[[package]]
+name = "cronsim"
+version = "2.7"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/1a/02f105147f7f2e06ed4f734ff5a6439590bb275a53dd91fc73df6312298a/cronsim-2.7-py3-none-any.whl", hash = "sha256:1e1431fa08c51dc7f72e67e571c7c7a09af26420169b607badd4ca9677ffad1e", size = 14213, upload-time = "2025-10-21T16:38:20.431Z" },
 ]
 
 [[package]]
@@ -720,6 +787,21 @@ wheels = [
 ]
 
 [[package]]
+name = "cyclopts"
+version = "4.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "docstring-parser" },
+    { name = "rich" },
+    { name = "rich-rst" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/7a/3c3623755561c7f283dd769470e99ae36c46810bf3b3f264d69006f6c97a/cyclopts-4.8.0.tar.gz", hash = "sha256:92cc292d18d8be372e58d8bce1aa966d30f819a5fb3fee02bd2ad4a6bb403f29", size = 164066, upload-time = "2026-03-07T19:39:18.122Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/01/6ec7210775ea5e4989a10d89eda6c5ea7ff06caa614231ad533d74fecac8/cyclopts-4.8.0-py3-none-any.whl", hash = "sha256:ef353da05fec36587d4ebce7a6e4b27515d775d184a23bab4b01426f93ddc8d4", size = 201948, upload-time = "2026-03-07T19:39:19.307Z" },
+]
+
+[[package]]
 name = "debugpy"
 version = "1.8.17"
 source = { registry = "https://pypi.org/simple" }
@@ -764,12 +846,30 @@ wheels = [
 ]
 
 [[package]]
+name = "diskcache"
+version = "5.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916, upload-time = "2023-08-31T06:12:00.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550, upload-time = "2023-08-31T06:11:58.822Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
 ]
 
 [[package]]
@@ -805,12 +905,34 @@ wheels = [
 ]
 
 [[package]]
+name = "docutils"
+version = "0.22.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
+]
+
+[[package]]
 name = "dpath"
 version = "2.1.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1f/2c/a4213cdbbc43b8fdf34b6e2afb415fd5d46e171d32a4bb92e7924548aa9f/dpath-2.1.3.tar.gz", hash = "sha256:d1a7a0e6427d0a4156c792c82caf1f0109603f68ace792e36ca4596fd2cb8d9d", size = 24016, upload-time = "2022-12-13T07:27:22.108Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/12/02fdb87afeab1987442164a2db470a995122c800f15265e9b7a5103a3fd9/dpath-2.1.3-py3-none-any.whl", hash = "sha256:d9560e03ccd83b3c6f29988b0162ce9b34fd28b9d8dbda46663b20c68d9cdae3", size = 17232, upload-time = "2022-12-13T07:27:20.023Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
 ]
 
 [[package]]
@@ -822,12 +944,66 @@ wheels = [
 ]
 
 [[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
+]
+
+[[package]]
+name = "fakeredis"
+version = "2.34.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "redis" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/11/40/fd09efa66205eb32253d2b2ebc63537281384d2040f0a88bcd2289e120e4/fakeredis-2.34.1.tar.gz", hash = "sha256:4ff55606982972eecce3ab410e03d746c11fe5deda6381d913641fbd8865ea9b", size = 177315, upload-time = "2026-02-25T13:17:51.315Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/b5/82f89307d0d769cd9bf46a54fb9136be08e4e57c5570ae421db4c9a2ba62/fakeredis-2.34.1-py3-none-any.whl", hash = "sha256:0107ec99d48913e7eec2a5e3e2403d1bd5f8aa6489d1a634571b975289c48f12", size = 122160, upload-time = "2026-02-25T13:17:49.701Z" },
+]
+
+[package.optional-dependencies]
+lua = [
+    { name = "lupa" },
+]
+
+[[package]]
+name = "fastmcp"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "authlib" },
+    { name = "cyclopts" },
+    { name = "exceptiongroup" },
+    { name = "httpx" },
+    { name = "jsonschema-path" },
+    { name = "mcp" },
+    { name = "openapi-pydantic" },
+    { name = "platformdirs" },
+    { name = "py-key-value-aio", extra = ["disk", "keyring", "memory"] },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pydocket" },
+    { name = "pyperclip" },
+    { name = "python-dotenv" },
+    { name = "rich" },
+    { name = "uvicorn" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/50/9bb042a2d290ccadb35db3580ac507f192e1a39c489eb8faa167cd5e3b57/fastmcp-2.14.0.tar.gz", hash = "sha256:c1f487b36a3e4b043dbf3330e588830047df2e06f8ef0920d62dfb34d0905727", size = 8232562, upload-time = "2025-12-11T23:04:27.134Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/73/b5656172a6beb2eacec95f04403ddea1928e4b22066700fd14780f8f45d1/fastmcp-2.14.0-py3-none-any.whl", hash = "sha256:7b374c0bcaf1ef1ef46b9255ea84c607f354291eaf647ff56a47c69f5ec0c204", size = 398965, upload-time = "2025-12-11T23:04:25.587Z" },
 ]
 
 [[package]]
@@ -1079,6 +1255,39 @@ wheels = [
 ]
 
 [[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/7b/c3081ff1af947915503121c649f26a778e1a2101fd525f74aef997d75b7e/jaraco_context-6.1.1.tar.gz", hash = "sha256:bc046b2dc94f1e5532bd02402684414575cc11f565d929b6563125deb0a6e581", size = 15832, upload-time = "2026-03-07T15:46:04.63Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/49/c152890d49102b280ecf86ba5f80a8c111c3a155dafa3bd24aeb64fde9e1/jaraco_context-6.1.1-py3-none-any.whl", hash = "sha256:0df6a0287258f3e364072c3e40d5411b20cafa30cb28c4839d24319cecf9f808", size = 7005, upload-time = "2026-03-07T15:46:03.515Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/27/056e0638a86749374d6f57d0b0db39f29509cce9313cf91bdc0ac4d91084/jaraco_functools-4.4.0.tar.gz", hash = "sha256:da21933b0417b89515562656547a77b4931f98176eb173644c0d35032a33d6bb", size = 19943, upload-time = "2025-12-21T09:29:43.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/c4/813bb09f0985cb21e959f21f2464169eca882656849adf727ac7bb7e1767/jaraco_functools-4.4.0-py3-none-any.whl", hash = "sha256:9eec1e36f45c818d9bf307c8948eb03b2b56cd44087b3cdc989abca1f20b9176", size = 10481, upload-time = "2025-12-21T09:29:42.27Z" },
+]
+
+[[package]]
 name = "jedi"
 version = "0.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1088,6 +1297,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/72/3a/79a912fbd4d8dd6fbb02bf69afd3bb72cf0c729bb3063c6f4498603db17a/jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0", size = 1231287, upload-time = "2024-11-11T01:41:42.873Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl", hash = "sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9", size = 1572278, upload-time = "2024-11-11T01:41:40.175Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
 ]
 
 [[package]]
@@ -1148,6 +1366,20 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonschema-path"
+version = "0.4.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pathable" },
+    { name = "pyyaml" },
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/8a/7e6102f2b8bdc6705a9eb5294f8f6f9ccd3a8420e8e8e19671d1dd773251/jsonschema_path-0.4.5.tar.gz", hash = "sha256:c6cd7d577ae290c7defd4f4029e86fdb248ca1bd41a07557795b3c95e5144918", size = 15113, upload-time = "2026-03-03T09:56:46.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/d5/4e96c44f6c1ea3d812cf5391d81a4f5abaa540abf8d04ecd7f66e0ed11df/jsonschema_path-0.4.5-py3-none-any.whl", hash = "sha256:7d77a2c3f3ec569a40efe5c5f942c44c1af2a6f96fe0866794c9ef5b8f87fd65", size = 19368, upload-time = "2026-03-03T09:56:45.39Z" },
+]
+
+[[package]]
 name = "jsonschema-specifications"
 version = "2025.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1198,6 +1430,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/02/49/9d1284d0dc65e2c757b74c6687b6d319b02f822ad039e5c512df9194d9dd/jupyter_core-5.9.1.tar.gz", hash = "sha256:4d09aaff303b9566c3ce657f580bd089ff5c91f5f89cf7d8846c3cdf465b5508", size = 89814, upload-time = "2025-10-16T19:19:18.444Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl", hash = "sha256:ebf87fdc6073d142e114c72c9e29a9d7ca03fad818c5d300ce2adc1fb0743407", size = 29032, upload-time = "2025-10-16T19:19:16.783Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
 ]
 
 [[package]]
@@ -1317,6 +1566,47 @@ wheels = [
 ]
 
 [[package]]
+name = "lupa"
+version = "2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/1c/191c3e6ec6502e3dbe25a53e27f69a5daeac3e56de1f73c0138224171ead/lupa-2.6.tar.gz", hash = "sha256:9a770a6e89576be3447668d7ced312cd6fd41d3c13c2462c9dc2c2ab570e45d9", size = 7240282, upload-time = "2025-10-24T07:20:29.738Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/1d/21176b682ca5469001199d8b95fa1737e29957a3d185186e7a8b55345f2e/lupa-2.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:663a6e58a0f60e7d212017d6678639ac8df0119bc13c2145029dcba084391310", size = 947232, upload-time = "2025-10-24T07:18:27.878Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/4c/d327befb684660ca13cf79cd1f1d604331808f9f1b6fb6bf57832f8edf80/lupa-2.6-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:d1f5afda5c20b1f3217a80e9bc1b77037f8a6eb11612fd3ada19065303c8f380", size = 1908625, upload-time = "2025-10-24T07:18:29.944Z" },
+    { url = "https://files.pythonhosted.org/packages/66/8e/ad22b0a19454dfd08662237a84c792d6d420d36b061f239e084f29d1a4f3/lupa-2.6-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:26f2b3c085fe76e9119e48c1013c1cccdc1f51585d456858290475aa38e7089e", size = 981057, upload-time = "2025-10-24T07:18:31.553Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/48/74859073ab276bd0566c719f9ca0108b0cfc1956ca0d68678d117d47d155/lupa-2.6-cp313-cp313-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:60d2f902c7b96fb8ab98493dcff315e7bb4d0b44dc9dd76eb37de575025d5685", size = 1156227, upload-time = "2025-10-24T07:18:33.981Z" },
+    { url = "https://files.pythonhosted.org/packages/09/6c/0e9ded061916877253c2266074060eb71ed99fb21d73c8c114a76725bce2/lupa-2.6-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a02d25dee3a3250967c36590128d9220ae02f2eda166a24279da0b481519cbff", size = 1035752, upload-time = "2025-10-24T07:18:36.32Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/ef/f8c32e454ef9f3fe909f6c7d57a39f950996c37a3deb7b391fec7903dab7/lupa-2.6-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6eae1ee16b886b8914ff292dbefbf2f48abfbdee94b33a88d1d5475e02423203", size = 2069009, upload-time = "2025-10-24T07:18:38.072Z" },
+    { url = "https://files.pythonhosted.org/packages/53/dc/15b80c226a5225815a890ee1c11f07968e0aba7a852df41e8ae6fe285063/lupa-2.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b0edd5073a4ee74ab36f74fe61450148e6044f3952b8d21248581f3c5d1a58be", size = 1056301, upload-time = "2025-10-24T07:18:40.165Z" },
+    { url = "https://files.pythonhosted.org/packages/31/14/2086c1425c985acfb30997a67e90c39457122df41324d3c179d6ee2292c6/lupa-2.6-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:0c53ee9f22a8a17e7d4266ad48e86f43771951797042dd51d1494aaa4f5f3f0a", size = 1170673, upload-time = "2025-10-24T07:18:42.426Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e5/b216c054cf86576c0191bf9a9f05de6f7e8e07164897d95eea0078dca9b2/lupa-2.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:de7c0f157a9064a400d828789191a96da7f4ce889969a588b87ec80de9b14772", size = 2162227, upload-time = "2025-10-24T07:18:46.112Z" },
+    { url = "https://files.pythonhosted.org/packages/59/2f/33ecb5bedf4f3bc297ceacb7f016ff951331d352f58e7e791589609ea306/lupa-2.6-cp313-cp313-win32.whl", hash = "sha256:ee9523941ae0a87b5b703417720c5d78f72d2f5bc23883a2ea80a949a3ed9e75", size = 1419558, upload-time = "2025-10-24T07:18:48.371Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/b4/55e885834c847ea610e111d87b9ed4768f0afdaeebc00cd46810f25029f6/lupa-2.6-cp313-cp313-win_amd64.whl", hash = "sha256:b1335a5835b0a25ebdbc75cf0bda195e54d133e4d994877ef025e218c2e59db9", size = 1683424, upload-time = "2025-10-24T07:18:50.976Z" },
+    { url = "https://files.pythonhosted.org/packages/66/9d/d9427394e54d22a35d1139ef12e845fd700d4872a67a34db32516170b746/lupa-2.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dcb6d0a3264873e1653bc188499f48c1fb4b41a779e315eba45256cfe7bc33c1", size = 953818, upload-time = "2025-10-24T07:18:53.378Z" },
+    { url = "https://files.pythonhosted.org/packages/10/41/27bbe81953fb2f9ecfced5d9c99f85b37964cfaf6aa8453bb11283983721/lupa-2.6-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:a37e01f2128f8c36106726cb9d360bac087d58c54b4522b033cc5691c584db18", size = 1915850, upload-time = "2025-10-24T07:18:55.259Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/98/f9ff60db84a75ba8725506bbf448fb085bc77868a021998ed2a66d920568/lupa-2.6-cp314-cp314-macosx_11_0_x86_64.whl", hash = "sha256:458bd7e9ff3c150b245b0fcfbb9bd2593d1152ea7f0a7b91c1d185846da033fe", size = 982344, upload-time = "2025-10-24T07:18:57.05Z" },
+    { url = "https://files.pythonhosted.org/packages/41/f7/f39e0f1c055c3b887d86b404aaf0ca197b5edfd235a8b81b45b25bac7fc3/lupa-2.6-cp314-cp314-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:052ee82cac5206a02df77119c325339acbc09f5ce66967f66a2e12a0f3211cad", size = 1156543, upload-time = "2025-10-24T07:18:59.251Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/9c/59e6cffa0d672d662ae17bd7ac8ecd2c89c9449dee499e3eb13ca9cd10d9/lupa-2.6-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96594eca3c87dd07938009e95e591e43d554c1dbd0385be03c100367141db5a8", size = 1047974, upload-time = "2025-10-24T07:19:01.449Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c6/a04e9cef7c052717fcb28fb63b3824802488f688391895b618e39be0f684/lupa-2.6-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8faddd9d198688c8884091173a088a8e920ecc96cda2ffed576a23574c4b3f6", size = 2073458, upload-time = "2025-10-24T07:19:03.369Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/10/824173d10f38b51fc77785228f01411b6ca28826ce27404c7c912e0e442c/lupa-2.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:daebb3a6b58095c917e76ba727ab37b27477fb926957c825205fbda431552134", size = 1067683, upload-time = "2025-10-24T07:19:06.2Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/dc/9692fbcf3c924d9c4ece2d8d2f724451ac2e09af0bd2a782db1cef34e799/lupa-2.6-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:f3154e68972befe0f81564e37d8142b5d5d79931a18309226a04ec92487d4ea3", size = 1171892, upload-time = "2025-10-24T07:19:08.544Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ff/e318b628d4643c278c96ab3ddea07fc36b075a57383c837f5b11e537ba9d/lupa-2.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e4dadf77b9fedc0bfa53417cc28dc2278a26d4cbd95c29f8927ad4d8fe0a7ef9", size = 2166641, upload-time = "2025-10-24T07:19:10.485Z" },
+    { url = "https://files.pythonhosted.org/packages/12/f7/a6f9ec2806cf2d50826980cdb4b3cffc7691dc6f95e13cc728846d5cb793/lupa-2.6-cp314-cp314-win32.whl", hash = "sha256:cb34169c6fa3bab3e8ac58ca21b8a7102f6a94b6a5d08d3636312f3f02fafd8f", size = 1456857, upload-time = "2025-10-24T07:19:37.989Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/de/df71896f25bdc18360fdfa3b802cd7d57d7fede41a0e9724a4625b412c85/lupa-2.6-cp314-cp314-win_amd64.whl", hash = "sha256:b74f944fe46c421e25d0f8692aef1e842192f6f7f68034201382ac440ef9ea67", size = 1731191, upload-time = "2025-10-24T07:19:40.281Z" },
+    { url = "https://files.pythonhosted.org/packages/47/3c/a1f23b01c54669465f5f4c4083107d496fbe6fb45998771420e9aadcf145/lupa-2.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0e21b716408a21ab65723f8841cf7f2f37a844b7a965eeabb785e27fca4099cf", size = 999343, upload-time = "2025-10-24T07:19:12.519Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/6d/501994291cb640bfa2ccf7f554be4e6914afa21c4026bd01bff9ca8aac57/lupa-2.6-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:589db872a141bfff828340079bbdf3e9a31f2689f4ca0d88f97d9e8c2eae6142", size = 2000730, upload-time = "2025-10-24T07:19:14.869Z" },
+    { url = "https://files.pythonhosted.org/packages/53/a5/457ffb4f3f20469956c2d4c4842a7675e884efc895b2f23d126d23e126cc/lupa-2.6-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:cd852a91a4a9d4dcbb9a58100f820a75a425703ec3e3f049055f60b8533b7953", size = 1021553, upload-time = "2025-10-24T07:19:17.123Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6b/36bb5a5d0960f2a5c7c700e0819abb76fd9bf9c1d8a66e5106416d6e9b14/lupa-2.6-cp314-cp314t-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:0334753be028358922415ca97a64a3048e4ed155413fc4eaf87dd0a7e2752983", size = 1133275, upload-time = "2025-10-24T07:19:20.51Z" },
+    { url = "https://files.pythonhosted.org/packages/19/86/202ff4429f663013f37d2229f6176ca9f83678a50257d70f61a0a97281bf/lupa-2.6-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:661d895cd38c87658a34780fac54a690ec036ead743e41b74c3fb81a9e65a6aa", size = 1038441, upload-time = "2025-10-24T07:19:22.509Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/42/d8125f8e420714e5b52e9c08d88b5329dfb02dcca731b4f21faaee6cc5b5/lupa-2.6-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6aa58454ccc13878cc177c62529a2056be734da16369e451987ff92784994ca7", size = 2058324, upload-time = "2025-10-24T07:19:24.979Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2c/47bf8b84059876e877a339717ddb595a4a7b0e8740bacae78ba527562e1c/lupa-2.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1425017264e470c98022bba8cff5bd46d054a827f5df6b80274f9cc71dafd24f", size = 1060250, upload-time = "2025-10-24T07:19:27.262Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/06/d88add2b6406ca1bdec99d11a429222837ca6d03bea42ca75afa169a78cb/lupa-2.6-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:224af0532d216e3105f0a127410f12320f7c5f1aa0300bdf9646b8d9afb0048c", size = 1151126, upload-time = "2025-10-24T07:19:29.522Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/a0/89e6a024c3b4485b89ef86881c9d55e097e7cb0bdb74efb746f2fa6a9a76/lupa-2.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9abb98d5a8fd27c8285302e82199f0e56e463066f88f619d6594a450bf269d80", size = 2153693, upload-time = "2025-10-24T07:19:31.379Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/36/a0f007dc58fc1bbf51fb85dcc82fcb1f21b8c4261361de7dab0e3d8521ef/lupa-2.6-cp314-cp314t-win32.whl", hash = "sha256:1849efeba7a8f6fb8aa2c13790bee988fd242ae404bd459509640eeea3d1e291", size = 1590104, upload-time = "2025-10-24T07:19:33.514Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/5e/db903ce9cf82c48d6b91bf6d63ae4c8d0d17958939a4e04ba6b9f38b8643/lupa-2.6-cp314-cp314t-win_amd64.whl", hash = "sha256:fc1498d1a4fc028bc521c26d0fad4ca00ed63b952e32fb95949bda76a04bad52", size = 1913818, upload-time = "2025-10-24T07:19:36.039Z" },
+]
+
+[[package]]
 name = "markdown"
 version = "3.10.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1416,7 +1706,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.23.0"
+version = "1.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1434,9 +1724,23 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/1a/9c8a5362e3448d585081d6c7aa95898a64e0ac59d3e26169ae6c3ca5feaf/mcp-1.23.0.tar.gz", hash = "sha256:84e0c29316d0a8cf0affd196fd000487ac512aa3f771b63b2ea864e22961772b", size = 596506, upload-time = "2025-12-02T13:40:02.558Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/b2/28739ce409f98159c0121eab56e69ad71546c4f34ac8b42e58c03f57dccc/mcp-1.23.0-py3-none-any.whl", hash = "sha256:5a645cf111ed329f4619f2629a3f15d9aabd7adc2ea09d600d31467b51ecb64f", size = 231427, upload-time = "2025-12-02T13:40:00.738Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
+]
+
+[[package]]
+name = "mcp-proxy-for-aws"
+version = "1.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "botocore", extra = ["crt"] },
+    { name = "fastmcp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/e7/02e4431694b9aca6ae774c8ad6fbe566cf6e0dd94319162f09ac9db3b671/mcp_proxy_for_aws-1.1.6.tar.gz", hash = "sha256:e08ea8196711edfb6a699e16c2625b8864a8c01897f60a6a26f5b01d89d6a1fb", size = 384985, upload-time = "2026-01-29T15:01:56.906Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/43/691c5e2b4f96b14ba07e5367622ec5968802ff51381302d8521f51433510/mcp_proxy_for_aws-1.1.6-py3-none-any.whl", hash = "sha256:555e8e4c205a417563b4c97be9d0e9d99c92f338fa5a613bb1ed486c2a015664", size = 31115, upload-time = "2026-01-29T15:01:55.844Z" },
 ]
 
 [[package]]
@@ -1446,6 +1750,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "10.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/5d/38b681d3fce7a266dd9ab73c66959406d565b3e85f21d5e66e1181d93721/more_itertools-10.8.0.tar.gz", hash = "sha256:f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd", size = 137431, upload-time = "2025-09-02T15:23:11.018Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl", hash = "sha256:52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b", size = 69667, upload-time = "2025-09-02T15:23:09.635Z" },
 ]
 
 [[package]]
@@ -1622,6 +1935,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/55/6e1a61ded7af8df04016d81b5b02daa59f2ea9252ee0397cb9f631efe9e5/numpy-2.4.2-cp314-cp314t-win32.whl", hash = "sha256:8c50dd1fc8826f5b26a5ee4d77ca55d88a895f4e4819c7ecc2a9f5905047a443", size = 6153937, upload-time = "2026-01-31T23:12:47.229Z" },
     { url = "https://files.pythonhosted.org/packages/45/aa/fa6118d1ed6d776b0983f3ceac9b1a5558e80df9365b1c3aa6d42bf9eee4/numpy-2.4.2-cp314-cp314t-win_amd64.whl", hash = "sha256:fcf92bee92742edd401ba41135185866f7026c502617f422eb432cfeca4fe236", size = 12631844, upload-time = "2026-01-31T23:12:48.997Z" },
     { url = "https://files.pythonhosted.org/packages/32/0a/2ec5deea6dcd158f254a7b372fb09cfba5719419c8d66343bab35237b3fb/numpy-2.4.2-cp314-cp314t-win_arm64.whl", hash = "sha256:1f92f53998a17265194018d1cc321b2e96e900ca52d54c7c77837b71b9465181", size = 10565379, upload-time = "2026-01-31T23:12:51.345Z" },
+]
+
+[[package]]
+name = "openapi-pydantic"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381, upload-time = "2025-01-08T19:29:25.275Z" },
 ]
 
 [[package]]
@@ -1805,12 +2130,30 @@ wheels = [
 ]
 
 [[package]]
+name = "pathable"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/55/b748445cb4ea6b125626f15379be7c96d1035d4fa3e8fee362fa92298abf/pathable-0.5.0.tar.gz", hash = "sha256:d81938348a1cacb525e7c75166270644782c0fb9c8cecc16be033e71427e0ef1", size = 16655, upload-time = "2026-02-20T08:47:00.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/96/5a770e5c461462575474468e5af931cff9de036e7c2b4fea23c1c58d2cbe/pathable-0.5.0-py3-none-any.whl", hash = "sha256:646e3d09491a6351a0c82632a09c02cdf70a252e73196b36d8a15ba0a114f0a6", size = 16867, upload-time = "2026-02-20T08:46:59.536Z" },
+]
+
+[[package]]
 name = "pathspec"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
+]
+
+[[package]]
+name = "pathvalidate"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/2a/52a8da6fe965dea6192eb716b357558e103aea0a1e9a8352ad575a8406ca/pathvalidate-3.3.1.tar.gz", hash = "sha256:b18c07212bfead624345bb8e1d6141cdcf15a39736994ea0b94035ad2b1ba177", size = 63262, upload-time = "2025-06-15T09:07:20.736Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/70/875f4a23bfc4731703a5835487d0d2fb999031bd415e7d17c0ae615c18b7/pathvalidate-3.3.1-py3-none-any.whl", hash = "sha256:5263baab691f8e1af96092fa5137ee17df5bdfbd6cff1fcac4d6ef4bc2e1735f", size = 24305, upload-time = "2025-06-15T09:07:19.117Z" },
 ]
 
 [[package]]
@@ -1947,6 +2290,15 @@ wheels = [
 ]
 
 [[package]]
+name = "prometheus-client"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/58/a794d23feb6b00fc0c72787d7e87d872a6730dd9ed7c7b3e954637d8f280/prometheus_client-0.24.1.tar.gz", hash = "sha256:7e0ced7fbbd40f7b84962d5d2ab6f17ef88a72504dcf7c0b40737b43b2a461f9", size = 85616, upload-time = "2026-01-14T15:26:26.965Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/c3/24a2f845e3917201628ecaba4f18bab4d18a337834c1df2a159ee9d22a42/prometheus_client-0.24.1-py3-none-any.whl", hash = "sha256:150db128af71a5c2482b36e588fc8a6b95e498750da4b17065947c16070f4055", size = 64057, upload-time = "2026-01-14T15:26:24.42Z" },
+]
+
+[[package]]
 name = "prompt-toolkit"
 version = "3.0.52"
 source = { registry = "https://pypi.org/simple" }
@@ -2071,6 +2423,47 @@ wheels = [
 ]
 
 [[package]]
+name = "py-key-value-aio"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beartype" },
+    { name = "py-key-value-shared" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/93/ce/3136b771dddf5ac905cc193b461eb67967cf3979688c6696e1f2cdcde7ea/py_key_value_aio-0.3.0.tar.gz", hash = "sha256:858e852fcf6d696d231266da66042d3355a7f9871650415feef9fca7a6cd4155", size = 50801, upload-time = "2025-11-17T16:50:04.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/10/72f6f213b8f0bce36eff21fda0a13271834e9eeff7f9609b01afdc253c79/py_key_value_aio-0.3.0-py3-none-any.whl", hash = "sha256:1c781915766078bfd608daa769fefb97e65d1d73746a3dfb640460e322071b64", size = 96342, upload-time = "2025-11-17T16:50:03.801Z" },
+]
+
+[package.optional-dependencies]
+disk = [
+    { name = "diskcache" },
+    { name = "pathvalidate" },
+]
+keyring = [
+    { name = "keyring" },
+]
+memory = [
+    { name = "cachetools" },
+]
+redis = [
+    { name = "redis" },
+]
+
+[[package]]
+name = "py-key-value-shared"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beartype" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/e4/1971dfc4620a3a15b4579fe99e024f5edd6e0967a71154771a059daff4db/py_key_value_shared-0.3.0.tar.gz", hash = "sha256:8fdd786cf96c3e900102945f92aa1473138ebe960ef49da1c833790160c28a4b", size = 11666, upload-time = "2025-11-17T16:50:06.849Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/e4/b8b0a03ece72f47dce2307d36e1c34725b7223d209fc679315ffe6a4e2c3/py_key_value_shared-0.3.0-py3-none-any.whl", hash = "sha256:5b0efba7ebca08bb158b1e93afc2f07d30b8f40c2fc12ce24a4c0d84f42f9298", size = 19560, upload-time = "2025-11-17T16:50:05.954Z" },
+]
+
+[[package]]
 name = "py-serializable"
 version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2170,6 +2563,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a1/6b/83661fa77dcefa195ad5f8cd9af3d1a7450fd57cc883ad04d65446ac2029/pydantic-2.12.3-py3-none-any.whl", hash = "sha256:6986454a854bc3bc6e5443e1369e06a3a456af9d339eda45510f517d9ea5c6bf", size = 462431, upload-time = "2025-10-17T15:04:19.346Z" },
 ]
 
+[package.optional-dependencies]
+email = [
+    { name = "email-validator" },
+]
+
 [[package]]
 name = "pydantic-core"
 version = "2.41.4"
@@ -2234,6 +2632,30 @@ wheels = [
 ]
 
 [[package]]
+name = "pydocket"
+version = "0.18.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "cronsim" },
+    { name = "fakeredis", extra = ["lua"] },
+    { name = "opentelemetry-api" },
+    { name = "prometheus-client" },
+    { name = "py-key-value-aio", extra = ["memory", "redis"] },
+    { name = "python-json-logger" },
+    { name = "redis" },
+    { name = "rich" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+    { name = "uncalled-for" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b8/5f/82dde9fb6099b960a4203596d3b755d1bd2c0d0210fea104d015d6515d7f/pydocket-0.18.2.tar.gz", hash = "sha256:cc2051d15557f83bb164a83b0743fa9c12c2bfe9a9145cff3a5922b4935ce4f5", size = 354762, upload-time = "2026-03-10T13:09:22.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/cf/8c1b6340baf81d7f6c97fe0181bda7cfd500d5e33bf469fbffbdae07b3c9/pydocket-0.18.2-py3-none-any.whl", hash = "sha256:19e48de15e83370f750e362610b777533ff9c0fa48bf36766ed581f91d266556", size = 99041, upload-time = "2026-03-10T13:09:20.598Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2266,6 +2688,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyperclip"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -2284,6 +2715,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab", size = 41978, upload-time = "2025-06-24T04:21:07.341Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc", size = 20556, upload-time = "2025-06-24T04:21:06.073Z" },
+]
+
+[[package]]
+name = "python-json-logger"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/bf/eca6a3d43db1dae7070f70e160ab20b807627ba953663ba07928cdd3dc58/python_json_logger-4.0.0.tar.gz", hash = "sha256:f58e68eb46e1faed27e0f574a55a0455eecd7b8a5b88b85a784519ba3cff047f", size = 17683, upload-time = "2025-10-06T04:15:18.984Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/e5/fecf13f06e5e5f67e8837d777d1bc43fac0ed2b77a676804df5c34744727/python_json_logger-4.0.0-py3-none-any.whl", hash = "sha256:af09c9daf6a813aa4cc7180395f50f2a9e5fa056034c9953aec92e381c5ba1e2", size = 15548, upload-time = "2025-10-06T04:15:17.553Z" },
 ]
 
 [[package]]
@@ -2315,6 +2755,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
     { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
     { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
 ]
 
 [[package]]
@@ -2406,6 +2855,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/98/f5/18bb77b7af9526add0c727a3b2048959847dc5fb030913e2918bf384fec3/rdflib-7.6.0.tar.gz", hash = "sha256:6c831288d5e4a5a7ece85d0ccde9877d512a3d0f02d7c06455d00d6d0ea379df", size = 4943826, upload-time = "2026-02-13T07:15:55.938Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/c2/6604a71269e0c1bd75656d5a001432d16f2cc5b8c057140ec797155c295e/rdflib-7.6.0-py3-none-any.whl", hash = "sha256:30c0a3ebf4c0e09215f066be7246794b6492e054e782d7ac2a34c9f70a15e0dd", size = 615416, upload-time = "2026-02-13T07:15:46.487Z" },
+]
+
+[[package]]
+name = "redis"
+version = "7.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/82/4d1a5279f6c1251d3d2a603a798a1137c657de9b12cfc1fba4858232c4d2/redis-7.3.0.tar.gz", hash = "sha256:4d1b768aafcf41b01022410b3cc4f15a07d9b3d6fe0c66fc967da2c88e551034", size = 4928081, upload-time = "2026-03-06T18:18:16.287Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/28/84e57fce7819e81ec5aa1bd31c42b89607241f4fb1a3ea5b0d2dbeaea26c/redis-7.3.0-py3-none-any.whl", hash = "sha256:9d4fcb002a12a5e3c3fbe005d59c48a2cc231f87fbb2f6b70c2d89bb64fec364", size = 404379, upload-time = "2026-03-06T18:18:14.583Z" },
 ]
 
 [[package]]
@@ -2547,6 +3005,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich-rst"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/6d/a506aaa4a9eaa945ed8ab2b7347859f53593864289853c5d6d62b77246e0/rich_rst-1.3.2.tar.gz", hash = "sha256:a1196fdddf1e364b02ec68a05e8ff8f6914fee10fbca2e6b6735f166bb0da8d4", size = 14936, upload-time = "2025-10-14T16:49:45.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl", hash = "sha256:a99b4907cbe118cf9d18b0b44de272efa61f15117c61e39ebdc431baf5df722a", size = 12567, upload-time = "2025-10-14T16:49:42.953Z" },
+]
+
+[[package]]
 name = "rpds-py"
 version = "0.28.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2685,12 +3156,34 @@ wheels = [
 ]
 
 [[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "jeepney" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
+]
+
+[[package]]
 name = "semantic-version"
 version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7d/31/f2289ce78b9b473d582568c234e104d2a342fd658cc288a7553d83bb8595/semantic_version-2.10.0.tar.gz", hash = "sha256:bdabb6d336998cbb378d4b9db3a4b56a1e3235701dc05ea2690d9a997ed5041c", size = 52289, upload-time = "2022-05-26T13:35:23.454Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/23/8146aad7d88f4fcb3a6218f41a60f6c2d4e3a72de72da1825dc7c8f7877c/semantic_version-2.10.0-py2.py3-none-any.whl", hash = "sha256:de78a3b8e0feda74cabc54aab2da702113e33ac9d9eb9d2389bcf1f58b7d9177", size = 15552, upload-time = "2022-05-26T13:35:21.206Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
 ]
 
 [[package]]
@@ -2968,6 +3461,21 @@ wheels = [
 ]
 
 [[package]]
+name = "typer"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2995,6 +3503,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
+]
+
+[[package]]
+name = "uncalled-for"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/7c/b5b7d8136f872e3f13b0584e576886de0489d7213a12de6bebf29ff6ebfc/uncalled_for-0.2.0.tar.gz", hash = "sha256:b4f8fdbcec328c5a113807d653e041c5094473dd4afa7c34599ace69ccb7e69f", size = 49488, upload-time = "2026-02-27T17:40:58.137Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/7f/4320d9ce3be404e6310b915c3629fe27bf1e2f438a1a7a3cb0396e32e9a9/uncalled_for-0.2.0-py3-none-any.whl", hash = "sha256:2c0bd338faff5f930918f79e7eb9ff48290df2cb05fcc0b40a7f334e55d4d85f", size = 11351, upload-time = "2026-02-27T17:40:56.804Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR introduces end-to-end support for registering, managing, and connecting to external MCP servers — including public Streamable HTTP endpoints that don't require AWS IAM authentication. Users can now register and delete MCP servers directly from the UI, in addition to the existing `config.yaml` approach.

This PR introduces end-to-end support for registering, managing, and connecting to external MCP servers — including public Streamable HTTP endpoints that don't require AWS IAM authentication. Users can now register and delete MCP servers directly from the UI, in addition to the existing `config.yaml` approach.

## Changes

### External/public MCP server support (`bc3cd41`)

- MCP server configs now accept a direct `url` field for external Streamable HTTP servers, bypassing AgentCore runtime/gateway resolution
- Added `AuthType` tracking (`SIGV4` | `NONE`) propagated through the seeder, CDK, and MCP client
- External servers with `NONE` auth skip SigV4 signing and AgentCore validation
- Region-based filtering no longer excludes external servers (no region in their URLs)
- Upgraded `mcp` SDK from 1.23.0 → 1.26.0; added `mcp-proxy-for-aws` dependency

### GraphQL mutations & backend CRUD (`b550688`)

- Added `registerMcpServer` and `deleteMcpServer` GraphQL mutations with input validation (name format, auth type, HTTPS-only URLs)
- Updated `McpServer` type with `authType` field and new `McpAuthType` enum (`SIGV4` / `NONE`)
- Lambda resolver upgraded from read-only to read-write access on the MCP server registry table
- External servers (`NONE` auth) are now listed regardless of region

### UI registration & management (`afafa61`)

- New **MCP Server Manager** page (accessible from AgentCore Manager → "Manage MCPs") with full table view, registration modal, and deletion support
- Registration modal adapts fields by auth type: SigV4 shows Runtime/Gateway ID inputs; `NONE` shows direct URL input with security warning
- Server-side validation of AgentCore resource existence for SigV4 servers (runtime/gateway ID verification)
- Tracks server source (`CDK` vs `UI`) — CDK-managed servers are protected from UI deletion
- "Used By" column shows which agents reference each server
- Added "Register new MCP server" action in the Agent Factory wizard's Additional Tools section
- Comprehensive documentation added to `expanding-ai-tools.md`

## Auth type guidance

| Auth Type | Use When |
|-----------|----------|
| **SigV4** | Server is hosted on AWS AgentCore (Runtime or Gateway) — **recommended** |
| **None** | Server is a trusted, public, read-only endpoint (e.g., AWS Knowledge MCP Server) |

## UI Changes

<img width="1134" height="317" alt="Screenshot 2026-03-12 at 14 08 27" src="https://github.com/user-attachments/assets/03dcccb3-4b1b-47c2-9396-fb66bcc22e25" />

<img width="1401" height="474" alt="Screenshot 2026-03-12 at 14 13 53" src="https://github.com/user-attachments/assets/47c4dec4-1978-4fee-bde0-5473710722ea" />

<img width="585" height="698" alt="Screenshot 2026-03-12 at 14 14 30" src="https://github.com/user-attachments/assets/ef9570f4-6a55-47bc-9b30-1104d0ee55e7" />


----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
