### PR TITLE
💚 Replace local Docker builds with AWS CodeBuild for Lambda packaging

### DIFF
--- a/iac-terraform/modules/evaluation/buildspec-pip.yml.tpl
+++ b/iac-terraform/modules/evaluation/buildspec-pip.yml.tpl
@@ -1,0 +1,36 @@
+## Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+## SPDX-License-Identifier: MIT-0
+##
+## Buildspec for CodeBuild: pip-install Lambda dependencies and produce a zip artifact.
+## Templated by Terraform — pip_packages and output_zip_name are injected.
+
+version: 0.2
+
+phases:
+  install:
+    commands:
+      - 'echo "Using Python $(python3 --version)"'
+      - 'python3 -m pip install --upgrade pip'
+
+  build:
+    commands:
+      - 'echo "Installing dependencies..."'
+      - 'mkdir -p /tmp/package'
+      - 'python3 -m pip install ${pip_packages} -t /tmp/package --quiet --upgrade'
+      - 'echo "Copying source files..."'
+      - 'cp *.py /tmp/package/'
+      - 'echo "Stripping unnecessary files to reduce package size..."'
+      - 'find /tmp/package -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true'
+      - 'find /tmp/package -type d -name "tests" -exec rm -rf {} + 2>/dev/null || true'
+      - 'find /tmp/package -type d -name "test" -exec rm -rf {} + 2>/dev/null || true'
+      - 'find /tmp/package -type f -name "*.pyc" -delete 2>/dev/null || true'
+      - 'echo "Creating zip artifact..."'
+      - 'cd /tmp/package && zip -r /tmp/output.zip . -q'
+      - 'mkdir -p /tmp/artifacts'
+      - 'cp /tmp/output.zip /tmp/artifacts/${output_zip_name}'
+
+artifacts:
+  files:
+    - '${output_zip_name}'
+  base-directory: '/tmp/artifacts'
+  discard-paths: yes

--- a/iac-terraform/modules/evaluation/codebuild.tf
+++ b/iac-terraform/modules/evaluation/codebuild.tf
@@ -1,0 +1,252 @@
+/* Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0
+----------------------------------------------------------------------
+Evaluation Module - CodeBuild for Evaluation Executor Lambda Package
+
+Replaces the local Docker pip-install with AWS CodeBuild.
+Lambda packages are built in the cloud — no local Docker required.
+
+Creates:
+- S3 objects for source code upload (build context)
+- CodeBuild project for pip install + zip
+- IAM role for CodeBuild
+- null_resource that triggers builds only when source files change
+*/
+
+# -----------------------------------------------------------------------------
+# Local Values for CodeBuild
+# -----------------------------------------------------------------------------
+
+locals {
+  executor_source_dir = "${local.functions_dir}/evaluation-executor"
+
+  # Content-based hash for change detection
+  executor_source_hash = sha256(join("", [
+    filesha256("${local.executor_source_dir}/evaluator.py"),
+    filesha256("${local.executor_source_dir}/index.py"),
+  ]))
+
+  # S3 keys for build context and artifact
+  executor_source_s3_key   = "codebuild/source/evaluation-executor-${local.executor_source_hash}.zip"
+  executor_artifact_s3_key = "lambda-code/evaluation-executor.zip"
+}
+
+# -----------------------------------------------------------------------------
+# Upload Source Files to S3 as Build Context
+# Uses archive_file + aws_s3_object so Terraform tracks the content hash
+# and only re-uploads when source files change.
+# -----------------------------------------------------------------------------
+
+data "archive_file" "executor_source_context" {
+  type        = "zip"
+  source_dir  = local.executor_source_dir
+  output_path = "${path.module}/../../../iac-terraform/build/.evaluation-executor-context.zip"
+  excludes    = ["__pycache__", "*.pyc", ".pytest_cache"]
+}
+
+resource "aws_s3_object" "executor_source_context" {
+  bucket = aws_s3_bucket.evaluations.id
+  key    = local.executor_source_s3_key
+  source = data.archive_file.executor_source_context.output_path
+  etag   = data.archive_file.executor_source_context.output_md5
+
+  depends_on = [data.archive_file.executor_source_context]
+}
+
+# -----------------------------------------------------------------------------
+# IAM Role for CodeBuild
+# Permissions: S3 read (source) + write (artifact), CloudWatch Logs, KMS
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role" "codebuild_executor" {
+  name = "${local.name_prefix}-codebuild-eval-executor"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "codebuild.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-codebuild-eval-executor"
+  })
+}
+
+resource "aws_iam_role_policy" "codebuild_executor" {
+  name = "${local.name_prefix}-codebuild-eval-executor-policy"
+  role = aws_iam_role.codebuild_executor.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      # CloudWatch Logs — write build logs
+      {
+        Sid    = "CloudWatchLogs"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = [
+          "arn:aws:logs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:log-group:/aws/codebuild/${local.name_prefix}-*",
+          "arn:aws:logs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:log-group:/aws/codebuild/${local.name_prefix}-*:*"
+        ]
+      },
+      # S3 — read source context + write artifact
+      {
+        Sid    = "S3ReadSource"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:GetObjectVersion",
+          "s3:GetBucketLocation",
+          "s3:ListBucket"
+        ]
+        Resource = [
+          aws_s3_bucket.evaluations.arn,
+          "${aws_s3_bucket.evaluations.arn}/*"
+        ]
+      },
+      {
+        Sid    = "S3WriteArtifact"
+        Effect = "Allow"
+        Action = [
+          "s3:PutObject",
+          "s3:GetBucketLocation"
+        ]
+        Resource = [
+          aws_s3_bucket.evaluations.arn,
+          "${aws_s3_bucket.evaluations.arn}/*"
+        ]
+      },
+      # KMS — decrypt/encrypt S3 objects
+      {
+        Sid    = "KMSAccess"
+        Effect = "Allow"
+        Action = [
+          "kms:Decrypt",
+          "kms:GenerateDataKey"
+        ]
+        Resource = [var.kms_key_arn]
+      }
+    ]
+  })
+}
+
+# -----------------------------------------------------------------------------
+# CodeBuild Project — Evaluation Executor Lambda Package
+# Installs strands-agents-evals + copies source files → zip artifact on S3
+# -----------------------------------------------------------------------------
+
+resource "aws_codebuild_project" "evaluation_executor" {
+  name         = "${local.name_prefix}-eval-executor-builder"
+  description  = "Builds the evaluation executor Lambda package (pip install + zip)"
+  service_role = aws_iam_role.codebuild_executor.arn
+
+  build_timeout = 15 # minutes
+
+  source {
+    type     = "S3"
+    location = "${aws_s3_bucket.evaluations.id}/${local.executor_source_s3_key}"
+
+    buildspec = templatefile("${path.module}/buildspec-pip.yml.tpl", {
+      pip_packages    = "strands-agents-evals"
+      output_zip_name = "evaluation-executor.zip"
+    })
+  }
+
+  artifacts {
+    type                   = "S3"
+    location               = aws_s3_bucket.evaluations.id
+    path                   = ""
+    name                   = "lambda-code"
+    packaging              = "NONE"
+    override_artifact_name = true
+  }
+
+  environment {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image        = var.lambda_architecture == "arm64" ? "aws/codebuild/amazonlinux-aarch64-standard:3.0" : "aws/codebuild/amazonlinux-x86_64-standard:5.0"
+    type         = var.lambda_architecture == "arm64" ? "ARM_CONTAINER" : "LINUX_CONTAINER"
+  }
+
+  logs_config {
+    cloudwatch_logs {
+      group_name = "/aws/codebuild/${local.name_prefix}-eval-executor-builder"
+    }
+  }
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-eval-executor-builder"
+  })
+}
+
+# -----------------------------------------------------------------------------
+# Trigger: Build Evaluation Executor Package (only when source changes)
+# The executor_source_hash changes only when .py source files change.
+# When it changes, Terraform recreates this null_resource → starts a build.
+# -----------------------------------------------------------------------------
+
+resource "null_resource" "build_evaluation_executor" {
+  triggers = {
+    source_hash = local.executor_source_hash
+    buildspec_hash = sha256(templatefile("${path.module}/buildspec-pip.yml.tpl", {
+      pip_packages    = "strands-agents-evals"
+      output_zip_name = "evaluation-executor.zip"
+    }))
+    project_config = aws_codebuild_project.evaluation_executor.id
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command     = <<-EOT
+      set -euo pipefail
+
+      echo "Starting CodeBuild for evaluation executor package (hash: ${local.executor_source_hash})..."
+
+      BUILD_ID=$(aws codebuild start-build \
+        --project-name "${aws_codebuild_project.evaluation_executor.name}" \
+        --source-location-override "${aws_s3_bucket.evaluations.id}/${local.executor_source_s3_key}" \
+        --query 'build.id' --output text)
+
+      echo "Build started: $BUILD_ID"
+      echo "Waiting for build to complete..."
+
+      while true; do
+        STATUS=$(aws codebuild batch-get-builds --ids "$BUILD_ID" \
+          --query 'builds[0].buildStatus' --output text)
+        case "$STATUS" in
+          SUCCEEDED)
+            echo "✅ Evaluation executor package build succeeded!"
+            break
+            ;;
+          FAILED|FAULT|STOPPED|TIMED_OUT)
+            echo "❌ Build failed with status: $STATUS"
+            LOG_URL=$(aws codebuild batch-get-builds --ids "$BUILD_ID" \
+              --query 'builds[0].logs.deepLink' --output text)
+            echo "Build logs: $LOG_URL"
+            exit 1
+            ;;
+          *)
+            echo "  Build status: $STATUS (waiting...)"
+            sleep 15
+            ;;
+        esac
+      done
+    EOT
+  }
+
+  depends_on = [
+    aws_codebuild_project.evaluation_executor,
+    aws_s3_object.executor_source_context
+  ]
+}

--- a/iac-terraform/modules/evaluation/lambdas.tf
+++ b/iac-terraform/modules/evaluation/lambdas.tf
@@ -93,85 +93,10 @@ resource "aws_cloudwatch_log_group" "evaluation_executor" {
   })
 }
 
-# Build the executor package with strands-agents-evals bundled
-# Uses Docker to avoid requiring local Python/pip and to compile packages for Linux (Lambda runtime)
-resource "null_resource" "evaluation_executor_deps" {
-  triggers = {
-    requirements = filemd5("${local.functions_dir}/evaluation-executor/evaluator.py")
-    index        = filemd5("${local.functions_dir}/evaluation-executor/index.py")
-  }
-
-  provisioner "local-exec" {
-    interpreter = ["/bin/bash", "-c"]
-    command     = <<-EOF
-      set -e
-
-      # Get absolute paths (required for Docker volume mounts)
-      MODULE_DIR="$(cd "${path.module}" && pwd)"
-      SOURCE_DIR="$(cd "${local.functions_dir}/evaluation-executor" && pwd)"
-      BUILD_DIR="$(cd "${path.module}/../../.." && pwd)/iac-terraform/build/evaluation-executor-package"
-
-      echo "Building evaluation executor Lambda package with Docker..."
-      echo "Source: $SOURCE_DIR"
-      echo "Build:  $BUILD_DIR"
-
-      # Clean and create build directory
-      rm -rf "$BUILD_DIR"
-      mkdir -p "$BUILD_DIR"
-
-      # Map Lambda architecture to Docker platform
-      LAMBDA_ARCH="${var.lambda_architecture}"
-      if [ "$LAMBDA_ARCH" = "arm64" ]; then
-        DOCKER_PLATFORM="linux/arm64"
-      else
-        DOCKER_PLATFORM="linux/amd64"
-      fi
-
-      # Build using Docker (consistent with knowledge_base module approach)
-      # Strips tests and __pycache__ to reduce package size (dist-info kept for entry_points discovery)
-      # Uses --platform to compile native extensions (.so) for the correct Lambda architecture
-      # Extract Python minor version from runtime (e.g., "python3.14" -> "3.14")
-      PYTHON_VERSION=$(echo "${var.python_runtime}" | sed 's/python//')
-
-      docker run --rm \
-        --platform "$DOCKER_PLATFORM" \
-        --entrypoint /bin/bash \
-        -v "$SOURCE_DIR":/source:ro \
-        -v "$BUILD_DIR":/output \
-        "public.ecr.aws/docker/library/python:$PYTHON_VERSION-slim" \
-        -c "
-          pip install strands-agents-evals -t /output --quiet --upgrade && \
-          cp /source/*.py /output/ && \
-          find /output -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null; \
-          find /output -type d -name 'tests' -exec rm -rf {} + 2>/dev/null; \
-          find /output -type d -name 'test' -exec rm -rf {} + 2>/dev/null; \
-          find /output -type f -name '*.pyc' -delete 2>/dev/null; \
-          true
-        "
-
-      echo "Evaluation executor package built: $BUILD_DIR"
-    EOF
-  }
-}
-
-data "archive_file" "evaluation_executor" {
-  type        = "zip"
-  source_dir  = "${path.module}/../../../iac-terraform/build/evaluation-executor-package"
-  output_path = "${path.module}/../../../iac-terraform/build/evaluation-executor.zip"
-  excludes    = ["__pycache__", "*.pyc", ".pytest_cache"]
-
-  depends_on = [null_resource.evaluation_executor_deps]
-}
-
-# Upload to S3 first — the bundled zip (~80MB) exceeds Lambda's direct upload limit (67MB)
-resource "aws_s3_object" "evaluation_executor_code" {
-  bucket      = aws_s3_bucket.evaluations.id
-  key         = "lambda-code/evaluation-executor.zip"
-  source      = data.archive_file.evaluation_executor.output_path
-  source_hash = data.archive_file.evaluation_executor.output_md5
-
-  depends_on = [data.archive_file.evaluation_executor]
-}
+# The evaluation executor package (with strands-agents-evals) is built by
+# CodeBuild in codebuild.tf — no local Docker required.
+# CodeBuild uploads the zip artifact directly to:
+#   s3://<evaluations-bucket>/lambda-code/evaluation-executor.zip
 
 resource "aws_lambda_function" "evaluation_executor" {
   # checkov:skip=CKV_AWS_116:DLQ handled by SQS redrive policy
@@ -182,9 +107,9 @@ resource "aws_lambda_function" "evaluation_executor" {
   function_name = "${local.name_prefix}-evaluation-executor"
   description   = "Processes individual evaluation test cases from SQS"
 
-  s3_bucket        = aws_s3_object.evaluation_executor_code.bucket
-  s3_key           = aws_s3_object.evaluation_executor_code.key
-  source_code_hash = data.archive_file.evaluation_executor.output_base64sha256
+  s3_bucket        = aws_s3_bucket.evaluations.id
+  s3_key           = local.executor_artifact_s3_key
+  source_code_hash = local.executor_source_hash
   handler          = "index.handler"
   runtime          = var.python_runtime
   architectures    = [var.lambda_architecture]
@@ -215,7 +140,10 @@ resource "aws_lambda_function" "evaluation_executor" {
     mode = "Active"
   }
 
-  depends_on = [aws_cloudwatch_log_group.evaluation_executor]
+  depends_on = [
+    aws_cloudwatch_log_group.evaluation_executor,
+    null_resource.build_evaluation_executor
+  ]
 
   tags = merge(var.tags, {
     Name = "${local.name_prefix}-evaluation-executor"

--- a/iac-terraform/modules/knowledge_base/buildspec-pip.yml.tpl
+++ b/iac-terraform/modules/knowledge_base/buildspec-pip.yml.tpl
@@ -1,0 +1,36 @@
+## Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+## SPDX-License-Identifier: MIT-0
+##
+## Buildspec for CodeBuild: pip-install Lambda dependencies and produce a zip artifact.
+## Templated by Terraform — pip_packages and output_zip_name are injected.
+
+version: 0.2
+
+phases:
+  install:
+    commands:
+      - 'echo "Using Python $(python3 --version)"'
+      - 'python3 -m pip install --upgrade pip'
+
+  build:
+    commands:
+      - 'echo "Installing dependencies..."'
+      - 'mkdir -p /tmp/package'
+      - 'python3 -m pip install ${pip_packages} -t /tmp/package --quiet --upgrade'
+      - 'echo "Copying source files..."'
+      - 'cp *.py /tmp/package/'
+      - 'echo "Stripping unnecessary files to reduce package size..."'
+      - 'find /tmp/package -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true'
+      - 'find /tmp/package -type d -name "tests" -exec rm -rf {} + 2>/dev/null || true'
+      - 'find /tmp/package -type d -name "test" -exec rm -rf {} + 2>/dev/null || true'
+      - 'find /tmp/package -type f -name "*.pyc" -delete 2>/dev/null || true'
+      - 'echo "Creating zip artifact..."'
+      - 'cd /tmp/package && zip -r /tmp/output.zip . -q'
+      - 'mkdir -p /tmp/artifacts'
+      - 'cp /tmp/output.zip /tmp/artifacts/${output_zip_name}'
+
+artifacts:
+  files:
+    - '${output_zip_name}'
+  base-directory: '/tmp/artifacts'
+  discard-paths: yes

--- a/iac-terraform/modules/knowledge_base/codebuild.tf
+++ b/iac-terraform/modules/knowledge_base/codebuild.tf
@@ -1,0 +1,333 @@
+# -------------------------------------------------------------------------
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# SPDX-License-Identifier: MIT-0
+# -------------------------------------------------------------------------
+# Knowledge Base Module - CodeBuild for Vector Index Creator Lambda Package
+#
+# Replaces the local Docker pip-install with AWS CodeBuild.
+# Lambda packages are built in the cloud — no local Docker required.
+#
+# Creates:
+# - S3 bucket for build context and artifacts
+# - S3 objects for source code upload (build context)
+# - CodeBuild project for pip install + zip
+# - IAM role for CodeBuild
+# - null_resource that triggers builds only when source files change
+# -------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# Local Values for CodeBuild
+# -----------------------------------------------------------------------------
+
+locals {
+  vector_index_source_dir = "${path.module}/lambdas/create-vector-index"
+
+  # Content-based hash for change detection
+  vector_index_source_hash = sha256(join("", [
+    filesha256("${local.vector_index_source_dir}/index.py"),
+    filesha256("${local.vector_index_source_dir}/requirements.txt"),
+  ]))
+
+  # S3 keys for build context and artifact
+  vector_index_source_s3_key   = "source/create-vector-index-${local.vector_index_source_hash}.zip"
+  vector_index_artifact_s3_key = "artifacts/create-vector-index.zip"
+
+  # Name prefix for CodeBuild resources
+  kb_name_prefix = lower(var.prefix)
+}
+
+# -----------------------------------------------------------------------------
+# S3 Bucket for Build Context & Artifacts
+# KB module doesn't have an existing bucket to reuse, so we create a small one.
+# -----------------------------------------------------------------------------
+
+resource "aws_s3_bucket" "kb_build" {
+  # checkov:skip=CKV_AWS_144:Cross-region replication not needed for temporary build artifacts
+  # checkov:skip=CKV_AWS_18:Access logging not needed for temporary build artifacts
+  # checkov:skip=CKV2_AWS_62:Event notifications not needed for build context bucket
+  count = var.enabled ? 1 : 0
+
+  bucket        = "${local.kb_name_prefix}-kb-codebuild-${local.account_id}"
+  force_destroy = true
+
+  tags = merge(var.tags, {
+    Name = "${local.kb_name_prefix}-kb-codebuild"
+  })
+}
+
+resource "aws_s3_bucket_versioning" "kb_build" {
+  count  = var.enabled ? 1 : 0
+  bucket = aws_s3_bucket.kb_build[0].id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "kb_build" {
+  count  = var.enabled ? 1 : 0
+  bucket = aws_s3_bucket.kb_build[0].id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = var.kms_key_arn != null ? "aws:kms" : "AES256"
+      kms_master_key_id = var.kms_key_arn
+    }
+    bucket_key_enabled = var.kms_key_arn != null ? true : false
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "kb_build" {
+  count                   = var.enabled ? 1 : 0
+  bucket                  = aws_s3_bucket.kb_build[0].id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "kb_build" {
+  count  = var.enabled ? 1 : 0
+  bucket = aws_s3_bucket.kb_build[0].id
+
+  rule {
+    id     = "expire-old-contexts"
+    status = "Enabled"
+
+    expiration {
+      days = 7
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 1
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
+    }
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Upload Source Files to S3 as Build Context
+# Uses archive_file + aws_s3_object so Terraform tracks the content hash
+# and only re-uploads when source files change.
+# -----------------------------------------------------------------------------
+
+data "archive_file" "vector_index_source_context" {
+  count = var.enabled ? 1 : 0
+
+  type        = "zip"
+  source_dir  = local.vector_index_source_dir
+  output_path = "${path.module}/build/.vector-index-source-context.zip"
+  excludes    = ["__pycache__", "*.pyc", ".pytest_cache"]
+}
+
+resource "aws_s3_object" "vector_index_source_context" {
+  count = var.enabled ? 1 : 0
+
+  bucket = aws_s3_bucket.kb_build[0].id
+  key    = local.vector_index_source_s3_key
+  source = data.archive_file.vector_index_source_context[0].output_path
+  etag   = data.archive_file.vector_index_source_context[0].output_md5
+
+  depends_on = [data.archive_file.vector_index_source_context]
+}
+
+# -----------------------------------------------------------------------------
+# IAM Role for CodeBuild
+# Permissions: S3 read (source) + write (artifact), CloudWatch Logs, KMS
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role" "codebuild_vector_index" {
+  count = var.enabled ? 1 : 0
+
+  name = "${local.kb_name_prefix}-codebuild-vector-index"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "codebuild.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = merge(var.tags, {
+    Name = "${local.kb_name_prefix}-codebuild-vector-index"
+  })
+}
+
+resource "aws_iam_role_policy" "codebuild_vector_index" {
+  count = var.enabled ? 1 : 0
+
+  name = "${local.kb_name_prefix}-codebuild-vector-index-policy"
+  role = aws_iam_role.codebuild_vector_index[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      # CloudWatch Logs — write build logs
+      {
+        Sid    = "CloudWatchLogs"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = [
+          "arn:aws:logs:${local.region}:${local.account_id}:log-group:/aws/codebuild/${local.kb_name_prefix}-*",
+          "arn:aws:logs:${local.region}:${local.account_id}:log-group:/aws/codebuild/${local.kb_name_prefix}-*:*"
+        ]
+      },
+      # S3 — read source context + write artifact
+      {
+        Sid    = "S3ReadWrite"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:GetObjectVersion",
+          "s3:GetBucketLocation",
+          "s3:ListBucket",
+          "s3:PutObject"
+        ]
+        Resource = [
+          aws_s3_bucket.kb_build[0].arn,
+          "${aws_s3_bucket.kb_build[0].arn}/*"
+        ]
+      },
+      # KMS — decrypt/encrypt S3 objects (conditional)
+      {
+        Sid    = "KMSAccess"
+        Effect = "Allow"
+        Action = [
+          "kms:Decrypt",
+          "kms:GenerateDataKey"
+        ]
+        Resource = var.kms_key_arn != null ? [var.kms_key_arn] : ["*"]
+        Condition = var.kms_key_arn != null ? {} : {
+          StringEquals = {
+            "kms:ViaService" = "s3.${local.region}.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+}
+
+# -----------------------------------------------------------------------------
+# CodeBuild Project — Vector Index Creator Lambda Package
+# Installs opensearch-py + requests-aws4auth, copies source → zip artifact on S3
+# -----------------------------------------------------------------------------
+
+resource "aws_codebuild_project" "vector_index_builder" {
+  count = var.enabled ? 1 : 0
+
+  name         = "${local.kb_name_prefix}-vector-index-builder"
+  description  = "Builds the vector index creator Lambda package (pip install + zip)"
+  service_role = aws_iam_role.codebuild_vector_index[0].arn
+
+  build_timeout = 15 # minutes
+
+  source {
+    type     = "S3"
+    location = "${aws_s3_bucket.kb_build[0].id}/${local.vector_index_source_s3_key}"
+
+    buildspec = templatefile("${path.module}/buildspec-pip.yml.tpl", {
+      pip_packages    = "-r requirements.txt"
+      output_zip_name = "create-vector-index.zip"
+    })
+  }
+
+  artifacts {
+    type                   = "S3"
+    location               = aws_s3_bucket.kb_build[0].id
+    path                   = ""
+    name                   = "artifacts"
+    packaging              = "NONE"
+    override_artifact_name = true
+  }
+
+  environment {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image        = var.lambda_architecture == "arm64" ? "aws/codebuild/amazonlinux-aarch64-standard:3.0" : "aws/codebuild/amazonlinux-x86_64-standard:5.0"
+    type         = var.lambda_architecture == "arm64" ? "ARM_CONTAINER" : "LINUX_CONTAINER"
+  }
+
+  logs_config {
+    cloudwatch_logs {
+      group_name = "/aws/codebuild/${local.kb_name_prefix}-vector-index-builder"
+    }
+  }
+
+  tags = merge(var.tags, {
+    Name = "${local.kb_name_prefix}-vector-index-builder"
+  })
+}
+
+# -----------------------------------------------------------------------------
+# Trigger: Build Vector Index Lambda Package (only when source changes)
+# The vector_index_source_hash changes only when source files change.
+# When it changes, Terraform recreates this null_resource → starts a build.
+# -----------------------------------------------------------------------------
+
+resource "null_resource" "build_vector_index_lambda" {
+  count = var.enabled ? 1 : 0
+
+  triggers = {
+    source_hash = local.vector_index_source_hash
+    buildspec_hash = sha256(templatefile("${path.module}/buildspec-pip.yml.tpl", {
+      pip_packages    = "-r requirements.txt"
+      output_zip_name = "create-vector-index.zip"
+    }))
+    project_config = aws_codebuild_project.vector_index_builder[0].id
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command     = <<-EOT
+      set -euo pipefail
+
+      echo "Starting CodeBuild for vector index Lambda package (hash: ${local.vector_index_source_hash})..."
+
+      BUILD_ID=$(aws codebuild start-build \
+        --project-name "${aws_codebuild_project.vector_index_builder[0].name}" \
+        --source-location-override "${aws_s3_bucket.kb_build[0].id}/${local.vector_index_source_s3_key}" \
+        --query 'build.id' --output text)
+
+      echo "Build started: $BUILD_ID"
+      echo "Waiting for build to complete..."
+
+      while true; do
+        STATUS=$(aws codebuild batch-get-builds --ids "$BUILD_ID" \
+          --query 'builds[0].buildStatus' --output text)
+        case "$STATUS" in
+          SUCCEEDED)
+            echo "✅ Vector index Lambda package build succeeded!"
+            break
+            ;;
+          FAILED|FAULT|STOPPED|TIMED_OUT)
+            echo "❌ Build failed with status: $STATUS"
+            LOG_URL=$(aws codebuild batch-get-builds --ids "$BUILD_ID" \
+              --query 'builds[0].logs.deepLink' --output text)
+            echo "Build logs: $LOG_URL"
+            exit 1
+            ;;
+          *)
+            echo "  Build status: $STATUS (waiting...)"
+            sleep 15
+            ;;
+        esac
+      done
+    EOT
+  }
+
+  depends_on = [
+    aws_codebuild_project.vector_index_builder,
+    aws_s3_object.vector_index_source_context
+  ]
+}

--- a/iac-terraform/modules/knowledge_base/main.tf
+++ b/iac-terraform/modules/knowledge_base/main.tf
@@ -316,67 +316,10 @@ resource "aws_opensearchserverless_access_policy" "data" {
 
 # -----------------------------------------------------------------------------
 # Lambda Function Package (with dependencies)
+# Built by CodeBuild in codebuild.tf — no local Docker required.
+# CodeBuild uploads the zip artifact to:
+#   s3://<kb-build-bucket>/artifacts/create-vector-index.zip
 # -----------------------------------------------------------------------------
-
-resource "null_resource" "build_vector_index_lambda" {
-  count = var.enabled ? 1 : 0
-
-  triggers = {
-    source_hash       = filesha256("${path.module}/lambdas/create-vector-index/index.py")
-    requirements_hash = filesha256("${path.module}/lambdas/create-vector-index/requirements.txt")
-  }
-
-  provisioner "local-exec" {
-    interpreter = ["/bin/bash", "-c"]
-    command     = <<-EOF
-      set -e
-
-      # Get absolute paths (required for Docker volume mounts)
-      MODULE_DIR="$(cd "${path.module}" && pwd)"
-      SOURCE_DIR="$MODULE_DIR/lambdas/create-vector-index"
-      BUILD_DIR="$MODULE_DIR/build/create-vector-index-package"
-      OUTPUT_ZIP="$MODULE_DIR/build/create-vector-index.zip"
-
-      echo "Building Lambda package with dependencies using Docker..."
-      echo "Source: $SOURCE_DIR"
-      echo "Build: $BUILD_DIR"
-
-      # Clean and create build directory
-      rm -rf "$BUILD_DIR"
-      mkdir -p "$BUILD_DIR"
-      mkdir -p "$MODULE_DIR/build"
-
-      # Build using Docker (no local Python required)
-      # Use standard Python image with --entrypoint override
-      docker run --rm \
-        --entrypoint /bin/bash \
-        -v "$SOURCE_DIR":/source:ro \
-        -v "$BUILD_DIR":/output \
-        public.ecr.aws/docker/library/python:3.12-slim \
-        -c "
-          pip install -r /source/requirements.txt -t /output --quiet --upgrade && \
-          cp /source/index.py /output/
-        "
-
-      # Create zip
-      cd "$BUILD_DIR"
-      rm -f "$OUTPUT_ZIP"
-      zip -r "$OUTPUT_ZIP" . -q
-
-      echo "Lambda package built: $OUTPUT_ZIP"
-    EOF
-  }
-}
-
-data "archive_file" "vector_index_lambda" {
-  count = var.enabled ? 1 : 0
-
-  type        = "zip"
-  source_dir  = "${path.module}/build/create-vector-index-package"
-  output_path = "${path.module}/build/create-vector-index.zip"
-
-  depends_on = [null_resource.build_vector_index_lambda]
-}
 
 # -----------------------------------------------------------------------------
 # Lambda Function to Create Vector Index
@@ -398,8 +341,9 @@ resource "aws_lambda_function" "create_vector_index" {
   timeout       = 900 # 15 minutes for retries
   memory_size   = 256
 
-  filename         = data.archive_file.vector_index_lambda[0].output_path
-  source_code_hash = data.archive_file.vector_index_lambda[0].output_base64sha256
+  s3_bucket        = aws_s3_bucket.kb_build[0].id
+  s3_key           = local.vector_index_artifact_s3_key
+  source_code_hash = local.vector_index_source_hash
 
   layers = [
     var.powertools_layer_arn,
@@ -420,7 +364,8 @@ resource "aws_lambda_function" "create_vector_index" {
 
   depends_on = [
     aws_iam_role_policy.vector_index_lambda_policy,
-    aws_opensearchserverless_access_policy.data
+    aws_opensearchserverless_access_policy.data,
+    null_resource.build_vector_index_lambda
   ]
 
   tags = var.tags


### PR DESCRIPTION
This PR eliminates the local Docker dependency for Lambda function packaging in the **evaluation** and **knowledge_base** Terraform modules. Instead of running `pip install` inside a local Docker container, Lambda deployment packages are now built in the cloud using AWS CodeBuild — following the same pattern already established by the `agent_core` module for Docker image builds.

## Motivation

Previously, deploying these modules required Docker to be installed and running locally. This created friction for developers, CI/CD pipelines, and environments where Docker is unavailable or impractical. By moving the build step to CodeBuild, we:

- **Remove the local Docker dependency** for `terraform apply`
- **Ensure consistent, reproducible builds** using AWS-managed build environments
- **Align packaging approach** across all modules that need cloud-side builds

## Changes

### Files Changed (6 files, +676 / -146 lines)

| File | Change |
|------|--------|
| `modules/evaluation/buildspec-pip.yml.tpl` | **New** — Generic buildspec template for pip-based Lambda packaging |
| `modules/evaluation/codebuild.tf` | **New** — CodeBuild project, IAM role, S3 source upload, build trigger |
| `modules/evaluation/lambdas.tf` | **Modified** — Removed Docker-based packaging; Lambda now references CodeBuild artifact in S3 |
| `modules/knowledge_base/buildspec-pip.yml.tpl` | **New** — Same buildspec template (supports `-r requirements.txt`) |
| `modules/knowledge_base/codebuild.tf` | **New** — CodeBuild project, dedicated S3 build bucket, IAM role, build trigger |
| `modules/knowledge_base/main.tf` | **Modified** — Removed Docker-based packaging; Lambda now references CodeBuild artifact in S3 |

### Architecture

```
Source code (local) ──upload──▶ S3 (source zip)
                                   │
                              CodeBuild
                              ├─ pip install → /tmp/package
                              ├─ copy *.py
                              ├─ strip __pycache__, tests, .pyc
                              └─ zip ──▶ S3 (artifact zip)
                                            │
                                       Lambda function
```

### Key Design Decisions

1. **Buildspec uses `python3` (not version-specific)** — CodeBuild managed images (AL2 standard 3.0/5.0) ship with Python 3.11/3.12. Using a generic `python3` binary avoids breakage when the runtime variable specifies a version not present in the build image.

2. **S3 artifact path convention** — CodeBuild S3 artifacts with `packaging = "NONE"` treat `path` + `name` as a directory prefix. We use `path = ""` and `name = "<directory>"` so the zip file lands at a predictable key (e.g., `lambda-code/evaluation-executor.zip`).

3. **Robust `null_resource` triggers** — The build trigger includes `source_hash`, `buildspec_hash`, and `project_config` (CodeBuild project ID) to ensure rebuilds happen when source code, build instructions, or project configuration changes.

4. **Knowledge base uses a dedicated build bucket** — Since the KB module's existing S3 buckets are purpose-specific, a new `kb_build` bucket with 7-day lifecycle cleanup is created for build artifacts.

5. **Conditional resource creation** — All KB module resources use `count = var.enabled ? 1 : 0` gating, consistent with the existing module pattern.

## Testing

- [x] `terraform validate` passes for both modules
- [x] Evaluation module deployed and verified end-to-end (CodeBuild succeeds, Lambda artifact created in S3, Lambda function operational)
- [x] Knowledge base module deployment (pending)

## Dependencies

- No new Terraform providers required
- Uses existing AWS CodeBuild service (already used by `agent_core` module)
- No changes to Lambda function source code

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
