### PR TITLE
🛂 propagate aws_profile to local-exec provisioners across modules

### DIFF
--- a/iac-terraform/main.tf
+++ b/iac-terraform/main.tf
@@ -114,6 +114,7 @@ module "shared" {
   prefix              = local.prefix
   lambda_architecture = var.lambda_architecture
   kms_key_arn         = aws_kms_key.main.arn
+  aws_profile         = var.aws_profile
 
   depends_on = [aws_kms_key.main]
 }
@@ -174,6 +175,9 @@ module "agent_core" {
   # KMS key from root level (breaks circular dependency)
   kms_key_arn = aws_kms_key.main.arn
   kms_key_id  = aws_kms_key.main.key_id
+
+  # AWS CLI profile for local-exec provisioners
+  aws_profile = var.aws_profile
 
   depends_on = [module.shared, aws_kms_key.main]
 }
@@ -561,6 +565,9 @@ module "knowledge_base" {
   data_source_prefix = try(var.knowledge_base.data_source_prefix, "data-source")
   input_prefix       = try(var.data_processing.input_prefix, "input")
   description        = try(var.knowledge_base.description, "Knowledge Base for searching helpful information.")
+
+  # AWS CLI profile for local-exec provisioners
+  aws_profile = var.aws_profile
 }
 
 # -----------------------------------------------------------------------------
@@ -640,6 +647,9 @@ module "evaluation" {
   # Encryption
   kms_key_arn = aws_kms_key.main.arn
 
+  # AWS CLI profile for local-exec provisioners
+  aws_profile = var.aws_profile
+
   depends_on = [module.appsync, module.api_tables, aws_kms_key.main]
 }
 
@@ -697,6 +707,9 @@ module "cleanup" {
 
   # Encryption
   kms_key_arn = aws_kms_key.main.arn
+
+  # AWS CLI profile for local-exec provisioners
+  aws_profile = var.aws_profile
 
   depends_on = [module.knowledge_base, module.agent_core]
 }

--- a/iac-terraform/modules/agent_core/codebuild.tf
+++ b/iac-terraform/modules/agent_core/codebuild.tf
@@ -373,7 +373,10 @@ resource "null_resource" "build_agent_image" {
 
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
-    command     = <<-EOT
+    environment = {
+      AWS_PROFILE = var.aws_profile
+    }
+    command = <<-EOT
       set -euo pipefail
 
       echo "Starting CodeBuild for agent image (tag: ${local.content_based_tag})..."
@@ -432,7 +435,10 @@ resource "null_resource" "build_swarm_image" {
 
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
-    command     = <<-EOT
+    environment = {
+      AWS_PROFILE = var.aws_profile
+    }
+    command = <<-EOT
       set -euo pipefail
 
       echo "Starting CodeBuild for swarm agent image (tag: ${local.swarm_content_based_tag})..."
@@ -540,7 +546,10 @@ resource "null_resource" "build_graph_image" {
 
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
-    command     = <<-EOT
+    environment = {
+      AWS_PROFILE = var.aws_profile
+    }
+    command = <<-EOT
       set -euo pipefail
 
       echo "Starting CodeBuild for graph agent image (tag: ${local.graph_content_based_tag})..."
@@ -648,7 +657,10 @@ resource "null_resource" "build_agents_as_tools_image" {
 
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
-    command     = <<-EOT
+    environment = {
+      AWS_PROFILE = var.aws_profile
+    }
+    command = <<-EOT
       set -euo pipefail
 
       echo "Starting CodeBuild for agents-as-tools agent image (tag: ${local.agents_as_tools_content_based_tag})..."

--- a/iac-terraform/modules/agent_core/variables.tf
+++ b/iac-terraform/modules/agent_core/variables.tf
@@ -184,3 +184,9 @@ variable "knowledge_base_id" {
   type        = string
   default     = null
 }
+
+variable "aws_profile" {
+  description = "AWS CLI profile name for local-exec provisioner commands."
+  type        = string
+  default     = ""
+}

--- a/iac-terraform/modules/cleanup/main.tf
+++ b/iac-terraform/modules/cleanup/main.tf
@@ -308,6 +308,7 @@ resource "null_resource" "cleanup_trigger" {
   triggers = {
     lambda_function_name = aws_lambda_function.cleanup.function_name
     region               = data.aws_region.current.id
+    aws_profile          = var.aws_profile
   }
 
   # This provisioner runs ONLY during terraform destroy
@@ -318,6 +319,7 @@ resource "null_resource" "cleanup_trigger" {
       aws lambda invoke \
         --function-name ${self.triggers.lambda_function_name} \
         --region ${self.triggers.region} \
+        ${lookup(self.triggers, "aws_profile", "") != "" ? "--profile ${lookup(self.triggers, "aws_profile", "")}" : ""} \
         --payload '{"RequestType": "Delete"}' \
         --cli-binary-format raw-in-base64-out \
         /tmp/cleanup-response.json 2>&1 || echo "Cleanup Lambda invocation failed, continuing destroy..."

--- a/iac-terraform/modules/cleanup/variables.tf
+++ b/iac-terraform/modules/cleanup/variables.tf
@@ -90,3 +90,9 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "aws_profile" {
+  description = "AWS CLI profile name for local-exec provisioner commands."
+  type        = string
+  default     = ""
+}

--- a/iac-terraform/modules/evaluation/codebuild.tf
+++ b/iac-terraform/modules/evaluation/codebuild.tf
@@ -209,7 +209,10 @@ resource "null_resource" "build_evaluation_executor" {
 
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
-    command     = <<-EOT
+    environment = {
+      AWS_PROFILE = var.aws_profile
+    }
+    command = <<-EOT
       set -euo pipefail
 
       echo "Starting CodeBuild for evaluation executor package (hash: ${local.executor_source_hash})..."

--- a/iac-terraform/modules/evaluation/variables.tf
+++ b/iac-terraform/modules/evaluation/variables.tf
@@ -88,3 +88,9 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "aws_profile" {
+  description = "AWS CLI profile name for local-exec provisioner commands."
+  type        = string
+  default     = ""
+}

--- a/iac-terraform/modules/knowledge_base/codebuild.tf
+++ b/iac-terraform/modules/knowledge_base/codebuild.tf
@@ -290,7 +290,10 @@ resource "null_resource" "build_vector_index_lambda" {
 
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
-    command     = <<-EOT
+    environment = {
+      AWS_PROFILE = var.aws_profile
+    }
+    command = <<-EOT
       set -euo pipefail
 
       echo "Starting CodeBuild for vector index Lambda package (hash: ${local.vector_index_source_hash})..."

--- a/iac-terraform/modules/knowledge_base/variables.tf
+++ b/iac-terraform/modules/knowledge_base/variables.tf
@@ -166,3 +166,9 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "aws_profile" {
+  description = "AWS CLI profile name for local-exec provisioner commands."
+  type        = string
+  default     = ""
+}

--- a/iac-terraform/modules/shared/codebuild-layers.tf
+++ b/iac-terraform/modules/shared/codebuild-layers.tf
@@ -255,7 +255,10 @@ resource "null_resource" "build_boto3_layer" {
 
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
-    command     = <<-EOT
+    environment = {
+      AWS_PROFILE = var.aws_profile
+    }
+    command = <<-EOT
       set -euo pipefail
 
       echo "Starting CodeBuild for boto3 layer (tag: ${local.boto3_content_tag})..."
@@ -395,7 +398,10 @@ resource "null_resource" "build_notify_runtime_update" {
 
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
-    command     = <<-EOT
+    environment = {
+      AWS_PROFILE = var.aws_profile
+    }
+    command = <<-EOT
       set -euo pipefail
 
       echo "Starting CodeBuild for notify-runtime-update Lambda (tag: ${local.notify_runtime_update_content_tag})..."

--- a/iac-terraform/modules/shared/variables.tf
+++ b/iac-terraform/modules/shared/variables.tf
@@ -51,3 +51,9 @@ variable "kms_key_arn" {
   description = "ARN of the KMS key for encrypting S3 objects and other resources."
   type        = string
 }
+
+variable "aws_profile" {
+  description = "AWS CLI profile name for local-exec provisioner commands."
+  type        = string
+  default     = ""
+}

--- a/iac-terraform/modules/user_interface/codebuild.tf
+++ b/iac-terraform/modules/user_interface/codebuild.tf
@@ -288,7 +288,10 @@ resource "null_resource" "build_react_app_codebuild" {
 
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
-    command     = <<-EOT
+    environment = {
+      AWS_PROFILE = var.aws_profile
+    }
+    command = <<-EOT
       set -euo pipefail
 
       echo "Starting CodeBuild for React app (source: ${local.react_content_tag}, config: ${local.config_hash})..."

--- a/iac-terraform/modules/user_interface/main.tf
+++ b/iac-terraform/modules/user_interface/main.tf
@@ -13,10 +13,9 @@ Equivalent to: iac-cdk/lib/user-interface/index.ts UserInterface construct
 */
 
 locals {
-  name_prefix     = lower(var.prefix)
-  react_app_path  = "${path.module}/../../../src/user-interface/react-app"
-  build_path      = "${local.react_app_path}/dist"
-  aws_profile_arg = var.aws_profile != "" ? "--profile ${var.aws_profile}" : ""
+  name_prefix    = lower(var.prefix)
+  react_app_path = "${path.module}/../../../src/user-interface/react-app"
+  build_path     = "${local.react_app_path}/dist"
 }
 
 # Get current region and account


### PR DESCRIPTION
Pass the `aws_profile` variable from the root module into shared, agent_core, knowledge_base, evaluation, and cleanup submodules so that all local-exec provisioners (CodeBuild triggers, Lambda invocations, S3 syncs, etc.) use the correct AWS CLI profile.

This ensures Terraform runs that rely on named AWS profiles work correctly for all local-exec commands instead of falling back to the default profile or environment credentials.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
