### PR TITLE
✨ propagate session state from API to agent runtime

### DIFF
--- a/src/agent-core/docker-agents-as-tools/app.py
+++ b/src/agent-core/docker-agents-as-tools/app.py
@@ -57,8 +57,12 @@ async def invoke(payload: dict, context: RequestContext):
         MEMORY_EXPORTER.clear()
         logger.info("Trajectory capture enabled for this request")
 
+    # Parse optional session state from payload (stringified JSON)
+    state_json = payload.get("state")
+    state = json.loads(state_json) if state_json else None
+
     if ORCHESTRATOR is None or SESSION_ID != session_id:
-        _initialize(user_id, session_id, include_trajectory)
+        _initialize(user_id, session_id, include_trajectory, state=state)
 
     _reset(include_trajectory)
 
@@ -123,7 +127,12 @@ def _get_context(payload: dict, context: RequestContext) -> tuple[str, str]:
     return user_id, session_id
 
 
-def _initialize(user_id: str, session_id: str, include_trajectory: bool):
+def _initialize(
+    user_id: str,
+    session_id: str,
+    include_trajectory: bool,
+    state: dict | None = None,
+):
     """initialize a new agent once for each runtime container session
 
     Conversation state will be persisted in both local memory and remote agentcore memory.
@@ -189,6 +198,7 @@ def _initialize(user_id: str, session_id: str, include_trajectory: bool):
             MCP_CLIENT_MANAGER,
             session_manager,
             trace_attributes=trace_attrs,  # type: ignore
+            state=state,
         )
         SESSION_ID = session_id
 

--- a/src/agent-core/docker-agents-as-tools/src/factory.py
+++ b/src/agent-core/docker-agents-as-tools/src/factory.py
@@ -35,6 +35,7 @@ def create_orchestrator(
     mcp_client_manager: MCPClientManager | None,
     session_manager: Any | None = None,
     trace_attributes: dict[str, str] | None = None,
+    state: dict | None = None,
 ) -> tuple[Agent, AgentCallbacks]:
     """
     Create and configure a Strands Agent with tools, callbacks, and conversation management.
@@ -69,6 +70,7 @@ def create_orchestrator(
         ),
         session_manager=session_manager,
         trace_attributes=trace_attributes,
+        state=state,
     )
     callbacks = AgentCallbacks(logger, session_id, user_id)
 

--- a/src/agent-core/docker-swarm/app.py
+++ b/src/agent-core/docker-swarm/app.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: MIT-0
 # ---------------------------------------------------------------------------- #
+import json
 import logging
 import os
 from datetime import datetime, timezone
@@ -103,6 +104,10 @@ async def invoke(payload, context: RequestContext):
                     extra={"context": {"memoryId": MEMORY_ID}},
                 )
 
+            # Parse optional session state from payload (stringified JSON)
+            state_json = payload.get("state")
+            state = json.loads(state_json) if state_json else None
+
             SWARM, CALLBACKS, AGENTS = create_swarm(
                 configuration,
                 logger,
@@ -110,6 +115,7 @@ async def invoke(payload, context: RequestContext):
                 user_id=user_id,
                 mcp_client_manager=MCP_CLIENT_MANAGER,
                 session_manager=None,
+                state=state,
             )
             CURRENT_SESSION_ID = session_id
 

--- a/src/agent-core/docker-swarm/src/factory.py
+++ b/src/agent-core/docker-swarm/src/factory.py
@@ -32,6 +32,7 @@ def create_swarm(
     user_id: str,
     mcp_client_manager: MCPClientManager | None,
     session_manager: Any | None = None,
+    state: dict | None = None,
 ) -> tuple[Swarm, AgentCallbacks, dict[str, Agent]]:
     """
     Create and configure a Strands Swarm with multiple agents.
@@ -58,6 +59,7 @@ def create_swarm(
             mcp_client_manager=mcp_client_manager,
             conversation_manager_type=configuration.conversationManager,
             session_manager=session_manager,
+            state=state,
         )
         agents[agent_def.name] = agent
 
@@ -114,6 +116,7 @@ def _create_agent_from_definition(
     mcp_client_manager: MCPClientManager | None,
     conversation_manager_type: EConversationManagerType,
     session_manager: Any | None = None,
+    state: dict | None = None,
 ) -> Agent:
     """
     Create a single Agent from a SwarmAgentDefinition.
@@ -149,6 +152,7 @@ def _create_agent_from_definition(
             conversation_manager_type.value, logger
         ),
         session_manager=session_manager,
+        state=state,
     )
 
     logger.info(

--- a/src/agent-core/docker/app.py
+++ b/src/agent-core/docker/app.py
@@ -131,6 +131,10 @@ async def invoke(payload, context: RequestContext):
                     "Agent configured with trace attributes for trajectory capture"
                 )
 
+            # Parse optional session state from payload (stringified JSON)
+            state_json = payload.get("state")
+            state = json.loads(state_json) if state_json else None
+
             AGENT, CALLBACKS = create_agent(
                 configuration,
                 logger,
@@ -139,6 +143,7 @@ async def invoke(payload, context: RequestContext):
                 MCP_CLIENT_MANAGER,
                 session_manager,
                 trace_attributes=trace_attrs,  # type: ignore
+                state=state,
             )
             CURRENT_SESSION_ID = session_id
 

--- a/src/agent-core/docker/src/factory.py
+++ b/src/agent-core/docker/src/factory.py
@@ -34,6 +34,7 @@ def create_agent(
     mcp_client_manager: MCPClientManager | None,
     session_manager: Any | None = None,
     trace_attributes: dict[str, str] | None = None,
+    state: dict | None = None,
 ) -> tuple[Agent, AgentCallbacks]:
     """
     Create and configure a Strands Agent with tools, callbacks, and conversation management.
@@ -68,6 +69,7 @@ def create_agent(
         ),
         session_manager=session_manager,
         trace_attributes=trace_attributes,
+        state=state,
     )
     callbacks = AgentCallbacks(logger, session_id, user_id)
 

--- a/src/genai-interface/functions/agent-core/index.py
+++ b/src/genai-interface/functions/agent-core/index.py
@@ -54,6 +54,7 @@ class CallArguments(BaseModel):
     text: Optional[str] = None
     agentRuntimeId: Optional[str] = None
     qualifier: Optional[str] = None
+    state: Optional[str] = None
 
 
 class InputModel(BaseModel):
@@ -177,13 +178,15 @@ def handle_run(record: InputModel) -> None:
         },
     )
     try:
-        payload = json.dumps(
-            {
-                "prompt": record.data.text,
-                "userId": record.userId,
-                "messageId": record.data.messageId,
-            }
-        ).encode()
+        payload_dict = {
+            "prompt": record.data.text,
+            "userId": record.userId,
+            "messageId": record.data.messageId,
+        }
+        if record.data.state is not None:
+            payload_dict["state"] = record.data.state
+
+        payload = json.dumps(payload_dict).encode()
 
         response = AC_CLIENT.invoke_agent_runtime(
             agentRuntimeArn=record.data.agentRuntimeId,


### PR DESCRIPTION
Add support for passing optional session state from the client through the Lambda handler and agent invocation pipeline to the Strands Agent constructor. This enables callers to inject initial state (e.g., context variables) into agent sessions.

- Add `state` field to `CallArguments` in the GenAI interface Lambda
- Thread state through the invoke payload to AgentCore runtimes
- Parse stringified JSON state in docker, docker-agents-as-tools, and docker-swarm entry points and pass to agent initialization
- Extend factory functions (`create_agent`, `create_orchestrator`, `create_swarm`) with `state` parameter forwarded to Agent constructor

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
