### PR TITLE
🐛 hydrate agent state on every non-heartbeat message

### DIFF
--- a/src/agent-core/docker/app.py
+++ b/src/agent-core/docker/app.py
@@ -186,6 +186,17 @@ async def invoke(payload, context: RequestContext):
         logger.info("Exiting function because the payload is only a heartbeat")
         return
 
+    # Hydrate agent state from payload on every non-heartbeat message.
+    state_json = payload.get("state")
+    if state_json and AGENT:
+        state_data = json.loads(state_json)
+        for key, value in state_data.items():
+            AGENT.state.set(key, value)
+        logger.info(
+            "Agent state hydrated from payload",
+            extra={"stateKeys": list(state_data.keys())},
+        )
+
     logger.info(
         "Calling agent with user message and context",
         extra={


### PR DESCRIPTION
Heartbeat payloads initialize the agent without state, so when the first real message arrives carrying session state (e.g. S3 coordinates for diagram exploration tools), it was silently dropped because the agent was already initialized.

Re-apply the payload state to AGENT.state on every non-heartbeat invocation so that late-arriving state is never lost.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
