### PR TITLE
 🥅 use while-read loop to safely iterate over projects list

### DIFF
--- a/iac-cdk/scripts/build.sh
+++ b/iac-cdk/scripts/build.sh
@@ -149,7 +149,8 @@ BUILD_IDS=()
 BUILD_PROJECTS=()
 SKIPPED=0
 
-for PROJECT in $PROJECTS; do
+while IFS= read -r PROJECT; do
+    [[ -z "$PROJECT" ]] && continue
     if needs_rebuild "$PROJECT"; then
         info "Starting build: ${PROJECT}"
 
@@ -168,7 +169,7 @@ for PROJECT in $PROJECTS; do
         skip "Already built (unchanged): ${PROJECT}"
         SKIPPED=$((SKIPPED + 1))
     fi
-done
+done <<< "$PROJECTS"
 
 TOTAL=${#BUILD_IDS[@]}
 


### PR DESCRIPTION
 Replace `for PROJECT in $PROJECTS` with `while IFS= read -r PROJECT`and a here-string to prevent word splitting issues on project names containing spaces or special characters. Also skip empty lines to avoid processing blank entries.

### Ack

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
