### PR TITLE
🛂 add cross-account Bedrock access via STS AssumeRole

### DIFF
--- a/iac-cdk/lib/agent-core/index.ts
+++ b/iac-cdk/lib/agent-core/index.ts
@@ -372,6 +372,16 @@ export class AcaAgentCoreContainer extends Construct {
                     `arn:aws:bedrock-agentcore:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:gateway/*`,
                 ],
             }),
+            // Cross-account Bedrock access via STS AssumeRole
+            ...(props.config.bedrockAccessRoleArn
+                ? [
+                      new iam.PolicyStatement({
+                          sid: "CrossAccountBedrockAccess",
+                          actions: ["sts:AssumeRole"],
+                          resources: [props.config.bedrockAccessRoleArn],
+                      }),
+                  ]
+                : []),
             new iam.PolicyStatement({
                 sid: "AgentCoreMemoryActions",
                 actions: [
@@ -489,6 +499,9 @@ export class AcaAgentCoreContainer extends Construct {
                     agentToolsTopicArn: agentToolsTopic.topicArn,
                     ...(memory && {
                         memoryId: memory.memoryId,
+                    }),
+                    ...(props.config.bedrockAccessRoleArn && {
+                        bedrockAccessRoleArn: props.config.bedrockAccessRoleArn,
                     }),
                 },
                 tags: {

--- a/iac-cdk/lib/api/agent-core-runtime.ts
+++ b/iac-cdk/lib/api/agent-core-runtime.ts
@@ -602,6 +602,9 @@ export class AgentCoreApis extends Construct {
                 AGENT_TOOLS_TOPIC_ARN: props.agentToolsTopic.topicArn,
                 AGENTS_TABLE_NAME: props.agentCoreRuntimeTable.tableName,
                 AGENTS_SUMMARY_TABLE_NAME: props.agentCoreSummaryTable.tableName,
+                ...(props.config.bedrockAccessRoleArn && {
+                    BEDROCK_ACCESS_ROLE_ARN: props.config.bedrockAccessRoleArn,
+                }),
             },
         });
         // TODO - consider using a custom policy with minimal permissions

--- a/iac-cdk/lib/shared/types.ts
+++ b/iac-cdk/lib/shared/types.ts
@@ -335,6 +335,8 @@ export interface ExperimentsConfig {
 export interface SystemConfig {
     prefix: string;
 
+    bedrockAccessRoleArn?: string;
+
     enableGeoRestrictions: boolean;
 
     allowedGeoRegions: string[];

--- a/iac-terraform/main.tf
+++ b/iac-terraform/main.tf
@@ -168,6 +168,9 @@ module "agent_core" {
   # The knowledge_base module outputs the ID which you can then add here for subsequent applies
   knowledge_base_id = var.knowledge_base_id
 
+  # Cross-account Bedrock access
+  bedrock_access_role_arn = var.bedrock_access_role_arn
+
   # KMS key from root level (breaks circular dependency)
   kms_key_arn = aws_kms_key.main.arn
   kms_key_id  = aws_kms_key.main.key_id
@@ -329,6 +332,9 @@ module "agent_core_apis" {
   notify_runtime_update_s3_bucket   = module.shared.notify_runtime_update_s3_bucket
   notify_runtime_update_s3_key      = module.shared.notify_runtime_update_s3_key
   notify_runtime_update_source_hash = module.shared.notify_runtime_update_source_hash
+
+  # Cross-account Bedrock access
+  bedrock_access_role_arn = var.bedrock_access_role_arn
 
   depends_on = [module.appsync, module.agent_core, module.websocket_backend]
 }

--- a/iac-terraform/modules/agent_core/agentcore_runtime.tf
+++ b/iac-terraform/modules/agent_core/agentcore_runtime.tf
@@ -50,16 +50,19 @@ resource "aws_bedrockagentcore_agent_runtime" "default" {
     network_mode = "PUBLIC"
   }
 
-  environment_variables = {
-    accountId          = data.aws_caller_identity.current.account_id
-    agentName          = local.agent_name
-    createdAt          = local.created_at
-    tableName          = aws_dynamodb_table.agent_runtime_config.name
-    toolRegistry       = aws_dynamodb_table.tool_registry.name
-    mcpServerRegistry  = aws_dynamodb_table.mcp_server_registry.name
-    agentToolsTopicArn = aws_sns_topic.agent_tools.arn
-    memoryId           = var.agent_runtime_config.memory_config != null ? aws_bedrockagentcore_memory.default[0].id : ""
-  }
+  environment_variables = merge(
+    {
+      accountId          = data.aws_caller_identity.current.account_id
+      agentName          = local.agent_name
+      createdAt          = local.created_at
+      tableName          = aws_dynamodb_table.agent_runtime_config.name
+      toolRegistry       = aws_dynamodb_table.tool_registry.name
+      mcpServerRegistry  = aws_dynamodb_table.mcp_server_registry.name
+      agentToolsTopicArn = aws_sns_topic.agent_tools.arn
+      memoryId           = var.agent_runtime_config.memory_config != null ? aws_bedrockagentcore_memory.default[0].id : ""
+    },
+    var.bedrock_access_role_arn != null ? { bedrockAccessRoleArn = var.bedrock_access_role_arn } : {}
+  )
 
   dynamic "lifecycle_configuration" {
     for_each = var.agent_runtime_config.lifecycle_config != null ? [1] : []

--- a/iac-terraform/modules/agent_core/codebuild.tf
+++ b/iac-terraform/modules/agent_core/codebuild.tf
@@ -405,7 +405,8 @@ resource "null_resource" "build_agent_image" {
   depends_on = [
     aws_codebuild_project.agent_image_builder,
     aws_s3_object.agent_docker_context,
-    aws_ecr_repository.agent_core
+    aws_ecr_repository.agent_core,
+    aws_iam_role_policy.codebuild
   ]
 }
 
@@ -461,7 +462,8 @@ resource "null_resource" "build_swarm_image" {
   depends_on = [
     aws_codebuild_project.swarm_image_builder,
     aws_s3_object.swarm_docker_context,
-    aws_ecr_repository.swarm_agent_core
+    aws_ecr_repository.swarm_agent_core,
+    aws_iam_role_policy.codebuild
   ]
 }
 
@@ -568,7 +570,8 @@ resource "null_resource" "build_graph_image" {
   depends_on = [
     aws_codebuild_project.graph_image_builder,
     aws_s3_object.graph_docker_context,
-    aws_ecr_repository.graph_agent_core
+    aws_ecr_repository.graph_agent_core,
+    aws_iam_role_policy.codebuild
   ]
 }
 
@@ -675,6 +678,7 @@ resource "null_resource" "build_agents_as_tools_image" {
   depends_on = [
     aws_codebuild_project.agents_as_tools_image_builder,
     aws_s3_object.agents_as_tools_docker_context,
-    aws_ecr_repository.agents_as_tools_agent_core
+    aws_ecr_repository.agents_as_tools_agent_core,
+    aws_iam_role_policy.codebuild
   ]
 }

--- a/iac-terraform/modules/agent_core/iam.tf
+++ b/iac-terraform/modules/agent_core/iam.tf
@@ -259,3 +259,27 @@ resource "aws_iam_role_policy" "execution" {
   role   = aws_iam_role.execution.id
   policy = data.aws_iam_policy_document.agentcore_execution.json
 }
+
+# -----------------------------------------------------------------------------
+# Cross-Account Bedrock Access Policy (Optional)
+# Allows the execution role to assume a role in another account for Bedrock
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role_policy" "cross_account_bedrock" {
+  count = var.bedrock_access_role_arn != null ? 1 : 0
+
+  name = "${local.name_prefix}-CrossAccountBedrockAccess"
+  role = aws_iam_role.execution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "AllowAssumeRoleForBedrockAccess"
+        Effect   = "Allow"
+        Action   = "sts:AssumeRole"
+        Resource = var.bedrock_access_role_arn
+      }
+    ]
+  })
+}

--- a/iac-terraform/modules/agent_core/variables.tf
+++ b/iac-terraform/modules/agent_core/variables.tf
@@ -166,6 +166,16 @@ variable "kms_key_id" {
 }
 
 # -----------------------------------------------------------------------------
+# Cross-Account Bedrock Access (Optional)
+# -----------------------------------------------------------------------------
+
+variable "bedrock_access_role_arn" {
+  description = "Optional ARN of a cross-account IAM role to assume for Bedrock model invocation."
+  type        = string
+  default     = null
+}
+
+# -----------------------------------------------------------------------------
 # Knowledge Base Integration
 # -----------------------------------------------------------------------------
 

--- a/iac-terraform/modules/agent_core_apis/lambdas/step_functions.tf
+++ b/iac-terraform/modules/agent_core_apis/lambdas/step_functions.tf
@@ -376,25 +376,28 @@ resource "aws_lambda_function" "create_runtime_version" {
   ]
 
   environment {
-    variables = {
-      POWERTOOLS_SERVICE_NAME       = "startRuntimeCreation"
-      POWERTOOLS_LOG_LEVEL          = "INFO"
-      REGION_NAME                   = data.aws_region.current.id
-      CONTAINER_URI                 = var.container_uri
-      SWARM_CONTAINER_URI           = var.swarm_container_uri
-      GRAPH_CONTAINER_URI           = var.graph_container_uri
-      AGENTS_AS_TOOLS_CONTAINER_URI = var.agents_as_tools_container_uri
-      AGENT_CORE_RUNTIME_ROLE_ARN   = var.agent_core_execution_role_arn
-      AGENT_CORE_RUNTIME_TABLE      = var.agent_core_runtime_table_name
-      TOOL_REGISTRY_TABLE           = var.tool_registry_table_name
-      MCP_SERVER_REGISTRY_TABLE     = var.mcp_server_registry_table_name
-      ACCOUNT_ID                    = data.aws_caller_identity.current.account_id
-      ENVIRONMENT_TAG               = var.environment_tag
-      STACK_TAG                     = var.stack_tag
-      AGENT_TOOLS_TOPIC_ARN         = var.agent_tools_topic_arn
-      AGENTS_TABLE_NAME             = var.agent_core_runtime_table_name
-      AGENTS_SUMMARY_TABLE_NAME     = var.agent_core_summary_table_name
-    }
+    variables = merge(
+      {
+        POWERTOOLS_SERVICE_NAME       = "startRuntimeCreation"
+        POWERTOOLS_LOG_LEVEL          = "INFO"
+        REGION_NAME                   = data.aws_region.current.id
+        CONTAINER_URI                 = var.container_uri
+        SWARM_CONTAINER_URI           = var.swarm_container_uri
+        GRAPH_CONTAINER_URI           = var.graph_container_uri
+        AGENTS_AS_TOOLS_CONTAINER_URI = var.agents_as_tools_container_uri
+        AGENT_CORE_RUNTIME_ROLE_ARN   = var.agent_core_execution_role_arn
+        AGENT_CORE_RUNTIME_TABLE      = var.agent_core_runtime_table_name
+        TOOL_REGISTRY_TABLE           = var.tool_registry_table_name
+        MCP_SERVER_REGISTRY_TABLE     = var.mcp_server_registry_table_name
+        ACCOUNT_ID                    = data.aws_caller_identity.current.account_id
+        ENVIRONMENT_TAG               = var.environment_tag
+        STACK_TAG                     = var.stack_tag
+        AGENT_TOOLS_TOPIC_ARN         = var.agent_tools_topic_arn
+        AGENTS_TABLE_NAME             = var.agent_core_runtime_table_name
+        AGENTS_SUMMARY_TABLE_NAME     = var.agent_core_summary_table_name
+      },
+      var.bedrock_access_role_arn != null ? { BEDROCK_ACCESS_ROLE_ARN = var.bedrock_access_role_arn } : {}
+    )
   }
 
   tracing_config {

--- a/iac-terraform/modules/agent_core_apis/lambdas/variables.tf
+++ b/iac-terraform/modules/agent_core_apis/lambdas/variables.tf
@@ -213,3 +213,13 @@ variable "notify_runtime_update_source_hash" {
   description = "Content hash for change detection"
   type        = string
 }
+
+# -----------------------------------------------------------------------------
+# Cross-Account Bedrock Access (Optional)
+# -----------------------------------------------------------------------------
+
+variable "bedrock_access_role_arn" {
+  description = "Optional ARN of a cross-account IAM role to assume for Bedrock model invocation."
+  type        = string
+  default     = null
+}

--- a/iac-terraform/modules/agent_core_apis/main.tf
+++ b/iac-terraform/modules/agent_core_apis/main.tf
@@ -89,6 +89,9 @@ module "lambdas" {
   notify_runtime_update_s3_bucket   = var.notify_runtime_update_s3_bucket
   notify_runtime_update_s3_key      = var.notify_runtime_update_s3_key
   notify_runtime_update_source_hash = var.notify_runtime_update_source_hash
+
+  # Cross-account Bedrock access
+  bedrock_access_role_arn = var.bedrock_access_role_arn
 }
 
 # -----------------------------------------------------------------------------

--- a/iac-terraform/modules/agent_core_apis/variables.tf
+++ b/iac-terraform/modules/agent_core_apis/variables.tf
@@ -191,3 +191,13 @@ variable "notify_runtime_update_source_hash" {
   description = "Content hash for change detection"
   type        = string
 }
+
+# -----------------------------------------------------------------------------
+# Cross-Account Bedrock Access (Optional)
+# -----------------------------------------------------------------------------
+
+variable "bedrock_access_role_arn" {
+  description = "Optional ARN of a cross-account IAM role to assume for Bedrock model invocation."
+  type        = string
+  default     = null
+}

--- a/iac-terraform/modules/evaluation/codebuild.tf
+++ b/iac-terraform/modules/evaluation/codebuild.tf
@@ -247,6 +247,7 @@ resource "null_resource" "build_evaluation_executor" {
 
   depends_on = [
     aws_codebuild_project.evaluation_executor,
-    aws_s3_object.executor_source_context
+    aws_s3_object.executor_source_context,
+    aws_iam_role_policy.codebuild_executor
   ]
 }

--- a/iac-terraform/modules/knowledge_base/codebuild.tf
+++ b/iac-terraform/modules/knowledge_base/codebuild.tf
@@ -328,6 +328,7 @@ resource "null_resource" "build_vector_index_lambda" {
 
   depends_on = [
     aws_codebuild_project.vector_index_builder,
-    aws_s3_object.vector_index_source_context
+    aws_s3_object.vector_index_source_context,
+    aws_iam_role_policy.codebuild_vector_index
   ]
 }

--- a/iac-terraform/modules/shared/codebuild-layers.tf
+++ b/iac-terraform/modules/shared/codebuild-layers.tf
@@ -293,7 +293,8 @@ resource "null_resource" "build_boto3_layer" {
 
   depends_on = [
     aws_codebuild_project.boto3_layer_builder,
-    aws_s3_object.boto3_requirements
+    aws_s3_object.boto3_requirements,
+    aws_iam_role_policy.layer_builder
   ]
 }
 
@@ -432,6 +433,7 @@ resource "null_resource" "build_notify_runtime_update" {
 
   depends_on = [
     aws_codebuild_project.notify_runtime_update_builder,
-    aws_s3_object.notify_runtime_update_source
+    aws_s3_object.notify_runtime_update_source,
+    aws_iam_role_policy.layer_builder
   ]
 }

--- a/iac-terraform/modules/user_interface/codebuild.tf
+++ b/iac-terraform/modules/user_interface/codebuild.tf
@@ -329,6 +329,7 @@ resource "null_resource" "build_react_app_codebuild" {
     aws_s3_object.react_source,
     aws_s3_object.aws_exports,
     aws_s3_bucket.website,
-    aws_cloudfront_distribution.website
+    aws_cloudfront_distribution.website,
+    aws_iam_role_policy.codebuild
   ]
 }

--- a/iac-terraform/terraform.tfvars.example
+++ b/iac-terraform/terraform.tfvars.example
@@ -26,6 +26,22 @@ aws_region = "us-east-1"
 # aws_profile = "your-profile-name"
 
 # =============================================================================
+# Optional: Cross-Account Bedrock Access
+# =============================================================================
+
+# ARN of a cross-account IAM role to assume for Bedrock model invocation (optional)
+# When set, agent runtimes will use STS AssumeRole to obtain temporary credentials
+# for invoking Bedrock models in the target account. This is useful when model access
+# is centralized in a separate AWS account.
+#
+# Prerequisites:
+# 1. The target account must have a role that trusts this account's AgentCore execution role
+# 2. The target role must have bedrock:InvokeModel* permissions
+#
+# Example:
+# bedrock_access_role_arn = "arn:aws:iam::<accountID>:role/<roleName>"
+
+# =============================================================================
 # Optional: Lambda Configuration
 # =============================================================================
 

--- a/iac-terraform/variables.tf
+++ b/iac-terraform/variables.tf
@@ -43,6 +43,16 @@ variable "environment" {
 }
 
 # -----------------------------------------------------------------------------
+# Cross-Account Bedrock Access (Optional)
+# -----------------------------------------------------------------------------
+
+variable "bedrock_access_role_arn" {
+  description = "Optional ARN of a cross-account IAM role to assume for Bedrock model invocation. When set, agents will use STS AssumeRole to obtain temporary credentials for Bedrock API calls in the target account."
+  type        = string
+  default     = null
+}
+
+# -----------------------------------------------------------------------------
 # Agent Core Configuration
 # -----------------------------------------------------------------------------
 

--- a/src/agent-core/shared/base_factory.py
+++ b/src/agent-core/shared/base_factory.py
@@ -7,8 +7,11 @@
 # ---------------------------------------------------------------------------- #
 from __future__ import annotations
 
+import logging
+import os
 from typing import TYPE_CHECKING, Any
 
+import boto3
 from strands.agent.conversation_manager import (
     ConversationManager,
     NullConversationManager,
@@ -19,6 +22,8 @@ from strands.models import BedrockModel
 
 from .base_constants import RETRIEVE_FROM_KB_PREFIX
 from .stream_types import ReasoningEffort
+
+_cross_account_logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from logging import Logger
@@ -144,7 +149,48 @@ class BaseAgentFactory:
                 model_args["additional_request_fields"] = temp_add_args | {
                     reasoning_key: reasoning_cfg
                 }
+        # Use cross-account session if a Bedrock access role ARN is configured
+        bedrock_access_role_arn = os.environ.get("bedrockAccessRoleArn")
+        if bedrock_access_role_arn:
+            boto_session = BaseAgentFactory._get_cross_account_boto_session(
+                bedrock_access_role_arn
+            )
+            model_args["boto_session"] = boto_session
+
         return BedrockModel(**model_args)
+
+    @staticmethod
+    def _get_cross_account_boto_session(role_arn: str) -> boto3.Session:
+        """Assume a cross-account IAM role and return a boto3 Session with temporary credentials.
+
+        This enables invoking Bedrock models in a different AWS account that hosts
+        the model access. The role is assumed via STS and the resulting temporary
+        credentials are used to create a new boto3 Session.
+
+        Args:
+            role_arn (str): The ARN of the cross-account role to assume.
+
+        Returns:
+            boto3.Session: A boto3 session configured with assumed-role credentials.
+        """
+        _cross_account_logger.info(
+            f"Assuming cross-account role for Bedrock access: {role_arn}"
+        )
+        sts_client = boto3.client("sts")
+        response = sts_client.assume_role(
+            RoleArn=role_arn,
+            RoleSessionName="AgentCoreCrossAccountBedrock",
+            DurationSeconds=3600,
+        )
+        credentials = response["Credentials"]
+        _cross_account_logger.info(
+            f"Successfully assumed cross-account role. Session expires at: {credentials['Expiration']}"
+        )
+        return boto3.Session(
+            aws_access_key_id=credentials["AccessKeyId"],
+            aws_secret_access_key=credentials["SecretAccessKey"],
+            aws_session_token=credentials["SessionToken"],
+        )
 
     @staticmethod
     def create_conversation_manager(

--- a/src/api/functions/create-runtime-version/index.py
+++ b/src/api/functions/create-runtime-version/index.py
@@ -36,6 +36,7 @@ AGENT_TOOLS_TOPIC_ARN = os.environ["AGENT_TOOLS_TOPIC_ARN"]
 ACCOUNT_ID = os.environ["ACCOUNT_ID"]
 AGENTS_TABLE_NAME = os.environ.get("AGENTS_TABLE_NAME", "")
 AGENTS_SUMMARY_TABLE_NAME = os.environ.get("AGENTS_SUMMARY_TABLE_NAME", "")
+BEDROCK_ACCESS_ROLE_ARN = os.environ.get("BEDROCK_ACCESS_ROLE_ARN", "")
 
 ENVIRONMENT_TAG = os.environ.get("ENVIRONMENT_TAG", None)
 STACK_TAG = os.environ.get("STACK_TAG", None)
@@ -256,6 +257,12 @@ def handler(event: InputModel, _) -> dict:
     ):
         logger.info(f"Attaching created AgentCore memory {event.memoryId}")
         api_args["environmentVariables"]["memoryId"] = event.memoryId
+
+    # Propagate cross-account Bedrock access role ARN to runtime containers
+    if BEDROCK_ACCESS_ROLE_ARN:
+        api_args["environmentVariables"][
+            "bedrockAccessRoleArn"
+        ] = BEDROCK_ACCESS_ROLE_ARN
 
     api_func = (
         BAC_CLIENT.update_agent_runtime if agent else BAC_CLIENT.create_agent_runtime


### PR DESCRIPTION
Adds an optional `bedrockAccessRoleArn` configuration (CDK) / `bedrock_access_role_arn` variable (Terraform) that enables agent runtimes to invoke Bedrock models in a different AWS account using STS AssumeRole.

**When the ARN is set:**
- A `_get_cross_account_boto_session()` method in `base_factory.py` uses STS to assume the target role and returns a boto3 session with temporary credentials
- The agent runtime's IAM role gets an `sts:AssumeRole` policy scoped to the target role ARN
- The `BEDROCK_ACCESS_ROLE_ARN` environment variable is set on the default runtime and the `startRuntimeCreation` Lambda

**When unset:** No change in behavior — the variable defaults to `null`/`undefined`.

| Layer | CDK Files | Terraform Files |
|-------|-----------|-----------------|
| Config | `lib/shared/types.ts` | `variables.tf` |
| Runtime env | `lib/agent-core/index.ts` | `agent_core/agentcore_runtime.tf` |
| IAM | `lib/agent-core/index.ts` | `agent_core/iam.tf` |
| Lambda env | `lib/api/agent-core-runtime.ts` | `agent_core_apis/lambdas/step_functions.tf` |
| Variable threading | — | `main.tf`, `*/variables.tf`, `*/main.tf` (5 files) |
| Docs | — | `terraform.tfvars.example` |
| Shared Python | `src/agent-core/shared/base_factory.py`, `src/api/functions/create-runtime-version/index.py` | — |

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
