### PR TITLE
🛂 replace BedrockAgentCoreFullAccess with least-privilege IAM policies

### DIFF
--- a/iac-cdk/lib/api/agent-core-runtime.ts
+++ b/iac-cdk/lib/api/agent-core-runtime.ts
@@ -98,9 +98,22 @@ export class AgentCoreApis extends Construct {
         props.agentCoreRuntimeTable.grantReadWriteData(agentCoreRuntimeCreationResolver);
         props.agentCoreSummaryTable.grantReadWriteData(agentCoreRuntimeCreationResolver);
 
-        // TODO - consider using a custom policy with minimal permissions
-        agentCoreRuntimeCreationResolver.role!.addManagedPolicy(
-            iam.ManagedPolicy.fromAwsManagedPolicyName("BedrockAgentCoreFullAccess"),
+        // Bedrock AgentCore — least-privilege: only the API actions this resolver Lambda invokes
+        agentCoreRuntimeCreationResolver.addToRolePolicy(
+            new iam.PolicyStatement({
+                sid: "BedrockAgentCoreAccess",
+                effect: iam.Effect.ALLOW,
+                actions: [
+                    "bedrock-agentcore:CreateAgentRuntimeEndpoint",
+                    "bedrock-agentcore:GetAgentRuntimeEndpoint",
+                    "bedrock-agentcore:ListAgentRuntimeVersions",
+                    "bedrock-agentcore:ListAgentRuntimeEndpoints",
+                    "bedrock-agentcore:TagResource",
+                ],
+                resources: [
+                    `arn:aws:bedrock-agentcore:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:runtime/*`,
+                ],
+            }),
         );
         // Add BedrockAgentCore PassRole permission
         agentCoreRuntimeCreationResolver.addToRolePolicy(
@@ -607,24 +620,25 @@ export class AgentCoreApis extends Construct {
                 }),
             },
         });
-        // TODO - consider using a custom policy with minimal permissions
-        // startRuntimeCreationFunc.addToRolePolicy(
-        //     new iam.PolicyStatement({
-        //         effect: iam.Effect.ALLOW,
-        //         actions: [
-        //             "bedrock-agentcore:ListAgentRuntimes",
-        //             "bedrock-agentcore:ListTagsForResource",
-        //             "bedrock-agentcore:UpdateAgentRuntime",
-        //             "bedrock-agentcore:CreateAgentRuntime",
-        //             "bedrock-agentcore:TagResource",
-        //         ],
-        //         resources: [
-        //             `arn:aws:bedrock-agentcore:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:runtime/*`,
-        //         ],
-        //     }),
-        // );
-        startRuntimeCreationFunc.role!.addManagedPolicy(
-            iam.ManagedPolicy.fromAwsManagedPolicyName("BedrockAgentCoreFullAccess"),
+        // Bedrock AgentCore — least-privilege: only the actions this runtime creation Lambda invokes
+        startRuntimeCreationFunc.addToRolePolicy(
+            new iam.PolicyStatement({
+                sid: "BedrockAgentCoreAccess",
+                effect: iam.Effect.ALLOW,
+                actions: [
+                    "bedrock-agentcore:ListAgentRuntimes",
+                    "bedrock-agentcore:ListTagsForResource",
+                    "bedrock-agentcore:UpdateAgentRuntime",
+                    "bedrock-agentcore:CreateAgentRuntime",
+                    "bedrock-agentcore:CreateAgentRuntimeEndpoint",
+                    "bedrock-agentcore:CreateWorkloadIdentity",
+                    "bedrock-agentcore:TagResource",
+                ],
+                resources: [
+                    `arn:aws:bedrock-agentcore:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:runtime/*`,
+                    `arn:aws:bedrock-agentcore:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:workload-identity-directory/*`,
+                ],
+            }),
         );
         startRuntimeCreationFunc.addToRolePolicy(
             new iam.PolicyStatement({

--- a/iac-cdk/lib/cleanup/index.ts
+++ b/iac-cdk/lib/cleanup/index.ts
@@ -68,7 +68,9 @@ export class Cleanup extends Construct {
             runtime: props.shared.pythonRuntime,
             functionName: `${prefix}-cleanCustomResources`,
             handler: "index.handler",
-            code: lambda.Code.fromAsset(path.join(__dirname, "../../../src/cleanup/functions", "cleanup-handler")),
+            code: lambda.Code.fromAsset(
+                path.join(__dirname, "../../../src/cleanup/functions", "cleanup-handler"),
+            ),
             timeout: Duration.minutes(15),
             environment: environmentVariables,
             layers: [props.shared.boto3Layer, props.shared.powerToolsLayer],
@@ -97,27 +99,45 @@ export class Cleanup extends Construct {
             }),
         );
 
-        cleanupLambda.role!.addManagedPolicy(
-            iam.ManagedPolicy.fromAwsManagedPolicyName("BedrockAgentCoreFullAccess"),
+        // Bedrock AgentCore — least-privilege for cleanup (runtime + memory)
+        cleanupLambda.addToRolePolicy(
+            new iam.PolicyStatement({
+                sid: "BedrockAgentCoreRuntimeCleanup",
+                effect: iam.Effect.ALLOW,
+                actions: [
+                    "bedrock-agentcore:ListAgentRuntimes",
+                    "bedrock-agentcore:ListTagsForResource",
+                    "bedrock-agentcore:DeleteAgentRuntime",
+                    "bedrock-agentcore:DeleteAgentRuntimeEndpoint",
+                ],
+                resources: [
+                    `arn:aws:bedrock-agentcore:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:runtime/*`,
+                ],
+            }),
         );
-
-        // cleanupLambda.addToRolePolicy(
-        //     new iam.PolicyStatement({
-        //         effect: iam.Effect.ALLOW,
-        //         actions: [
-        //             "bedrock-agentcore:ListAgentRuntimes",
-        //             "bedrock-agentcore:ListTagsForResource",
-        //             "bedrock-agentcore:DeleteAgentRuntime",
-        //             "bedrock-agentcore:DeleteAgentRuntimeEndpoint",
-        //         ],
-        //         resources: [
-        //             `arn:aws:bedrock-agentcore:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:runtime/*`,
-        //         ],
-        //         conditions: {
-        //             StringEquals: getTagConditions(this),
-        //         },
-        //     }),
-        // );
+        cleanupLambda.addToRolePolicy(
+            new iam.PolicyStatement({
+                effect: iam.Effect.ALLOW,
+                actions: ["bedrock-agentcore:DeleteWorkloadIdentity"],
+                resources: [
+                    `arn:aws:bedrock-agentcore:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:workload-identity-directory/*`,
+                ],
+            }),
+        );
+        cleanupLambda.addToRolePolicy(
+            new iam.PolicyStatement({
+                sid: "BedrockAgentCoreMemoryCleanup",
+                effect: iam.Effect.ALLOW,
+                actions: [
+                    "bedrock-agentcore:ListMemories",
+                    "bedrock-agentcore:ListTagsForResource",
+                    "bedrock-agentcore:DeleteMemory",
+                ],
+                resources: [
+                    `arn:aws:bedrock-agentcore:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:memory/*`,
+                ],
+            }),
+        );
 
         // Add permissions for EventBridge rule cleanup
         // Restricted to resources tagged with "aca"

--- a/iac-terraform/modules/agent_core_apis/lambdas/main.tf
+++ b/iac-terraform/modules/agent_core_apis/lambdas/main.tf
@@ -142,11 +142,31 @@ resource "aws_iam_role_policy_attachment" "agent_core_resolver_xray" {
   policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
 }
 
-# Bedrock AgentCore Full Access (managed policy)
-# TODO: Consider using a custom policy with minimal permissions
-resource "aws_iam_role_policy_attachment" "agent_core_resolver_bedrock" {
-  role       = aws_iam_role.agent_core_resolver.name
-  policy_arn = "arn:aws:iam::aws:policy/BedrockAgentCoreFullAccess"
+# Bedrock AgentCore — least-privilege custom policy
+# Only the API actions the resolver Lambda actually invokes:
+#   create_agent_runtime_endpoint, get_agent_runtime_endpoint,
+#   list_agent_runtime_versions, list_agent_runtime_endpoints
+data "aws_iam_policy_document" "agent_core_resolver_bedrock" {
+  statement {
+    sid    = "BedrockAgentCoreAccess"
+    effect = "Allow"
+    actions = [
+      "bedrock-agentcore:CreateAgentRuntimeEndpoint",
+      "bedrock-agentcore:GetAgentRuntimeEndpoint",
+      "bedrock-agentcore:ListAgentRuntimeVersions",
+      "bedrock-agentcore:ListAgentRuntimeEndpoints",
+      "bedrock-agentcore:TagResource",
+    ]
+    resources = [
+      "arn:aws:bedrock-agentcore:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:runtime/*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "agent_core_resolver_bedrock" {
+  name   = "${local.name_prefix}-agentCoreResolver-bedrock"
+  role   = aws_iam_role.agent_core_resolver.id
+  policy = data.aws_iam_policy_document.agent_core_resolver_bedrock.json
 }
 
 # DynamoDB access policy

--- a/iac-terraform/modules/agent_core_apis/lambdas/step_functions.tf
+++ b/iac-terraform/modules/agent_core_apis/lambdas/step_functions.tf
@@ -430,10 +430,31 @@ resource "aws_iam_role_policy_attachment" "create_runtime_version_xray" {
   policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
 }
 
-# Full AgentCore access for create runtime
-resource "aws_iam_role_policy_attachment" "create_runtime_version_bedrock" {
-  role       = aws_iam_role.create_runtime_version.name
-  policy_arn = "arn:aws:iam::aws:policy/BedrockAgentCoreFullAccess"
+# Bedrock AgentCore — least-privilege for create runtime
+data "aws_iam_policy_document" "create_runtime_version_bedrock" {
+  statement {
+    sid    = "BedrockAgentCoreAccess"
+    effect = "Allow"
+    actions = [
+      "bedrock-agentcore:ListAgentRuntimes",
+      "bedrock-agentcore:ListTagsForResource",
+      "bedrock-agentcore:UpdateAgentRuntime",
+      "bedrock-agentcore:CreateAgentRuntime",
+      "bedrock-agentcore:CreateAgentRuntimeEndpoint",
+      "bedrock-agentcore:CreateWorkloadIdentity",
+      "bedrock-agentcore:TagResource",
+    ]
+    resources = [
+      "arn:aws:bedrock-agentcore:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:runtime/*",
+      "arn:aws:bedrock-agentcore:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:workload-identity-directory/*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "create_runtime_version_bedrock" {
+  name   = "${local.name_prefix}-startRuntimeCreation-bedrock"
+  role   = aws_iam_role.create_runtime_version.id
+  policy = data.aws_iam_policy_document.create_runtime_version_bedrock.json
 }
 
 # PassRole for create runtime

--- a/iac-terraform/modules/cleanup/main.tf
+++ b/iac-terraform/modules/cleanup/main.tf
@@ -179,11 +179,51 @@ resource "aws_iam_role_policy" "cleanup_bedrock" {
   policy = data.aws_iam_policy_document.cleanup_bedrock.json
 }
 
-# Bedrock AgentCore permissions (full access for cleanup)
-# Using managed policy as AgentCore doesn't support tag-based conditions well
-resource "aws_iam_role_policy_attachment" "cleanup_agentcore" {
-  role       = aws_iam_role.cleanup.name
-  policy_arn = "arn:aws:iam::aws:policy/BedrockAgentCoreFullAccess"
+# Bedrock AgentCore — least-privilege for cleanup
+data "aws_iam_policy_document" "cleanup_agentcore" {
+  statement {
+    sid    = "BedrockAgentCoreRuntimeCleanup"
+    effect = "Allow"
+    actions = [
+      "bedrock-agentcore:ListAgentRuntimes",
+      "bedrock-agentcore:ListTagsForResource",
+      "bedrock-agentcore:DeleteAgentRuntime",
+      "bedrock-agentcore:DeleteAgentRuntimeEndpoint",
+    ]
+    resources = [
+      "arn:aws:bedrock-agentcore:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:runtime/*",
+    ]
+  }
+
+  statement {
+    sid    = "BedrockAgentCoreWorkloadIdentityCleanup"
+    effect = "Allow"
+    actions = [
+      "bedrock-agentcore:DeleteWorkloadIdentity",
+    ]
+    resources = [
+      "arn:aws:bedrock-agentcore:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:workload-identity-directory/*",
+    ]
+  }
+
+  statement {
+    sid    = "BedrockAgentCoreMemoryCleanup"
+    effect = "Allow"
+    actions = [
+      "bedrock-agentcore:ListMemories",
+      "bedrock-agentcore:ListTagsForResource",
+      "bedrock-agentcore:DeleteMemory",
+    ]
+    resources = [
+      "arn:aws:bedrock-agentcore:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:memory/*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "cleanup_agentcore" {
+  name   = "${local.name_prefix}-cleanup-agentcore"
+  role   = aws_iam_role.cleanup.id
+  policy = data.aws_iam_policy_document.cleanup_agentcore.json
 }
 
 # EventBridge permissions (tag-scoped)

--- a/src/api/functions/check-on-create-memory/index.py
+++ b/src/api/functions/check-on-create-memory/index.py
@@ -59,7 +59,7 @@ def handler(event: InputModel, _) -> dict:
     except ClientError as err:
         msg = "Failed to fetch properties of the AgentCore Memory instance"
         logger.error(msg, extra={"rawErrorMessage": str(err)})
-        output = OutputModel(status=400, body=Body(message=msg, status="FAILED"))
+        raise err
 
     logger.info(
         "Lambda handler ready to return", extra={"lambdaResponse": output.model_dump()}

--- a/src/api/functions/check-on-create-runtime/index.py
+++ b/src/api/functions/check-on-create-runtime/index.py
@@ -72,7 +72,7 @@ def handler(event: InputModel, _) -> dict:
     except ClientError as err:
         msg = "Failed to fetch AgentCore Runtime status"
         logger.error(msg, extra={"rawErrorMessage": str(err)})
-        output = OutputModel(status=400, body=Body(message=msg, status="FAILED"))
+        raise err
 
     logger.info(
         "Lambda handler ready to return", extra={"lambdaResponse": output.model_dump()}

--- a/src/api/functions/check-on-exist-memory/index.py
+++ b/src/api/functions/check-on-exist-memory/index.py
@@ -115,11 +115,8 @@ def handler(event: InputModel, _) -> dict:
                 logger.info("Fake match -- resetting to None")
                 matching_memory_id = None
 
-        status_code = 200
     except ClientError as err:
         logger.error("Failed in checking memory", extra={"rawErrorMessage": str(err)})
-        status_code = 400
+        raise err
 
-    return OutputModel(
-        status=status_code, body=Body(memoryId=matching_memory_id)
-    ).model_dump()
+    return OutputModel(status=200, body=Body(memoryId=matching_memory_id)).model_dump()


### PR DESCRIPTION
Replace broad AWS managed policy BedrockAgentCoreFullAccess with scoped-down inline IAM policy statements across all Lambda functions that interact with Bedrock AgentCore APIs.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
