### PR TITLE
✨ Add StructuredOutputEvaluator and agent state support for evaluation test cases

### DIFF
--- a/docs/src/evaluation.md
+++ b/docs/src/evaluation.md
@@ -72,7 +72,7 @@ AppSync → EvaluationResolver → SQS Queue → EvaluationExecutor → DynamoDB
 
 ## Available Evaluators
 
-The system supports eight evaluator types from the Strands Evaluation SDK:
+The system supports nine evaluator types — eight from the Strands Evaluation SDK plus one custom evaluator:
 
 | Evaluator | Purpose | Requires Rubric | Requires Trajectory | Best For |
 |-----------|---------|-----------------|---------------------|----------|
@@ -84,6 +84,7 @@ The system supports eight evaluator types from the Strands Evaluation SDK:
 | **ToolSelectionAccuracyEvaluator** | Validates tool selection decisions | No | Yes | Multi-tool agents |
 | **ToolParameterAccuracyEvaluator** | Validates tool parameters accuracy | No | Yes | Complex tool usage |
 | **InteractionsEvaluator** | Evaluates agent-to-agent handoffs and interactions (swarm only) | Yes | Yes | Swarm agents |
+| **StructuredOutputEvaluator** | Deterministic field-by-field JSON comparison of structured output (no LLM needed) | No | No | Structured output validation |
 
 ## Recommended Evaluator Combinations
 
@@ -100,6 +101,11 @@ OutputEvaluator, HelpfulnessEvaluator, TrajectoryEvaluator, ToolSelectionAccurac
 ### For Simple Q&A Agents
 ```
 OutputEvaluator, HelpfulnessEvaluator
+```
+
+### For Agents with Structured Output (JSON fields)
+```
+StructuredOutputEvaluator, OutputEvaluator
 
 
 
@@ -154,6 +160,32 @@ evaluationExecutor.addEventSource(
 ]
 ```
 
+### Structured Output Test Cases (for StructuredOutputEvaluator)
+
+For agents that return structured JSON output (e.g., extracted fields like `aws_services`, `links`), use `StructuredOutputEvaluator` with a structured `expected_output`. The evaluator compares each field deterministically — no LLM is required.
+
+**Semantics:**
+- **Non-null values**: The actual output must contain the field with an identical value (exact match for strings, order-insensitive comparison for lists).
+- **Null values**: The field must be **absent** from the actual output or explicitly `null`. This is the "null-means-absent" convention.
+- **Extra fields**: Fields present in the actual output but not in the expected output are ignored.
+
+The `expected_output` field accepts both a **dict** (recommended) or a **JSON string**:
+
+```json
+[
+  {
+    "name": "aws-question-0001",
+    "input": "What is Bedrock?",
+    "expected_output": {
+      "aws_services": ["Amazon Bedrock"]
+    },
+    "metadata": { "category": "aws"}
+  }
+]
+```
+
+> **Note**: `StructuredOutputEvaluator` uses the agent's `structuredOutput` dict (returned alongside the text response), not the text response itself. This means you can combine it with `OutputEvaluator` — one checks the structured fields, the other evaluates the natural language response.
+
 ### Swarm Agent Test Cases (with expected_interactions)
 
 For `InteractionsEvaluator`, use the `expected_interactions` field to define the expected agent-to-agent handoff sequence:
@@ -179,7 +211,7 @@ For `InteractionsEvaluator`, use the `expected_interactions` field to define the
 |-------|-------------|---------|
 | `name` | Test case identifier | All evaluators |
 | `input` | User input/question | All evaluators |
-| `expected_output` | Expected agent response | OutputEvaluator |
+| `expected_output` | Expected agent response (string or dict for structured output) | OutputEvaluator, StructuredOutputEvaluator |
 | `expected_trajectory` | Expected sequence of tool/agent names | TrajectoryEvaluator |
 | `expected_interactions` | Expected agent-to-agent handoffs (swarm only) | InteractionsEvaluator |
 | `metadata` | Additional test case metadata | Filtering/categorization |
@@ -196,6 +228,7 @@ For `InteractionsEvaluator`, use the `expected_interactions` field to define the
 | ToolSelectionAccuracyEvaluator | ✅ | ✅ |
 | ToolParameterAccuracyEvaluator | ✅ | ✅ |
 | InteractionsEvaluator | ❌ | ✅ |
+| StructuredOutputEvaluator | ✅ | ❌ |
 
 > **Note**: `InteractionsEvaluator` is specifically designed for swarm agents as it evaluates agent-to-agent handoffs, which don't exist in single agent configurations.
 
@@ -208,6 +241,7 @@ For `InteractionsEvaluator`, use the `expected_interactions` field to define the
 5. **Define expected_trajectory for workflow validation**: Use this with `TrajectoryEvaluator` to verify action sequences
 6. **Test iteratively**: Run small test sets first to validate evaluator selection
 7. **Monitor pass rates**: A consistent pass rate below 70% may indicate evaluator mismatch
+8. **Use StructuredOutputEvaluator for JSON outputs**: For agents that return structured data (e.g., extracted `loop_id`, `template_tags`), this evaluator provides deterministic field-level comparison without LLM costs. Use `null` in `expected_output` to assert a field should be absent.
 
 ## Related Resources
 

--- a/docs/src/evaluation.md
+++ b/docs/src/evaluation.md
@@ -186,6 +186,27 @@ The `expected_output` field accepts both a **dict** (recommended) or a **JSON st
 
 > **Note**: `StructuredOutputEvaluator` uses the agent's `structuredOutput` dict (returned alongside the text response), not the text response itself. This means you can combine it with `OutputEvaluator` — one checks the structured fields, the other evaluates the natural language response.
 
+### Test Cases with Agent State
+
+For agents whose tools rely on **agent state** (e.g. S3 URI references for document processing), you can pass a `state` field in each test case. The value must be a **stringified JSON object**.
+
+The state is forwarded to the agent runtime and becomes available via `tool_context.agent.state` inside tools.
+
+```json
+[
+  {
+    "name": "internal-doc-summary",
+    "input": "Summarize the key findings from this internal architecture review document.",
+    "expected_output": "The architecture review recommends migrating to a serverless-first approach...",
+    "state": "{\"s3_bucket\":\"your-bucket\",\"document_s3_key\":\"reviews/2026-q1-architecture-review.pdf\"}",
+    "expected_trajectory": ["summarize_document"],
+    "metadata": { "category": "document-processing" }
+  }
+]
+```
+
+> **Note**: The `state` field is optional. Test cases without `state` continue to work exactly as before.
+
 ### Swarm Agent Test Cases (with expected_interactions)
 
 For `InteractionsEvaluator`, use the `expected_interactions` field to define the expected agent-to-agent handoff sequence:
@@ -212,6 +233,7 @@ For `InteractionsEvaluator`, use the `expected_interactions` field to define the
 | `name` | Test case identifier | All evaluators |
 | `input` | User input/question | All evaluators |
 | `expected_output` | Expected agent response (string or dict for structured output) | OutputEvaluator, StructuredOutputEvaluator |
+| `state` | Stringified JSON object passed as agent state (optional) | Agents with state-dependent tools |
 | `expected_trajectory` | Expected sequence of tool/agent names | TrajectoryEvaluator |
 | `expected_interactions` | Expected agent-to-agent handoffs (swarm only) | InteractionsEvaluator |
 | `metadata` | Additional test case metadata | Filtering/categorization |

--- a/src/api/functions/evaluation-executor/evaluator.py
+++ b/src/api/functions/evaluation-executor/evaluator.py
@@ -20,13 +20,16 @@ Note: Requires strands-agents-evals package to be installed.
 """
 from __future__ import annotations
 
+import json
 import logging
+import re
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from strands_evals.evaluators import (
+    Evaluator,
     FaithfulnessEvaluator,
     GoalSuccessRateEvaluator,
     HelpfulnessEvaluator,
@@ -36,8 +39,12 @@ from strands_evals.evaluators import (
     ToolSelectionAccuracyEvaluator,
     TrajectoryEvaluator,
 )
-from strands_evals.types.evaluation import EvaluationData
+from strands_evals.types.evaluation import EvaluationData, EvaluationOutput
 from strands_evals.types.trace import AgentInvocationSpan, Session, SpanInfo, Trace
+from typing_extensions import TypeVar
+
+InputT = TypeVar("InputT")
+OutputT = TypeVar("OutputT")
 
 logger = logging.getLogger(__name__)
 
@@ -339,6 +346,204 @@ class TrajectoryBuilder:
         return Session(traces=[combined_trace], session_id=session_id)
 
 
+# ========================= StructuredOutputEvaluator ========================= #
+
+
+class StructuredOutputEvaluator(Evaluator[InputT, OutputT]):
+    """Deterministic evaluator for structured JSON output.
+
+    Compares expected key-value pairs against the agent's actual structured output.
+    This is a metric-based evaluator (no LLM required).
+
+    Semantics:
+    - For non-null expected values: the actual output must contain the field with
+      an identical value (exact match for strings, sorted comparison for lists).
+    - For null expected values: the field must be absent from the actual output
+      or explicitly set to null/None.
+    - Fields present in the actual output but not in the expected output are ignored.
+
+    The evaluator receives structured data through `actual_structured_output`
+    (a dict passed alongside the evaluation case) rather than parsing JSON from
+    the canonical text output. This keeps the text output untouched for other
+    evaluators.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    # ---- public API required by Evaluator base class ---- #
+
+    def evaluate(
+        self,
+        evaluation_case: EvaluationData[InputT, OutputT],
+    ) -> list[EvaluationOutput]:
+        """Synchronous structured-output evaluation.
+
+        Uses ``evaluation_case.expected_output`` as the ground truth and
+        ``evaluation_case.actual_output`` as the agent response to compare.
+
+        ``expected_output`` can be:
+        - A JSON string  (``'{"loop_id": "x22A-002", "template_tags": null}'``)
+        - Already serialized by the caller from a dict
+
+        ``actual_output`` for this evaluator is expected to be a JSON string
+        representation of the agent's structured output dict (set by the runner).
+        """
+        # --- parse expected ------------------------------------------------- #
+        expected = self._to_dict(
+            evaluation_case.expected_output, label="expected_output"
+        )
+        if expected is None:
+            return [
+                EvaluationOutput(
+                    score=0.0,
+                    test_pass=False,
+                    reason="expected_output could not be parsed as JSON object",
+                )
+            ]
+
+        # --- parse actual --------------------------------------------------- #
+        actual = self._to_dict(evaluation_case.actual_output, label="actual_output")
+        if actual is None:
+            return [
+                EvaluationOutput(
+                    score=0.0,
+                    test_pass=False,
+                    reason="actual_output could not be parsed as JSON object",
+                )
+            ]
+
+        # --- compare field by field ----------------------------------------- #
+        total_fields = len(expected)
+        if total_fields == 0:
+            return [
+                EvaluationOutput(
+                    score=1.0,
+                    test_pass=True,
+                    reason="No expected fields to check (empty expected_output)",
+                )
+            ]
+
+        matched = 0
+        field_reports: list[str] = []
+
+        for key, expected_value in expected.items():
+            actual_value = actual.get(key, _SENTINEL)
+
+            if expected_value is None:
+                # Null-means-absent: field should be missing, null, or empty
+                # in actual ([], {}, "" are treated as equivalent to null)
+                if self._is_empty(actual_value):
+                    matched += 1
+                    field_reports.append(f"{key} ✓ (correctly absent/null/empty)")
+                else:
+                    field_reports.append(
+                        f"{key} ✗ (expected absent/null, got {json.dumps(actual_value)})"
+                    )
+            else:
+                # Non-null: exact value match
+                if actual_value is _SENTINEL:
+                    field_reports.append(f"{key} ✗ (missing in actual output)")
+                elif self._values_equal(expected_value, actual_value):
+                    matched += 1
+                    field_reports.append(f"{key} ✓")
+                else:
+                    field_reports.append(
+                        f"{key} ✗ (expected {json.dumps(expected_value)}, "
+                        f"got {json.dumps(actual_value)})"
+                    )
+
+        score = matched / total_fields
+        test_pass = score == 1.0
+        reason = f"{matched}/{total_fields} structured fields match: " + ", ".join(
+            field_reports
+        )
+
+        return [
+            EvaluationOutput(
+                score=score,
+                test_pass=test_pass,
+                reason=reason,
+            )
+        ]
+
+    async def evaluate_async(
+        self,
+        evaluation_case: EvaluationData[InputT, OutputT],
+    ) -> list[EvaluationOutput]:
+        """Async wrapper – delegates to the synchronous implementation."""
+        return self.evaluate(evaluation_case)
+
+    # ---- helpers ----------------------------------------------------------- #
+
+    @staticmethod
+    def _to_dict(value: Any, label: str = "value") -> Optional[dict]:
+        """Convert a value to a dict.
+
+        Accepts:
+        - dict  → returned as-is
+        - str   → attempt JSON parse; if the string contains mixed text + JSON,
+                  extract the first JSON object via regex
+        - other → None (cannot convert)
+        """
+        if isinstance(value, dict):
+            return value
+
+        if not isinstance(value, str):
+            logger.warning(f"{label} is not a string or dict: {type(value)}")
+            return None
+
+        # Try direct JSON parse first
+        try:
+            parsed = json.loads(value)
+            if isinstance(parsed, dict):
+                return parsed
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+        # Fallback: extract first JSON object from mixed text
+        match = re.search(r"\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}", value)
+        if match:
+            try:
+                parsed = json.loads(match.group())
+                if isinstance(parsed, dict):
+                    return parsed
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+        logger.warning(f"Could not extract JSON object from {label}")
+        return None
+
+    @staticmethod
+    def _is_empty(value: Any) -> bool:
+        """Check if a value is semantically empty/absent.
+
+        Considers None, empty list, empty dict, and empty string as empty.
+        This allows expected null values to match agent outputs that return
+        [] or {} instead of null.
+        """
+        if value is None or value is _SENTINEL:
+            return True
+        if isinstance(value, (list, dict, str)) and len(value) == 0:
+            return True
+        return False
+
+    @staticmethod
+    def _values_equal(expected: Any, actual: Any) -> bool:
+        """Compare two values with special handling for lists (order-insensitive)."""
+        if isinstance(expected, list) and isinstance(actual, list):
+            try:
+                return sorted(expected) == sorted(actual)
+            except TypeError:
+                # Fallback for non-sortable items
+                return expected == actual
+        return expected == actual
+
+
+# Sentinel object to distinguish "key missing" from "key present with None value"
+_SENTINEL = object()
+
+
 # ========================= EvaluatorFactory ========================= #
 
 
@@ -354,6 +559,7 @@ class EvaluatorFactory:
     - ToolParameterAccuracyEvaluator: Validates tool parameters
     - TrajectoryEvaluator: Assesses sequence of actions/tool calls taken by an agent (requires rubric)
     - InteractionsEvaluator: Evaluates how well the agent interacts with users (requires rubric)
+    - StructuredOutputEvaluator: Deterministic JSON field comparison (no LLM needed)
     """
 
     # Mapping of evaluator type names to classes
@@ -366,6 +572,7 @@ class EvaluatorFactory:
         "ToolParameterAccuracyEvaluator": ToolParameterAccuracyEvaluator,
         "TrajectoryEvaluator": TrajectoryEvaluator,
         "InteractionsEvaluator": InteractionsEvaluator,
+        "StructuredOutputEvaluator": StructuredOutputEvaluator,
     }
 
     # Evaluators that require a rubric parameter
@@ -373,6 +580,11 @@ class EvaluatorFactory:
         "OutputEvaluator",
         "TrajectoryEvaluator",
         "InteractionsEvaluator",
+    }
+
+    # Evaluators that are deterministic (no LLM / model required)
+    DETERMINISTIC_EVALUATORS = {
+        "StructuredOutputEvaluator",
     }
 
     @classmethod
@@ -400,6 +612,10 @@ class EvaluatorFactory:
             )
 
         evaluator_class = cls.EVALUATOR_CLASSES[config.evaluator_type]
+
+        # Deterministic evaluators don't require an LLM model
+        if config.evaluator_type in cls.DETERMINISTIC_EVALUATORS:
+            return evaluator_class()
 
         # Only certain evaluators require rubric parameter
         if config.evaluator_type in cls.EVALUATORS_REQUIRING_RUBRIC:
@@ -470,13 +686,14 @@ class EvaluationRunner:
         self,
         evaluator_type: str,
         input_text: str,
-        expected_output: str,
+        expected_output: Union[str, dict],
         actual_output: str,
         rubric: str = "",
         trajectory: Optional[dict] = None,
         case_name: str = "eval-case",
         expected_trajectory: Optional[List[str]] = None,
         expected_interactions: Optional[List[dict]] = None,
+        actual_structured_output: Optional[dict] = None,
     ) -> EvaluationResult:
         """Run evaluation using specified evaluator type.
 
@@ -484,7 +701,7 @@ class EvaluationRunner:
             evaluator_type: Type of evaluator to use
             input_text: The input that was sent to the agent
             expected_output: The expected output
-            actual_output: The actual output from the agent
+            actual_output: The actual output from the agent (canonical text)
             rubric: Optional rubric for evaluators that support it
             trajectory: Optional trajectory data from agent execution (supports both
                         single agent format with 'traces' and swarm format with
@@ -493,6 +710,9 @@ class EvaluationRunner:
             expected_trajectory: Optional expected sequence of agent/tool names
             expected_interactions: Optional expected interactions for swarm agents
                 Each interaction: {"node_name": str, "dependencies": [str], "messages": str}
+            actual_structured_output: Optional structured output dict from the agent.
+                Used by StructuredOutputEvaluator instead of actual_output so that
+                other evaluators receive the canonical text output untouched.
 
         Returns:
             EvaluationResult with score, passed status, and reason
@@ -500,7 +720,8 @@ class EvaluationRunner:
         logger.info(
             f"Running {evaluator_type} evaluation, "
             f"input_length={len(input_text)}, "
-            f"has_trajectory={trajectory is not None}"
+            f"has_trajectory={trajectory is not None}, "
+            f"has_structured_output={actual_structured_output is not None}"
         )
 
         try:
@@ -555,11 +776,39 @@ class EvaluationRunner:
                 except Exception as e:
                     logger.warning(f"Failed to build session from trajectory: {e}")
 
+            # For StructuredOutputEvaluator, use the structured output dict
+            # (serialized as JSON) instead of the canonical text output so that
+            # other evaluators still receive the untouched text.
+            effective_actual_output = actual_output
+            if (
+                evaluator_type == "StructuredOutputEvaluator"
+                and actual_structured_output is not None
+            ):
+                # actual_structured_output can be a dict OR a JSON string
+                # (AgentCore returns it as a JSON string in the SSE payload).
+                # Only json.dumps() if it's a dict; otherwise use as-is.
+                if isinstance(actual_structured_output, dict):
+                    effective_actual_output = json.dumps(actual_structured_output)
+                else:
+                    effective_actual_output = str(actual_structured_output)
+                logger.info(
+                    "StructuredOutputEvaluator: using structured output "
+                    "instead of canonical text output"
+                )
+
+            # Ensure expected_output is a JSON string (not a dict) because
+            # EvaluationData.expected_output is typed as str in the Strands SDK.
+            # If we pass a dict, Pydantic coerces it to Python repr format
+            # (single quotes, None instead of null) which breaks JSON parsing.
+            effective_expected_output: Any = expected_output
+            if isinstance(expected_output, dict):
+                effective_expected_output = json.dumps(expected_output)
+
             # Create evaluation data with appropriate trajectory/interactions
             eval_data_kwargs: Dict[str, Any] = {
                 "input": input_text,
-                "expected_output": expected_output,
-                "actual_output": actual_output,
+                "expected_output": effective_expected_output,
+                "actual_output": effective_actual_output,
                 "name": case_name,
             }
 

--- a/src/api/functions/evaluation-executor/index.py
+++ b/src/api/functions/evaluation-executor/index.py
@@ -17,7 +17,7 @@ import time
 import uuid
 from datetime import datetime, timezone
 from decimal import Decimal
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import TYPE_CHECKING, Optional, Tuple, Union
 
 import boto3
 from aws_lambda_powertools import Logger, Tracer
@@ -29,6 +29,7 @@ from botocore.exceptions import ClientError
 
 # Import evaluator classes
 from evaluator import EvaluationRunner
+from pydantic import ConfigDict, Field
 
 if TYPE_CHECKING:
     from aws_lambda_powertools.utilities.typing import LambdaContext
@@ -36,11 +37,21 @@ if TYPE_CHECKING:
 
 # ===================== Models ==================== #
 class TestCase(BaseModel):
-    """Test case data model."""
+    """Test case data model.
+
+    Accepts both snake_case (from test case JSON files) and camelCase field names.
+    E.g. both "expected_output" and "expectedOutput" map to the same field.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
 
     name: str
     input: str
-    expectedOutput: Optional[str] = None
+    expectedOutput: Optional[Union[str, dict]] = Field(
+        default=None, alias="expected_output"
+    )
+    expected_trajectory: Optional[list] = None
+    expected_interactions: Optional[list] = None
     metadata: Optional[dict] = None
 
 
@@ -117,7 +128,7 @@ def process_record(record: SQSRecord):
     Missing or invalid fields will raise ValidationError.
     """
     # Parse and validate SQS message payload using Pydantic
-    payload: SQSMessagePayload = parse(event=record.body, model=SQSMessagePayload)
+    payload: SQSMessagePayload = parse(event=record.body, model=SQSMessagePayload)  # type: ignore
 
     evaluator_id = payload.evaluatorId
     test_case_index = payload.testCaseIndex
@@ -157,6 +168,7 @@ def process_record(record: SQSRecord):
             actual_output=result.get("output", ""),
             evaluator_config=evaluator_config,
             trajectory=result.get("trajectory"),
+            actual_structured_output=result.get("structuredOutput"),
         )
 
         # Add latency
@@ -341,6 +353,7 @@ def _invoke_agent_runtime(
                     logger.debug("Parsed event", extra={"event": event})
 
         output = response_data.get("content", "")
+        structured_output = response_data.get("structuredOutput")
         trajectory = response_data.get("trajectory")
 
         logger.info(
@@ -348,12 +361,14 @@ def _invoke_agent_runtime(
             extra={
                 "sessionId": session_id,
                 "outputLength": len(str(output)),
+                "hasStructuredOutput": structured_output is not None,
                 "hasTrajectory": trajectory is not None,
             },
         )
 
         return {
-            "output": output,
+            "output": output,  # Canonical text output for most evaluators
+            "structuredOutput": structured_output,  # Dict for StructuredOutputEvaluator
             "sessionId": session_id,
             "agentRuntimeArn": agent_runtime_arn,
             "trajectory": trajectory,  # Include trajectory for evaluators
@@ -425,24 +440,28 @@ def _evaluate_result(
     actual_output: str,
     evaluator_config: EvaluatorConfig,
     trajectory: Optional[dict] = None,
+    actual_structured_output: Optional[dict] = None,
 ) -> dict:
     """Evaluate the agent's output using Strands Evals SDK.
 
     Supports multiple comma-separated evaluator types (e.g., "OutputEvaluator, HelpfulnessEvaluator").
     When multiple types are provided, runs each evaluator separately and aggregates results.
 
-    Uses the evaluator module which supports 5 built-in evaluators:
+    Uses the evaluator module which supports built-in and custom evaluators:
     - OutputEvaluator: Compares actual vs expected output (works without trajectory)
     - HelpfulnessEvaluator: Evaluates response helpfulness (requires trajectory)
     - FaithfulnessEvaluator: Checks factual accuracy (requires trajectory)
     - ToolSelectionAccuracyEvaluator: Validates tool selection (requires trajectory)
     - ToolParameterAccuracyEvaluator: Validates tool parameters (requires trajectory)
+    - StructuredOutputEvaluator: Deterministic JSON field comparison (no LLM needed)
 
     Args:
         test_case: TestCase model with input, expected output, and metadata
-        actual_output: Actual output from agent
+        actual_output: Actual canonical text output from agent
         evaluator_config: Configuration with evaluator types, rubrics, and thresholds
         trajectory: Optional trajectory data from agent for advanced evaluators
+        actual_structured_output: Optional structured output dict from the agent.
+            Passed to StructuredOutputEvaluator for field-level comparison.
 
     Returns:
         dict: Evaluation result with score, passed, reason
@@ -492,6 +511,7 @@ def _evaluate_result(
                 expected_output=expected_output,
                 actual_output=actual_output,
                 trajectory=trajectory,
+                actual_structured_output=actual_structured_output,
             )
 
             score = result.score
@@ -742,7 +762,7 @@ def _finalize_evaluation(evaluator_id: str, item: dict) -> None:
         # Update status to Completed
         timestamp = datetime.now(timezone.utc).isoformat()
 
-        EVALUATIONS_TABLE.update_item(
+        EVALUATIONS_TABLE.update_item(  # type: ignore
             Key={"EvaluatorName": evaluator_id},
             UpdateExpression="""
                 SET #s = :status,

--- a/src/api/functions/evaluation-executor/index.py
+++ b/src/api/functions/evaluation-executor/index.py
@@ -295,13 +295,20 @@ def _invoke_agent_runtime(
     # Include trajectory flag to capture agent reasoning traces for evaluation
     # Trajectory data is required by evaluators like HelpfulnessEvaluator,
     # FaithfulnessEvaluator, and other trajectory-based evaluators
-    payload = json.dumps(
-        {
-            "prompt": input_text,
-            "userId": "evaluation-executor",
-            "includeTrajectory": True,  # Capture agent trajectory for evaluation
-        }
-    ).encode()
+    payload_dict = {
+        "prompt": input_text,
+        "userId": "evaluation-executor",
+        "includeTrajectory": True,  # Capture agent trajectory for evaluation
+    }
+
+    # Include state if provided in the test case (stringified JSON).
+    # This allows evaluation of agents whose tools rely on agent state
+    # (e.g. S3 URI references for document processing).
+    state = test_case.get("state")
+    if state:
+        payload_dict["state"] = state
+
+    payload = json.dumps(payload_dict).encode()
 
     # Step 4: Invoke agent runtime
     try:

--- a/src/user-interface/react-app/src/common/types.ts
+++ b/src/user-interface/react-app/src/common/types.ts
@@ -70,6 +70,9 @@ export interface TestCase {
     name: string;
     input: string;
     expected_output: string | Record<string, unknown>;
+    state?: string;
+    expected_trajectory?: string[];
+    expected_interactions?: Record<string, unknown>[];
     metadata?: Record<string, string>;
 }
 

--- a/src/user-interface/react-app/src/common/types.ts
+++ b/src/user-interface/react-app/src/common/types.ts
@@ -41,6 +41,7 @@ export enum EvaluatorType {
     TRAJECTORY = "TrajectoryEvaluator",
     INTERACTIONS = "InteractionsEvaluator",
     GOAL_SUCCESS_RATE = "GoalSuccessRateEvaluator",
+    STRUCTURED_OUTPUT = "StructuredOutputEvaluator",
     CUSTOM = "Custom",
 }
 
@@ -68,7 +69,7 @@ export interface Evaluator {
 export interface TestCase {
     name: string;
     input: string;
-    expected_output: string;
+    expected_output: string | Record<string, unknown>;
     metadata?: Record<string, string>;
 }
 

--- a/src/user-interface/react-app/src/components/admin/evaluations/view-results-modal.tsx
+++ b/src/user-interface/react-app/src/components/admin/evaluations/view-results-modal.tsx
@@ -142,7 +142,6 @@ export default function ViewResultsModal({
                                 id: "reason",
                                 header: "Evaluator Feedback",
                                 cell: (item) => <ReasonCell reason={item.reason} />,
-                                width: 450,
                             },
                             {
                                 id: "latency",
@@ -154,6 +153,7 @@ export default function ViewResultsModal({
                         variant="embedded"
                         stripedRows
                         stickyHeader
+                        wrapLines
                     />
                 </Container>
             </SpaceBetween>

--- a/src/user-interface/react-app/src/components/wizard/create-evaluator-wizard.tsx
+++ b/src/user-interface/react-app/src/components/wizard/create-evaluator-wizard.tsx
@@ -219,6 +219,9 @@ export default function CreateEvaluatorWizard({
                     name: item.name,
                     input: item.input,
                     expected_output: item.expected_output || "", // Optional
+                    ...(item.state && { state: item.state }),
+                    ...(item.expected_trajectory && { expected_trajectory: item.expected_trajectory }),
+                    ...(item.expected_interactions && { expected_interactions: item.expected_interactions }),
                     metadata: item.metadata || {},
                 };
             });

--- a/src/user-interface/react-app/src/components/wizard/create-evaluator-wizard.tsx
+++ b/src/user-interface/react-app/src/components/wizard/create-evaluator-wizard.tsx
@@ -68,6 +68,12 @@ const EVALUATOR_TYPE_OPTIONS = [
     { label: "Tool Selection Evaluator", value: EvaluatorType.TOOL_SELECTION, description: "Evaluates if the agent selected the correct tools (requires trajectory)" },
     { label: "Tool Parameter Evaluator", value: EvaluatorType.TOOL_PARAMETER, description: "Checks if tool parameters were correctly provided (requires trajectory)" },
     { label: "Trajectory Evaluator", value: EvaluatorType.TRAJECTORY, description: "Assesses the sequence of actions/tool calls taken by the agent to reach its goal" },
+    {
+        label: "Structured Output Evaluator",
+        value: EvaluatorType.STRUCTURED_OUTPUT,
+        description:
+            "Deterministic field-by-field comparison of structured JSON output against expected values (no LLM needed)",
+    },
 ];
 
 // Evaluators that require a rubric
@@ -716,8 +722,14 @@ export default function CreateEvaluatorWizard({
                                                 id: "expected_output",
                                                 header: "Expected Output",
                                                 cell: item => (
-                                                    <span title={item.expected_output}>
-                                                        {item.expected_output.length > 50 ? `${item.expected_output.substring(0, 50)}...` : item.expected_output}
+                                                    <span
+                                                        style={{
+                                                            wordBreak: "break-word",
+                                                        }}
+                                                    >
+                                                        {typeof item.expected_output === "object"
+                                                            ? JSON.stringify(item.expected_output)
+                                                            : item.expected_output || "-"}
                                                     </span>
                                                 ),
                                             },


### PR DESCRIPTION
This PR introduces two new evaluation capabilities:

1. **StructuredOutputEvaluator** — a custom, deterministic evaluator that performs field-by-field JSON comparison of structured agent output against expected values, with no LLM required.
2. **Agent state support in test cases** — an optional `state` field that forwards stringified JSON to the agent runtime, enabling evaluation of agents whose tools depend on runtime state (e.g., S3 URI references for document processing).


## Changes

### StructuredOutputEvaluator (`3b0dd72`)

- **New evaluator class** (`evaluator.py`): `StructuredOutputEvaluator` compares each field in the agent's `structuredOutput` dict against the `expected_output` dict deterministically:
  - **Non-null expected values** → field must exist with an identical value (exact match for strings; order-insensitive for lists).
  - **Null expected values** → field must be absent or explicitly `null` ("null-means-absent" convention).
  - **Extra fields** in the actual output are ignored.
- **EvaluatorFactory updates**: registered `StructuredOutputEvaluator` in the factory, added a `DETERMINISTIC_EVALUATORS` set so it is instantiated without an LLM model.
- **EvaluationRunner**: accepts `actual_structured_output` and routes it to `StructuredOutputEvaluator` while leaving the canonical text output untouched for other evaluators. `expected_output` dicts are serialized to JSON strings to satisfy Pydantic typing.
- **Lambda handler** (`index.py`):
  - `TestCase` model now accepts `expected_output` as `str | dict`, supports both `snake_case` and `camelCase` field names via Pydantic aliases, and includes `expected_trajectory` / `expected_interactions`.
  - `structuredOutput` is captured from the agent response and forwarded through `_evaluate_result`.
- **Frontend** (`types.ts`, `create-evaluator-wizard.tsx`):
  - Added `STRUCTURED_OUTPUT` enum member and wizard option.
  - `expected_output` type widened to `string | Record<string, unknown>`.
  - Expected-output column renders objects as JSON with word-break styling.
- **Documentation** (`evaluation.md`): new sections covering semantics, test-case format, recommended evaluator combos, and compatibility matrix entry.

### Agent state support (`001f6b4`)

- **Lambda handler** (`index.py`): reads the optional `state` field from each test case and includes it in the agent-runtime invocation payload.
- **Frontend** (`types.ts`, `create-evaluator-wizard.tsx`): `TestCase` interface extended with optional `state`, `expected_trajectory`, and `expected_interactions` fields; wizard serialization preserves these fields when present.
- **Results modal** (`view-results-modal.tsx`): removed fixed column width and enabled `wrapLines` for better readability of long evaluator feedback.
- **Documentation** (`evaluation.md`): new "Test Cases with Agent State" section with example JSON and field-reference table update.

---

## How to test

1. **StructuredOutputEvaluator** — create an evaluator with type `StructuredOutputEvaluator` and upload a test-case JSON where `expected_output` is a dict:
   ```json
   [
     {
       "name": "structured-test",
       "input": "What is Bedrock?",
       "expected_output": { "aws_services": ["Amazon Bedrock"] }
     }
   ]
   ```
   Run the evaluation and verify field-level pass/fail results (no LLM invocation).

2. **Agent state** — add a `state` field to a test case:
   ```json
   [
     {
       "name": "state-test",
       "input": "Summarize this document.",
       "expected_output": "...",
       "state": "{\"s3_bucket\":\"my-bucket\",\"document_s3_key\":\"doc.pdf\"}"
     }
   ]
   ```
   Confirm the agent receives the state and tools can access it via `tool_context.agent.state`.
   
-----


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
