### PR TITLE
➖ replace DynamoDB seeder with AwsCustomResource

### DIFF
--- a/iac-cdk/bin/aca.ts
+++ b/iac-cdk/bin/aca.ts
@@ -5,10 +5,34 @@
 // SPDX-License-Identifier: MIT-0
 
 import * as cdk from "aws-cdk-lib";
+import * as lambda from "aws-cdk-lib/aws-lambda";
 import { AwsSolutionsChecks } from "cdk-nag";
+import { IConstruct } from "constructs";
 import "source-map-support/register";
 import { AcaStack } from "../lib/aca-stack";
 import { getConfig } from "./config";
+
+/**
+ * CDK Aspect that upgrades any Lambda function using an outdated Node.js runtime
+ * to the latest supported version (nodejs24.x). This ensures CDK framework-managed
+ * Lambdas (e.g., AwsCustomResource singleton) use a current runtime.
+ * Must be registered before CDK-nag so runtime is updated before validation.
+ */
+class LambdaNodejsRuntimeUpgrader implements cdk.IAspect {
+    visit(node: IConstruct): void {
+        if (node instanceof cdk.CfnResource && node.cfnResourceType === "AWS::Lambda::Function") {
+            const cfnFunc = node as lambda.CfnFunction;
+            const runtime = cfnFunc.runtime;
+            if (
+                typeof runtime === "string" &&
+                runtime.startsWith("nodejs") &&
+                runtime !== "nodejs24.x"
+            ) {
+                cfnFunc.runtime = "nodejs24.x";
+            }
+        }
+    }
+}
 
 const app = new cdk.App();
 const config = getConfig();
@@ -25,4 +49,6 @@ cdk.Tags.of(stack).add("Team", "genaiic");
 if (config.prefix) {
     cdk.Tags.of(stack).add("Environment", config.prefix.toLowerCase());
 }
+// Register runtime upgrader BEFORE CDK-nag so Lambda runtimes are updated before validation
+cdk.Aspects.of(app).add(new LambdaNodejsRuntimeUpgrader());
 cdk.Aspects.of(app).add(new AwsSolutionsChecks());

--- a/iac-cdk/lib/aca-stack.ts
+++ b/iac-cdk/lib/aca-stack.ts
@@ -1,3 +1,8 @@
+// ----------------------------------------------------------------------
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: MIT-0
+// ----------------------------------------------------------------------
 import * as cdk from "aws-cdk-lib";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as sns from "aws-cdk-lib/aws-sns";
@@ -196,26 +201,20 @@ export class AcaStack extends cdk.Stack {
                 },
             ],
         );
-        // Add suppressions for DynamoDB seeder custom resource
-        NagSuppressions.addResourceSuppressionsByPath(
-            this,
-            [`/${this.stackName}/Custom::DynamodbSeederCustomDynamodbSeeder/ServiceRole/Resource`],
-            [
-                {
-                    id: "AwsSolutions-IAM4",
-                    reason: "DynamoDB seeder uses AWS managed policy for Lambda basic execution role. This is a third-party construct from @cloudcomponents/cdk-dynamodb-seeder.",
-                },
-            ],
-        );
-        NagSuppressions.addResourceSuppressionsByPath(
-            this,
-            [`/${this.stackName}/Custom::DynamodbSeederCustomDynamodbSeeder/Resource`],
-            [
-                {
-                    id: "AwsSolutions-L1",
-                    reason: "DynamoDB seeder Lambda runtime version is managed by the third-party construct @cloudcomponents/cdk-dynamodb-seeder.",
-                },
-            ],
-        );
+
+        // AwsCustomResource singleton Lambda (used by DynamoDB table seeders)
+        // Only exists when at least one AwsCustomResource is created (KB seeder or tool registry seeder)
+        if (knowledgeBase || props.config.toolRegistry.length > 0) {
+            NagSuppressions.addResourceSuppressionsByPath(
+                this,
+                [`/${this.stackName}/AWS679f53fac002430cb0da5b7982bd2287/ServiceRole/Resource`],
+                [
+                    {
+                        id: "AwsSolutions-IAM4",
+                        reason: "AWS managed policy for Lambda basic execution is required by CDK's AwsCustomResource singleton Lambda. This Lambda is framework-managed.",
+                    },
+                ],
+            );
+        }
     }
 }

--- a/iac-cdk/lib/agent-core/index.ts
+++ b/iac-cdk/lib/agent-core/index.ts
@@ -5,16 +5,14 @@
 // ----------------------------------------------------------------------
 import * as agentcore from "@aws-cdk/aws-bedrock-agentcore-alpha";
 import { RuntimeNetworkConfiguration } from "@aws-cdk/aws-bedrock-agentcore-alpha";
-import { DynamoDBSeeder, Seeds } from "@cloudcomponents/cdk-dynamodb-seeder";
-
 import * as cdk from "aws-cdk-lib";
-import * as path from "path";
 import { CfnOutput } from "aws-cdk-lib";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import { DockerImageAsset, Platform } from "aws-cdk-lib/aws-ecr-assets";
 import * as iam from "aws-cdk-lib/aws-iam";
 import { PolicyDocument, PolicyStatement, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
 import * as cr from "aws-cdk-lib/custom-resources";
+import * as path from "path";
 
 import * as sns from "aws-cdk-lib/aws-sns";
 
@@ -89,16 +87,60 @@ export class AcaAgentCoreContainer extends Construct {
                 pointInTimeRecoveryEnabled: true,
             },
         });
-        new DynamoDBSeeder(this, "ToolsSeeder", {
-            table: toolRegistry,
-            seeds: Seeds.fromInline(
-                props.config.toolRegistry.map((tool) => ({
-                    ToolName: tool.name,
-                    ToolDescription: tool.description,
-                    InvokesSubAgent: tool.invokesSubAgent,
-                })),
-            ),
-        });
+        // Seed tool registry table using native CDK AwsCustomResource (DynamoDB BatchWriteItem)
+        const toolSeedItems = props.config.toolRegistry.map((tool) => ({
+            PutRequest: {
+                Item: {
+                    ToolName: { S: tool.name },
+                    ToolDescription: { S: tool.description },
+                    ...(tool.invokesSubAgent !== undefined && {
+                        InvokesSubAgent: { BOOL: tool.invokesSubAgent },
+                    }),
+                },
+            },
+        }));
+
+        if (toolSeedItems.length > 0) {
+            const toolSeeder = new cr.AwsCustomResource(this, "ToolsSeederFunc", {
+                onCreate: {
+                    service: "DynamoDB",
+                    action: "BatchWriteItem",
+                    parameters: {
+                        RequestItems: {
+                            [toolRegistry.tableName]: toolSeedItems,
+                        },
+                    },
+                    physicalResourceId: cr.PhysicalResourceId.of("ToolRegistrySeeder"),
+                },
+                onUpdate: {
+                    service: "DynamoDB",
+                    action: "BatchWriteItem",
+                    parameters: {
+                        RequestItems: {
+                            [toolRegistry.tableName]: toolSeedItems,
+                        },
+                    },
+                    physicalResourceId: cr.PhysicalResourceId.of("ToolRegistrySeeder"),
+                },
+                policy: cr.AwsCustomResourcePolicy.fromStatements([
+                    new iam.PolicyStatement({
+                        actions: ["dynamodb:BatchWriteItem"],
+                        resources: [toolRegistry.tableArn],
+                    }),
+                ]),
+            });
+
+            NagSuppressions.addResourceSuppressions(
+                toolSeeder,
+                [
+                    {
+                        id: "AwsSolutions-IAM5",
+                        reason: "IAM role implicitly created by CDK for AwsCustomResource.",
+                    },
+                ],
+                true,
+            );
+        }
 
         // MCP Server Registry table
         const mcpServerRegistry = new dynamodb.Table(this, "McpServerRegistry", {

--- a/iac-cdk/lib/api/agent-core-runtime.ts
+++ b/iac-cdk/lib/api/agent-core-runtime.ts
@@ -197,7 +197,10 @@ export class AgentCoreApis extends Construct {
             typeName: "Mutation",
             fieldName: "publishRuntimeUpdate",
             code: appsync.Code.fromAsset(
-                path.join(__dirname, "../../../src/api/functions/resolvers/runtime-update/publish.js"),
+                path.join(
+                    __dirname,
+                    "../../../src/api/functions/resolvers/runtime-update/publish.js",
+                ),
             ),
             runtime: appsync.FunctionRuntime.JS_1_0_0,
             dataSource: noneDataSource,
@@ -206,7 +209,10 @@ export class AgentCoreApis extends Construct {
             typeName: "Subscription",
             fieldName: "receiveUpdateNotification",
             code: appsync.Code.fromAsset(
-                path.join(__dirname, "../../../src/api/functions/resolvers/runtime-update/subscribe.js"),
+                path.join(
+                    __dirname,
+                    "../../../src/api/functions/resolvers/runtime-update/subscribe.js",
+                ),
             ),
             runtime: appsync.FunctionRuntime.JS_1_0_0,
             dataSource: noneDataSource,
@@ -278,10 +284,13 @@ export class AgentCoreApis extends Construct {
             }:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:17`,
         );
         const notifyRuntimeUpdate = new NodejsFunction(this, "notify-runtime-update", {
-            entry: path.join(__dirname, "../../../src/api/functions/notify-runtime-update/index.ts"),
+            entry: path.join(
+                __dirname,
+                "../../../src/api/functions/notify-runtime-update/index.ts",
+            ),
             layers: [powertoolsLayerJS],
             handler: "index.handler",
-            runtime: Runtime.NODEJS_24_X,
+            runtime: Runtime.NODEJS_LATEST,
             loggingFormat: LoggingFormat.JSON,
             bundling: {
                 externalModules: ["@aws-sdk/*", "@aws-lambda-powertools/*", "@aws-crypto/*"],
@@ -310,7 +319,10 @@ export class AgentCoreApis extends Construct {
 
         const stateMachine = new sfn.StateMachine(scope, "DeleteAgentCoreEndpointStateMachine", {
             definitionBody: sfn.DefinitionBody.fromFile(
-                path.join(__dirname, "../../../src/api/state-machines/delete-agentcore-endpoints.json"),
+                path.join(
+                    __dirname,
+                    "../../../src/api/state-machines/delete-agentcore-endpoints.json",
+                ),
             ),
             definitionSubstitutions: substitutions,
             stateMachineName: `${prefix}-deleteAgentCoreEndpoint`,
@@ -515,7 +527,10 @@ export class AgentCoreApis extends Construct {
 
         const stateMachineDeleteRuntime = new sfn.StateMachine(scope, "DeleteRuntimeStateMachine", {
             definitionBody: sfn.DefinitionBody.fromFile(
-                path.join(__dirname, "../../../src/api/state-machines/delete-agentcore-runtime.json"),
+                path.join(
+                    __dirname,
+                    "../../../src/api/state-machines/delete-agentcore-runtime.json",
+                ),
             ),
             definitionSubstitutions: substitutionsDeleteRuntime,
             stateMachineName: `${prefix}-deleteAgentCoreRuntime`,
@@ -689,7 +704,10 @@ export class AgentCoreApis extends Construct {
 
         const stateMachineCreateRuntime = new sfn.StateMachine(scope, "CreateRuntimeStateMachine", {
             definitionBody: sfn.DefinitionBody.fromFile(
-                path.join(__dirname, "../../../src/api/state-machines/create-agentcore-runtime.json"),
+                path.join(
+                    __dirname,
+                    "../../../src/api/state-machines/create-agentcore-runtime.json",
+                ),
             ),
             definitionSubstitutions: substitutionsCreateRuntime,
             stateMachineName: `${prefix}-createAgentCoreRuntime`,

--- a/iac-cdk/lib/api/websocket-api-backend.ts
+++ b/iac-cdk/lib/api/websocket-api-backend.ts
@@ -1,8 +1,8 @@
-/* Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-
-SPDX-License-Identifier: MIT-0
-----------------------------------------------------------------------
-*/
+// ----------------------------------------------------------------------
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: MIT-0
+// ----------------------------------------------------------------------
 
 import * as path from "path";
 
@@ -74,10 +74,13 @@ export class WebsocketApiBackend extends Construct {
         );
 
         const outgoingMessageHandler = new NodejsFunction(this, "outgoing-message-handler", {
-            entry: path.join(__dirname, "../../../src/api/functions/outgoing-message-handler/index.ts"),
+            entry: path.join(
+                __dirname,
+                "../../../src/api/functions/outgoing-message-handler/index.ts",
+            ),
             layers: [powertoolsLayerJS],
             handler: "index.handler",
-            runtime: Runtime.NODEJS_24_X,
+            runtime: Runtime.NODEJS_LATEST,
             loggingFormat: LoggingFormat.JSON,
             bundling: {
                 externalModules: ["@aws-sdk/*", "@aws-lambda-powertools/*", "@aws-crypto/*"],

--- a/iac-cdk/lib/cleanup/index.ts
+++ b/iac-cdk/lib/cleanup/index.ts
@@ -209,7 +209,7 @@ export class Cleanup extends Construct {
             [
                 {
                     id: "AwsSolutions-L1",
-                    reason: "Lambda implicitly created by DynamoDBSeeder.",
+                    reason: "Lambda runtime version is managed by CDK custom resource provider framework construct.",
                 },
             ],
         );

--- a/iac-cdk/lib/knowledge-base/index.ts
+++ b/iac-cdk/lib/knowledge-base/index.ts
@@ -8,9 +8,7 @@ import {
     opensearchserverless as oss,
     opensearch_vectorindex as osvi,
 } from "@cdklabs/generative-ai-cdk-constructs";
-import { DynamoDBSeeder, Seeds } from "@cloudcomponents/cdk-dynamodb-seeder";
 import * as cdk from "aws-cdk-lib";
-import * as path from "path";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import * as events from "aws-cdk-lib/aws-events";
 import * as targets from "aws-cdk-lib/aws-events-targets";
@@ -19,8 +17,10 @@ import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as eventsources from "aws-cdk-lib/aws-lambda-event-sources";
 import * as s3 from "aws-cdk-lib/aws-s3";
 import * as sqs from "aws-cdk-lib/aws-sqs";
+import * as cr from "aws-cdk-lib/custom-resources";
 import { NagSuppressions } from "cdk-nag";
 import { Construct } from "constructs";
+import * as path from "path";
 import { Shared } from "../shared";
 import { ChunkingStrategyType, KnowledgeBaseParameters, SystemConfig } from "../shared/types";
 import { createLambda, createQueue, generatePrefix } from "../shared/utils";
@@ -216,19 +216,82 @@ export class VectorKnowledgeBase extends Construct {
             }),
         );
 
-        // Seed the inventory table with KB info
-        new DynamoDBSeeder(this, "knowledgeBaseTableSeeder", {
-            table: this.kbInventoryTable,
-            seeds: Seeds.fromInline([
-                {
-                    KnowledgeBaseId: this.knowledgeBase.knowledgeBaseId,
-                    DataSourceId: dataSource.dataSourceId,
-                    DataSourcePrefix: dataSourcePrefix,
-                    S3DataProcessingRuleName: this.s3DataSourceRule.ruleName,
-                    RawInputPrefix: props.config.dataProcessingParameters.inputPrefix,
+        // Seed the inventory table with KB info using native CDK AwsCustomResource
+        const kbSeeder = new cr.AwsCustomResource(this, "knowledgeBaseTableSeeder", {
+            onCreate: {
+                service: "DynamoDB",
+                action: "BatchWriteItem",
+                parameters: {
+                    RequestItems: {
+                        [this.kbInventoryTable.tableName]: [
+                            {
+                                PutRequest: {
+                                    Item: {
+                                        KnowledgeBaseId: {
+                                            S: this.knowledgeBase.knowledgeBaseId,
+                                        },
+                                        DataSourceId: { S: dataSource.dataSourceId },
+                                        DataSourcePrefix: { S: dataSourcePrefix },
+                                        S3DataProcessingRuleName: {
+                                            S: this.s3DataSourceRule.ruleName,
+                                        },
+                                        RawInputPrefix: {
+                                            S: props.config.dataProcessingParameters!.inputPrefix,
+                                        },
+                                    },
+                                },
+                            },
+                        ],
+                    },
                 },
+                physicalResourceId: cr.PhysicalResourceId.of("KnowledgeBaseInventorySeeder"),
+            },
+            onUpdate: {
+                service: "DynamoDB",
+                action: "BatchWriteItem",
+                parameters: {
+                    RequestItems: {
+                        [this.kbInventoryTable.tableName]: [
+                            {
+                                PutRequest: {
+                                    Item: {
+                                        KnowledgeBaseId: {
+                                            S: this.knowledgeBase.knowledgeBaseId,
+                                        },
+                                        DataSourceId: { S: dataSource.dataSourceId },
+                                        DataSourcePrefix: { S: dataSourcePrefix },
+                                        S3DataProcessingRuleName: {
+                                            S: this.s3DataSourceRule.ruleName,
+                                        },
+                                        RawInputPrefix: {
+                                            S: props.config.dataProcessingParameters!.inputPrefix,
+                                        },
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                },
+                physicalResourceId: cr.PhysicalResourceId.of("KnowledgeBaseInventorySeeder"),
+            },
+            policy: cr.AwsCustomResourcePolicy.fromStatements([
+                new iam.PolicyStatement({
+                    actions: ["dynamodb:BatchWriteItem"],
+                    resources: [this.kbInventoryTable.tableArn],
+                }),
             ]),
         });
+
+        NagSuppressions.addResourceSuppressions(
+            kbSeeder,
+            [
+                {
+                    id: "AwsSolutions-IAM5",
+                    reason: "IAM role implicitly created by CDK for AwsCustomResource.",
+                },
+            ],
+            true,
+        );
 
         // Grant Bedrock permissions
         this.funcStartSync.addToRolePolicy(

--- a/iac-cdk/package-lock.json
+++ b/iac-cdk/package-lock.json
@@ -11,9 +11,8 @@
                 "@aws-cdk/aws-bedrock-agentcore-alpha": "^2.232.1-alpha.0",
                 "@aws-cdk/aws-cognito-identitypool-alpha": "^2.181.1-alpha.0",
                 "@cdklabs/generative-ai-cdk-constructs": "^0.1.315",
-                "@cloudcomponents/cdk-dynamodb-seeder": "^2.4.0",
-                "aws-cdk-lib": "^2.243.0",
-                "cdk-nag": "2.34.23",
+                "aws-cdk-lib": "^2.238.0",
+                "cdk-nag": "^2.37.55",
                 "constructs": "^10.5.1",
                 "js-yaml": "^4.1.1",
                 "source-map-support": "^0.5.21"
@@ -112,6 +111,7 @@
                 "semver"
             ],
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "jsonschema": "~1.4.1",
                 "semver": "^7.7.3"
@@ -1052,6 +1052,7 @@
             "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -1551,32 +1552,12 @@
                 "constructs": "^10.0.0"
             }
         },
-        "node_modules/@cdklabs/generative-ai-cdk-constructs/node_modules/cdk-nag": {
-            "version": "2.37.55",
-            "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.37.55.tgz",
-            "integrity": "sha512-xcAkygwbph3pp7N0UEzJBmXUH/MIsluV7DYJSeZ/V3yCr0Y0QaRGO298WyD6mi4K+Rmnpl+EJoWUxcOblOqLKA==",
-            "license": "Apache-2.0",
-            "peerDependencies": {
-                "aws-cdk-lib": "^2.176.0",
-                "constructs": "^10.0.5"
-            }
-        },
         "node_modules/@cdklabs/generative-ai-cdk-constructs/node_modules/deepmerge": {
             "version": "4.3.1",
             "inBundle": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/@cloudcomponents/cdk-dynamodb-seeder": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/@cloudcomponents/cdk-dynamodb-seeder/-/cdk-dynamodb-seeder-2.4.0.tgz",
-            "integrity": "sha512-yXEPqvQ/tz7vAJ+py+jksTY2A5Z/f1SNt7+0K8mV3GR0Tp+rNR9rT0kKIIe7heMlrJGwcnOCozOKdRLbau3+cA==",
-            "license": "MIT",
-            "peerDependencies": {
-                "aws-cdk-lib": "^2.141.0",
-                "constructs": "^10.3.0"
             }
         },
         "node_modules/@cspotcode/source-map-support": {
@@ -3292,6 +3273,7 @@
             "integrity": "sha512-jrTfRC7FM6nChvU7X2KqcrgquofrWLFDeYC1hKfwNWomVvrn7JIksqf344WN2X/y8xrgqBd2dJATZV4GbatBfg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~6.19.2"
             }
@@ -3447,6 +3429,7 @@
                 "mime-types"
             ],
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-cdk/asset-awscli-v1": "2.2.263",
                 "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
@@ -3941,6 +3924,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
@@ -3967,6 +3951,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
             "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -4005,6 +3990,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -4090,12 +4076,12 @@
             "license": "CC-BY-4.0"
         },
         "node_modules/cdk-nag": {
-            "version": "2.34.23",
-            "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.34.23.tgz",
-            "integrity": "sha512-TCvQy5uCk1QHek7UhbmFh4Uk2HveXyuQ6jfUC0ZfW5HgAMhv8+6lTY56Jq09/rm0csKDzWnMpGGAXjgLW6rg0A==",
+            "version": "2.37.55",
+            "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.37.55.tgz",
+            "integrity": "sha512-xcAkygwbph3pp7N0UEzJBmXUH/MIsluV7DYJSeZ/V3yCr0Y0QaRGO298WyD6mi4K+Rmnpl+EJoWUxcOblOqLKA==",
             "license": "Apache-2.0",
             "peerDependencies": {
-                "aws-cdk-lib": "^2.156.0",
+                "aws-cdk-lib": "^2.176.0",
                 "constructs": "^10.0.5"
             }
         },
@@ -4246,7 +4232,8 @@
             "version": "10.5.1",
             "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.5.1.tgz",
             "integrity": "sha512-f/TfFXiS3G/yVIXDjOQn9oTlyu9Wo7Fxyjj7lb8r92iO81jR2uST+9MstxZTmDGx/CgIbxCXkFXgupnLTNxQZg==",
-            "license": "Apache-2.0"
+            "license": "Apache-2.0",
+            "peer": true
         },
         "node_modules/convert-source-map": {
             "version": "2.0.0",
@@ -4336,6 +4323,7 @@
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
             "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -4572,9 +4560,9 @@
             }
         },
         "node_modules/fast-xml-parser": {
-            "version": "5.4.1",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
-            "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
+            "version": "5.5.6",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.6.tgz",
+            "integrity": "sha512-3+fdZyBRVg29n4rXP0joHthhcHdPUHaIC16cuyyd1iLsuaO6Vea36MPrxgAzbZna8lhvZeRL8Bc9GP56/J9xEw==",
             "dev": true,
             "funding": [
                 {
@@ -4584,7 +4572,8 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "fast-xml-builder": "^1.0.0",
+                "fast-xml-builder": "^1.1.4",
+                "path-expression-matcher": "^1.1.3",
                 "strnum": "^2.1.2"
             },
             "bin": {
@@ -5023,6 +5012,7 @@
             "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/core": "^29.7.0",
                 "@jest/types": "^29.6.3",
@@ -5814,6 +5804,7 @@
             "version": "10.2.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
             "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+            "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
                 "brace-expansion": "^5.0.2"
@@ -6278,6 +6269,7 @@
             "version": "6.3.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -6678,6 +6670,7 @@
             "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@cspotcode/source-map-support": "^0.8.0",
                 "@tsconfig/node10": "^1.0.7",
@@ -6752,6 +6745,7 @@
             "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"

--- a/iac-cdk/package.json
+++ b/iac-cdk/package.json
@@ -36,9 +36,8 @@
         "@aws-cdk/aws-bedrock-agentcore-alpha": "^2.232.1-alpha.0",
         "@aws-cdk/aws-cognito-identitypool-alpha": "^2.181.1-alpha.0",
         "@cdklabs/generative-ai-cdk-constructs": "^0.1.315",
-        "@cloudcomponents/cdk-dynamodb-seeder": "^2.4.0",
-        "aws-cdk-lib": "^2.243.0",
-        "cdk-nag": "2.34.23",
+        "aws-cdk-lib": "^2.238.0",
+        "cdk-nag": "^2.37.55",
         "constructs": "^10.5.1",
         "js-yaml": "^4.1.1",
         "source-map-support": "^0.5.21"
@@ -47,6 +46,7 @@
         "glob": "^10",
         "inflight": "^2.0.0",
         "brace-expansion": "^2.0.1",
-        "minimatch": "^10.2.1"
+        "minimatch": "^10.2.1",
+        "fast-xml-parser": ">=5.5.6"
     }
 }


### PR DESCRIPTION
[CDK] - Replace DynamoDB seeder with AwsCustomResource to avoid issue with nodejs18 lambdas


- Replace third-party @cloudcomponents/cdk-dynamodb-seeder with CDK's built-in AwsCustomResource for seeding DynamoDB tables
- Add LambdaNodejsRuntimeUpgrader CDK Aspect to ensure all framework-managed Lambda functions use nodejs24.x runtime before CDK-nag validation
- Update NagSuppressions to target AwsCustomResource singleton Lambda instead of the removed DynamoDB seeder construct
- Update package-lock.json with related dependency changes



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
