### PR TITLE
🛂 tf: add missing IAM permissions for agent runtime deletion

### DIFF
--- a/iac-terraform/modules/agent_core_apis/lambdas/step_functions.tf
+++ b/iac-terraform/modules/agent_core_apis/lambdas/step_functions.tf
@@ -57,7 +57,7 @@ locals {
       name        = "startDeleteRuntime"
       asset       = "delete-agent-runtime"
       description = "Initiates deletion of Bedrock AgentCore runtime"
-      permissions = ["bedrock-agentcore:DeleteAgentRuntime"]
+      permissions = ["bedrock-agentcore:DeleteAgentRuntime", "bedrock-agentcore:DeleteAgentRuntimeEndpoint"]
       resource    = "runtime/*"
       extra_envs  = {}
     }
@@ -267,6 +267,24 @@ resource "aws_iam_role_policy" "step_function_lambdas_bedrock" {
         Effect   = "Allow"
         Action   = each.value.permissions
         Resource = "arn:aws:bedrock-agentcore:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:${each.value.resource}"
+      }
+    ]
+  })
+}
+
+# DeleteWorkloadIdentity permission for delete_runtime function
+resource "aws_iam_role_policy" "delete_runtime_workload_identity" {
+  name = "${local.name_prefix}-startDeleteRuntime-workload-identity"
+  role = aws_iam_role.step_function_lambdas["delete_runtime"].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "DeleteWorkloadIdentity"
+        Effect   = "Allow"
+        Action   = ["bedrock-agentcore:DeleteWorkloadIdentity"]
+        Resource = "arn:aws:bedrock-agentcore:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:workload-identity-directory/*"
       }
     ]
   })


### PR DESCRIPTION
*Description of changes:*

Add DeleteAgentRuntimeEndpoint and DeleteWorkloadIdentity permissions to the delete runtime Lambda function to ensure complete cleanup of associated AgentCore resources when deleting a runtime.

This is the same issue that we fixed in 8413270fc05cc8746c2bc4890b9942849aa19342 but applying now to Terraform

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
