### PR TITLE
✨ Support AI Skills for single agents

### DIFF
--- a/docs/src/skills.md
+++ b/docs/src/skills.md
@@ -1,0 +1,244 @@
+# Agent Skills
+
+Skills give agents on-demand access to specialized instructions without bloating the system prompt. Instead of front-loading every possible instruction into a single prompt, you define modular skill packages that the agent discovers and activates only when relevant.
+
+This feature implements the [Agent Skills specification](https://agentskills.io/specification) via the Strands SDK `AgentSkills` plugin.
+
+## Overview
+
+### What Are Skills?
+
+A skill is a self-contained instruction package stored as a markdown file with YAML frontmatter. Skills follow the **progressive disclosure** pattern:
+
+1. **Discovery** — On initialization, skill metadata (name + description) is injected into the agent's system prompt as an XML block
+2. **Activation** — When the agent determines it needs a skill, it calls the `skills` tool → full instructions are loaded on-demand
+3. **Execution** — The agent follows the loaded instructions for the duration of the conversation
+
+This keeps the context window lean while giving the agent access to deep, specialized knowledge.
+
+### When to Use Skills
+
+| Approach | Best for | Trade-off |
+|----------|----------|-----------|
+| **System prompt** | Small, always-relevant instructions | Grows unwieldy with many capabilities |
+| **Skills** | Modular, domain-specific instruction sets | Requires a tool call to activate |
+| **Multi-agent** | Fundamentally different roles or models | Higher complexity and latency |
+
+Use skills when you want a single agent that can handle a wide range of tasks by loading the right instructions at the right time, without the overhead of a multi-agent architecture.
+
+---
+
+## Creating a Skill
+
+### Via the UI
+
+1. Navigate to **AgentCore Manager** → click **Manage Skills** in the toolbar
+2. Click **Create Skill**
+3. Fill in the form:
+   - **Skill Name** — Unique identifier (letters, digits, hyphens, underscores, max 64 chars). Examples: `pdf-processing`, `analog-alarms`, `code-review`
+   - **Description** — Short summary that appears in the agent's system prompt. Keep it concise — this is what the agent reads to decide whether to activate the skill.
+   - **Instructions (Markdown)** — The full skill body loaded on-demand when activated. Use markdown formatting with headers, lists, code blocks.
+4. Click **Create**
+
+### Adding Resource Files
+
+After creating a skill, re-open it for editing and switch to the **Resources** tab:
+
+1. Select the target directory (`scripts/`, `references/`, or `assets/`)
+2. Enter the filename (e.g., `extract.py`)
+3. Paste the file content
+4. Click **Upload**
+
+> **Note:** The Resources tab is disabled during creation — you must save the skill first, then re-open it to manage resources.
+
+---
+
+## SKILL.md Format
+
+Skills follow the [Agent Skills specification](https://agentskills.io/specification). Each skill is stored as a `SKILL.md` file with YAML frontmatter:
+
+```markdown
+---
+name: pdf-processing
+description: Extract text and tables from PDF files. Use when handling PDFs.
+allowed-tools: file_read shell
+---
+
+# PDF Processing
+
+You are a PDF processing expert. When asked to extract content from a PDF:
+
+1. Use `shell` to run the extraction script at `scripts/extract.py`
+2. Use `file_read` to review the output
+3. Summarize the extracted content for the user
+
+## Supported Formats
+- Standard PDF documents
+- Scanned PDFs (via OCR)
+- PDF forms
+```
+
+### Frontmatter Fields
+
+| Field | Required | Constraints |
+|-------|----------|-------------|
+| `name` | Yes | Max 64 chars. Lowercase letters, numbers, hyphens. Must not start/end with hyphen. Must match the directory name. |
+| `description` | Yes | Max 1024 chars. What the skill does and when to use it. This text appears in the agent's system prompt. |
+| `allowed-tools` | No | Space-separated list of tool names this skill uses (informational — not enforced at runtime). |
+| `license` | No | License name or reference to bundled license file. |
+| `compatibility` | No | Max 500 chars. Environment requirements. |
+| `metadata` | No | Arbitrary key-value mapping for custom data. |
+
+---
+
+## Resource Files
+
+Skills can include resource files organized in three standard subdirectories:
+
+```
+my-skill/
+├── SKILL.md           # Required: metadata + instructions
+├── scripts/           # Optional: executable scripts the agent can run
+│   └── extract.py
+├── references/        # Optional: reference documents and guides
+│   └── API-reference.md
+└── assets/            # Optional: static files (templates, configs, data)
+    └── mapping-template.json
+```
+
+### Supported File Types
+
+Resource files uploaded via the UI are **text-only** (content is pasted into a textarea). Supported file extensions include:
+
+| Directory | Typical Files | Purpose |
+|-----------|---------------|---------|
+| `scripts/` | `.py`, `.sh`, `.js`, `.ts` | Executable scripts the agent can run via `shell` or `file_read` |
+| `references/` | `.md`, `.txt`, `.json`, `.yaml`, `.csv` | Reference documents the agent can read for additional context |
+| `assets/` | `.json`, `.yaml`, `.xml`, `.csv`, `.txt`, `.html` | Templates, configuration files, static data |
+
+### Limits
+
+- **Maximum 20 resource files** per skill (matches the SDK's `max_resource_files` default)
+- **Maximum 1 MB** per individual resource file
+- **Text content only** — binary files (images, compiled scripts) are not supported via the UI
+
+### How the Agent Accesses Resources
+
+When a skill is activated via the `skills` tool, the SDK returns:
+- The full SKILL.md instructions
+- A listing of all available resource files with their absolute local paths
+
+The agent can then use tools like `file_read` to access these files. For example:
+
+```
+Available resources:
+  scripts/extract.py (at /tmp/agent_skills_xyz/pdf-processing/scripts/extract.py)
+  references/API-reference.md (at /tmp/agent_skills_xyz/pdf-processing/references/API-reference.md)
+```
+
+> **Note:** Scripts are not automatically executed — the agent must explicitly call a tool (like `shell`) to run them.
+
+---
+
+## Attaching Skills to Agents
+
+Skills are attached to agents during configuration in the **Agent Factory Wizard**:
+
+1. Create or edit an agent in the Agent Factory
+2. Navigate to the **Tools & Skills** step
+3. In the **Skills** section at the bottom, select skills from the dropdown
+4. Attached skills appear as dismissible tokens — click × to detach
+
+Skills are stored in the agent configuration as a list of skill names:
+
+```json
+{
+  "skills": ["pdf-processing", "code-review", "data-analysis"]
+}
+```
+
+---
+
+## How Skills Work at Runtime
+
+When an agent starts:
+
+1. The runtime reads the `skills` list from the agent configuration
+2. For each skill name, downloads the entire skill directory from S3 (`skills/{name}/SKILL.md` + resources)
+3. Writes to a local temp directory with the standard Agent Skills layout
+4. Passes the temp directory to `AgentSkills(skills=temp_dir)` plugin
+5. The plugin injects skill metadata into the system prompt and registers the `skills` tool
+
+During conversation:
+
+```
+System prompt includes:
+<available_skills>
+  <skill>
+    <name>pdf-processing</name>
+    <description>Extract text and tables from PDF files.</description>
+  </skill>
+  <skill>
+    <name>code-review</name>
+    <description>Review code for best practices and bugs.</description>
+  </skill>
+</available_skills>
+
+User: "Can you extract the tables from this PDF?"
+
+Agent thinks: "This is about PDF processing → I should activate that skill"
+Agent calls: skills(skill_name="pdf-processing")
+Agent receives: Full instructions + resource listing
+Agent follows: The step-by-step instructions from the skill
+```
+
+---
+
+## Best Practices
+
+### Writing Good Descriptions
+
+The description is what appears in the system prompt — it's the agent's only information to decide whether to activate a skill. Make it:
+
+- **Action-oriented**: "Extract text and tables from PDF files" ✅ vs. "PDF processing capabilities" ❌
+- **Contextual**: "Use when handling PDFs" tells the agent WHEN to activate
+- **Concise**: Keep under 100 characters if possible — it's injected into every request
+
+### Writing Good Instructions
+
+The instruction body is loaded on-demand. It can be as long and detailed as needed:
+
+- Use markdown headers to organize sections
+- Include step-by-step procedures
+- Reference resource files with relative paths (e.g., "run `scripts/extract.py`")
+- Include examples and edge cases
+- Use the `allowed-tools` frontmatter to document which tools the skill expects
+
+### Skill Naming Conventions
+
+- Use lowercase with hyphens: `pdf-processing`, `code-review`, `data-analysis`
+- Be specific: `s3-bucket-security` > `security`
+- Match the directory name exactly (enforced by the spec)
+
+### When NOT to Use Skills
+
+- If the instruction is always needed → put it in the **system prompt**
+- If the skill would never be skipped → it's not saving context window space
+- If the agent needs different tools/models → use a **multi-agent** architecture instead
+
+---
+
+## Limitations
+
+- **Voice mode (BidiAgent)**: Skills are not currently supported in voice-to-voice mode. The `BidiAgent` class does not yet support the `plugins` parameter. This will be added when the Strands SDK adds plugin support to BidiAgent.
+- **Binary resources**: Only text files can be uploaded via the UI. Binary files (images, compiled scripts) require direct S3 upload.
+- **No inter-skill dependencies**: Skills are independent — there is no built-in mechanism for one skill to depend on another.
+
+---
+
+## Related Resources
+
+- [Agent Skills Specification](https://agentskills.io/specification)
+- [Strands Agents Skills Documentation](https://strandsagents.com/docs/user-guide/concepts/plugins/skills/)
+- [Expanding AI Tools](./expanding-ai-tools.md)
+- [Agent Factory Operations](./agent-factory.md)

--- a/iac-cdk/lib/aca-stack.ts
+++ b/iac-cdk/lib/aca-stack.ts
@@ -18,6 +18,7 @@ import { VectorKnowledgeBase } from "./knowledge-base";
 import { Observability } from "./observability";
 import { Shared } from "./shared";
 import { SystemConfig } from "./shared/types";
+import { SkillsBucket } from "./skills-bucket";
 import { UserInterface } from "./user-interface";
 
 export interface AcaProps extends cdk.StackProps {
@@ -79,6 +80,9 @@ export class AcaStack extends cdk.Stack {
         // (prefix = stackName.toLowerCase(), same as generatePrefix)
         const sessionsTableName = `${this.stackName.toLowerCase()}-sessionsTable`;
 
+        // Skills bucket for Agent Skills storage
+        const skillsBucket = new SkillsBucket(this, "SkillsBucket");
+
         const agentCoreInfra = new AcaAgentCoreContainer(this, "AgentCoreInfra", {
             shared: shared,
             config: props.config,
@@ -88,7 +92,25 @@ export class AcaStack extends cdk.Stack {
             graphImage: props.builder.graphImage,
             agentsAsToolsImage: props.builder.agentsAsToolsImage,
             sessionsTableName: sessionsTableName,
+            skillsBucketName: skillsBucket.bucket.bucketName,
         });
+
+        // Grant AgentCore execution role read access to skills bucket (for runtime loading)
+        skillsBucket.bucket.grantRead(agentCoreInfra.executionRole);
+
+        // Suppress CDK NAG for the skills bucket read grant on the execution role's default policy.
+        // The wildcard is necessary because the agent needs to read any skill file (skills/*.md)
+        // from the bucket at runtime — the specific keys are determined dynamically by the agent configuration.
+        NagSuppressions.addResourceSuppressionsByPath(
+            this,
+            [`/${this.stackName}/AgentCoreInfra/AgentExecutionRole/DefaultPolicy/Resource`],
+            [
+                {
+                    id: "AwsSolutions-IAM5",
+                    reason: "Wildcard S3 read permissions required for AgentCore execution role to load skill markdown files from the dedicated skills bucket. Skill keys are dynamic (determined by agent configuration at runtime).",
+                },
+            ],
+        );
 
         const api = new ChatbotApi(this, "ChatbotApi", {
             shared,
@@ -114,6 +136,7 @@ export class AcaStack extends cdk.Stack {
             mcpServerRegistryTable: agentCoreInfra.mcpServerRegistry,
             agentToolsTopic: agentCoreInfra.agentToolsTopic,
             batchImage: props.builder.batchImage,
+            skillsBucket: skillsBucket.bucket,
         });
 
         // Grant AgentCore containers permission to write session history to DynamoDB

--- a/iac-cdk/lib/agent-core/index.ts
+++ b/iac-cdk/lib/agent-core/index.ts
@@ -35,6 +35,8 @@ interface AcaAgentCoreContainerProps {
     readonly agentsAsToolsImage: CodeBuildDockerImage;
     /** Sessions table name for container-side history persistence (optional) */
     readonly sessionsTableName?: string;
+    /** Skills bucket name for runtime skill loading (optional) */
+    readonly skillsBucketName?: string;
 }
 
 export class AcaAgentCoreContainer extends Construct {
@@ -764,6 +766,10 @@ export class AcaAgentCoreContainer extends Construct {
                     }),
                     ...(props.config.bedrockAccessRoleArn && {
                         bedrockAccessRoleArn: props.config.bedrockAccessRoleArn,
+                    }),
+                    // Skills bucket for runtime skill loading
+                    ...(props.skillsBucketName && {
+                        skillsBucket: props.skillsBucketName,
                     }),
                 },
                 tags: {

--- a/iac-cdk/lib/api/agent-core-runtime.ts
+++ b/iac-cdk/lib/api/agent-core-runtime.ts
@@ -39,6 +39,8 @@ export interface AgentCoreApisProps {
     readonly mcpServerRegistryTable: dynamodb.Table;
     readonly agentCoreExecutionRole: iam.Role;
     readonly agentToolsTopic: sns.Topic;
+    /** Optional skills bucket for propagating bucket name to runtime containers */
+    readonly skillsBucket?: cdk.aws_s3.Bucket;
 }
 
 export class AgentCoreApis extends Construct {
@@ -634,6 +636,9 @@ export class AgentCoreApis extends Construct {
                 AGENTS_SUMMARY_TABLE_NAME: props.agentCoreSummaryTable.tableName,
                 ...(props.config.bedrockAccessRoleArn && {
                     BEDROCK_ACCESS_ROLE_ARN: props.config.bedrockAccessRoleArn,
+                }),
+                ...(props.skillsBucket && {
+                    SKILLS_BUCKET_NAME: props.skillsBucket.bucketName,
                 }),
             },
         });

--- a/iac-cdk/lib/api/http-api-backend.ts
+++ b/iac-cdk/lib/api/http-api-backend.ts
@@ -35,6 +35,8 @@ export interface HttpApiBackendProps {
     readonly byUserIdIndex: string;
     readonly api: appsync.GraphqlApi;
     readonly operationToExclude: string[];
+    /** Optional skills bucket for skill CRUD operations */
+    readonly skillsBucket?: cdk.aws_s3.Bucket;
 }
 
 export class HttpApiBackend extends Construct {
@@ -71,6 +73,9 @@ export class HttpApiBackend extends Construct {
             MCP_SERVER_REGISTRY_TABLE: props.mcpServerRegistryTable.tableName,
             REGION_NAME: cdk.Aws.REGION,
             AWS_ACCOUNT_ID: cdk.Aws.ACCOUNT_ID,
+            ...(props.skillsBucket && {
+                SKILLS_BUCKET_NAME: props.skillsBucket.bucketName,
+            }),
         };
 
         const lambdaResolver = new lambda.Function(this, "HttpApiResolver", {
@@ -96,6 +101,11 @@ export class HttpApiBackend extends Construct {
         props.stateClassRegistryTable.grantReadData(lambdaResolver);
         props.deterministicNodeRegistryTable.grantReadData(lambdaResolver);
         props.mcpServerRegistryTable.grantReadWriteData(lambdaResolver);
+
+        // Grant read/write access to skills bucket for CRUD operations
+        if (props.skillsBucket) {
+            props.skillsBucket.grantReadWrite(lambdaResolver);
+        }
 
         // Allow Lambda to validate AgentCore runtime endpoints and gateways
         // when registering SigV4 MCP servers via the UI

--- a/iac-cdk/lib/api/index.ts
+++ b/iac-cdk/lib/api/index.ts
@@ -57,6 +57,8 @@ export interface ChatbotApiProps {
     readonly kbInventoryTable?: dynamodb.Table;
     readonly vectorCollection?: VectorCollection;
     readonly kbRole?: iam.IRole;
+    // Skills bucket for skill CRUD and runtime loading
+    readonly skillsBucket?: s3.Bucket;
 }
 
 /**

--- a/iac-cdk/lib/skills-bucket/index.ts
+++ b/iac-cdk/lib/skills-bucket/index.ts
@@ -1,0 +1,64 @@
+// ----------------------------------------------------------------------
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: MIT-0
+// ----------------------------------------------------------------------
+import * as cdk from "aws-cdk-lib";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import { Construct } from "constructs";
+import { generatePrefix } from "../shared/utils";
+
+/**
+ * Dedicated S3 bucket for storing Agent Skills (markdown instruction packages).
+ *
+ * Skills are stored as markdown files with YAML frontmatter following the
+ * Agent Skills specification (https://agentskills.io/specification).
+ *
+ * Phase 1 layout: skills/{name}.md
+ * Phase 2 layout: skills/{name}/SKILL.md + scripts/ + references/ + assets/
+ */
+export class SkillsBucket extends Construct {
+    public readonly bucket: s3.Bucket;
+
+    constructor(scope: Construct, id: string) {
+        super(scope, id);
+
+        const prefix = generatePrefix(this);
+        const stack = cdk.Stack.of(this);
+
+        const removalCondition = ["prod-", "prd-", "live-"].some((p) =>
+            prefix.toLowerCase().startsWith(p.toLowerCase()),
+        )
+            ? cdk.RemovalPolicy.RETAIN
+            : cdk.RemovalPolicy.DESTROY;
+        const autoDeleteObjects = removalCondition === cdk.RemovalPolicy.DESTROY;
+
+        // Access logging bucket
+        const loggingBucket = new s3.Bucket(this, "SkillsLoggingBucket", {
+            bucketName: `${prefix}-logging-skills-${stack.region}-${stack.account}`,
+            encryption: s3.BucketEncryption.S3_MANAGED,
+            enforceSSL: true,
+            versioned: true,
+            removalPolicy: removalCondition,
+            autoDeleteObjects: autoDeleteObjects,
+        });
+
+        this.bucket = new s3.Bucket(this, "SkillsBucket", {
+            bucketName: `${prefix}-skills-${stack.region}-${stack.account}`,
+            versioned: true,
+            encryption: s3.BucketEncryption.S3_MANAGED,
+            blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+            removalPolicy: removalCondition,
+            autoDeleteObjects: autoDeleteObjects,
+            enforceSSL: true,
+            serverAccessLogsBucket: loggingBucket,
+            serverAccessLogsPrefix: `/aws/${prefix}/skills-bucket/logs`,
+            lifecycleRules: [
+                {
+                    // Clean up old versions after 90 days
+                    noncurrentVersionExpiration: cdk.Duration.days(90),
+                },
+            ],
+        });
+    }
+}

--- a/src/agent-core/docker/app.py
+++ b/src/agent-core/docker/app.py
@@ -672,6 +672,10 @@ async def _handle_voice_mode(
             region_name=AWS_REGION,
         )
 
+    # TODO: Add AgentSkills plugin support for voice mode once BidiAgent supports
+    # the `plugins` parameter. Monitor Strands SDK releases for BidiAgent plugin support.
+    # See: https://strandsagents.com/docs/user-guide/concepts/plugins/skills/
+
     voice_agent = BidiAgent(
         model=sonic_model,
         tools=tools + [stop_conversation],

--- a/src/agent-core/docker/src/factory.py
+++ b/src/agent-core/docker/src/factory.py
@@ -54,26 +54,28 @@ def _download_skills_to_dir(
     skill_names: list[str],
     logger: Any,
 ) -> str | None:
-    """Download skill markdown files from S3 into a local directory.
+    """Download skills from S3 into a local directory.
 
-    Creates a temporary directory with the standard AgentSkills layout::
+    Supports the full Agent Skills spec directory structure::
 
         <temp_dir>/
             analog-alarms/
                 SKILL.md
-            analog-io/
+                scripts/
+                    validate_limits.py
+                references/
+                    alarm-types-reference.md
+            pdf-processing/
                 SKILL.md
-            ...
+                scripts/
+                    extract.py
 
-    This mirrors the Agent Skills spec directory structure so that
-    ``AgentSkills(skills=str(dir_path))`` uses the exact same SDK code
-    path as loading from a local filesystem, ensuring consistent behaviour.
-
-    Each skill is stored in S3 at ``s3://{bucket}/skills/{name}.md``.
-    Skills that fail to download are logged as warnings and skipped.
+    For each skill, first tries the directory layout (``skills/{name}/``).
+    If found, downloads all files in the directory. Otherwise, falls back
+    to the flat file layout (``skills/{name}.md``) for backward compatibility.
 
     Args:
-        skill_names: List of skill names (without ``.md`` extension).
+        skill_names: List of skill names.
         logger: Logger instance.
 
     Returns:
@@ -91,32 +93,21 @@ def _download_skills_to_dir(
     loaded = 0
 
     for name in skill_names:
-        key = f"skills/{name}.md"
+        # Try directory layout first: skills/{name}/
+        dir_prefix = f"skills/{name}/"
         try:
-            obj = s3.get_object(Bucket=bucket, Key=key)
-            content = obj["Body"].read().decode("utf-8")
-
-            # Write to <skills_dir>/<name>/SKILL.md — same layout as spec
-            skill_subdir = os.path.join(skills_dir, name)
-            os.makedirs(skill_subdir, exist_ok=True)
-            skill_path = os.path.join(skill_subdir, "SKILL.md")
-            with open(skill_path, "w", encoding="utf-8") as f:
-                f.write(content)
-
-            loaded += 1
-            logger.info(
-                f"Downloaded skill '{name}' from S3",
-                extra={
-                    "skillName": name,
-                    "s3Key": key,
-                    "localPath": skill_path,
-                    "contentLength": len(content),
-                },
-            )
+            objects = s3.list_objects_v2(Bucket=bucket, Prefix=dir_prefix)
+            if objects.get("KeyCount", 0) > 0:
+                loaded += _download_skill_directory(
+                    s3, bucket, name, dir_prefix, skills_dir, logger
+                )
+            else:
+                # Fallback: flat file layout (Phase 1 backward compat)
+                loaded += _download_skill_flat(s3, bucket, name, skills_dir, logger)
         except Exception as exc:
             logger.warning(
                 f"Failed to download skill '{name}' from S3 — skipping",
-                extra={"skillName": name, "s3Key": key, "error": str(exc)},
+                extra={"skillName": name, "error": str(exc)},
             )
 
     if loaded == 0:
@@ -127,6 +118,75 @@ def _download_skills_to_dir(
         extra={"skillsDir": skills_dir, "loadedCount": loaded},
     )
     return skills_dir
+
+
+def _download_skill_directory(
+    s3: Any, bucket: str, name: str, prefix: str, skills_dir: str, logger: Any
+) -> int:
+    """Download all files in a skill directory from S3.
+
+    Preserves the directory structure (SKILL.md, scripts/, references/, assets/).
+    """
+    skill_subdir = os.path.join(skills_dir, name)
+    paginator = s3.get_paginator("list_objects_v2")
+
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            key = obj["Key"]
+            # Relative path within the skill directory
+            relative = key[len(prefix) :]
+            if not relative:
+                continue
+
+            local_path = os.path.join(skill_subdir, relative)
+            os.makedirs(os.path.dirname(local_path), exist_ok=True)
+
+            response = s3.get_object(Bucket=bucket, Key=key)
+            with open(local_path, "wb") as f:
+                f.write(response["Body"].read())
+
+    # Verify SKILL.md exists
+    skill_md = os.path.join(skill_subdir, "SKILL.md")
+    if os.path.exists(skill_md):
+        logger.info(
+            f"Downloaded skill directory '{name}' from S3",
+            extra={"skillName": name, "layout": "directory"},
+        )
+        return 1
+    else:
+        logger.warning(f"Skill '{name}' directory missing SKILL.md — skipping")
+        return 0
+
+
+def _download_skill_flat(
+    s3: Any, bucket: str, name: str, skills_dir: str, logger: Any
+) -> int:
+    """Download a flat .md file (Phase 1 backward compatibility).
+
+    Writes to <skills_dir>/<name>/SKILL.md to match the expected layout.
+    """
+    key = f"skills/{name}.md"
+    try:
+        obj = s3.get_object(Bucket=bucket, Key=key)
+        content = obj["Body"].read().decode("utf-8")
+
+        skill_subdir = os.path.join(skills_dir, name)
+        os.makedirs(skill_subdir, exist_ok=True)
+        skill_path = os.path.join(skill_subdir, "SKILL.md")
+        with open(skill_path, "w", encoding="utf-8") as f:
+            f.write(content)
+
+        logger.info(
+            f"Downloaded skill '{name}' (flat file) from S3",
+            extra={"skillName": name, "layout": "flat"},
+        )
+        return 1
+    except Exception as exc:
+        logger.warning(
+            f"Failed to download skill '{name}': {exc}",
+            extra={"skillName": name, "error": str(exc)},
+        )
+        return 0
 
 
 def create_agent(

--- a/src/agent-core/docker/src/factory.py
+++ b/src/agent-core/docker/src/factory.py
@@ -5,12 +5,15 @@
 # ------------------------------------------------------------------------ #
 from __future__ import annotations
 
+import os
+import tempfile
 from typing import TYPE_CHECKING, Any
 
+import boto3
 from shared.base_constants import RETRIEVE_FROM_KB_PREFIX
 from shared.base_factory import BaseAgentFactory
 from shared.mcp_client import MCPClientManager
-from strands import Agent
+from strands import Agent, AgentSkills
 from strands.hooks.events import (
     AfterToolCallEvent,
     BeforeToolCallEvent,
@@ -24,6 +27,106 @@ from .types import (
 
 if TYPE_CHECKING:
     from logging import Logger
+
+# ── S3 skill loading ────────────────────────────────────────────────
+# Skills are markdown files stored in S3 under the ``skills/`` prefix.
+# Each file follows the Agent Skills spec: YAML frontmatter (name,
+# description) followed by markdown instructions.
+#
+# To match the SDK's deterministic behaviour we download skills
+# into a local temp directory using the standard ``<name>/SKILL.md``
+# layout and pass the directory path to ``AgentSkills(skills=dir_path)``.
+# This ensures the SDK uses the exact same code path as when loading
+# skills from a local filesystem directory.
+
+_s3_skill_client: Any | None = None
+
+
+def _get_s3_skill_client():
+    """Lazily create a shared boto3 S3 client for skill loading."""
+    global _s3_skill_client
+    if _s3_skill_client is None:
+        _s3_skill_client = boto3.client("s3")
+    return _s3_skill_client
+
+
+def _download_skills_to_dir(
+    skill_names: list[str],
+    logger: Any,
+) -> str | None:
+    """Download skill markdown files from S3 into a local directory.
+
+    Creates a temporary directory with the standard AgentSkills layout::
+
+        <temp_dir>/
+            analog-alarms/
+                SKILL.md
+            analog-io/
+                SKILL.md
+            ...
+
+    This mirrors the Agent Skills spec directory structure so that
+    ``AgentSkills(skills=str(dir_path))`` uses the exact same SDK code
+    path as loading from a local filesystem, ensuring consistent behaviour.
+
+    Each skill is stored in S3 at ``s3://{bucket}/skills/{name}.md``.
+    Skills that fail to download are logged as warnings and skipped.
+
+    Args:
+        skill_names: List of skill names (without ``.md`` extension).
+        logger: Logger instance.
+
+    Returns:
+        Path to the temporary skills directory, or None if no skills loaded.
+    """
+    bucket = os.environ.get("skillsBucket")
+    if not bucket:
+        logger.warning(
+            "Cannot load skills: 'skillsBucket' environment variable not set"
+        )
+        return None
+
+    s3 = _get_s3_skill_client()
+    skills_dir = tempfile.mkdtemp(prefix="agent_skills_")
+    loaded = 0
+
+    for name in skill_names:
+        key = f"skills/{name}.md"
+        try:
+            obj = s3.get_object(Bucket=bucket, Key=key)
+            content = obj["Body"].read().decode("utf-8")
+
+            # Write to <skills_dir>/<name>/SKILL.md — same layout as spec
+            skill_subdir = os.path.join(skills_dir, name)
+            os.makedirs(skill_subdir, exist_ok=True)
+            skill_path = os.path.join(skill_subdir, "SKILL.md")
+            with open(skill_path, "w", encoding="utf-8") as f:
+                f.write(content)
+
+            loaded += 1
+            logger.info(
+                f"Downloaded skill '{name}' from S3",
+                extra={
+                    "skillName": name,
+                    "s3Key": key,
+                    "localPath": skill_path,
+                    "contentLength": len(content),
+                },
+            )
+        except Exception as exc:
+            logger.warning(
+                f"Failed to download skill '{name}' from S3 — skipping",
+                extra={"skillName": name, "s3Key": key, "error": str(exc)},
+            )
+
+    if loaded == 0:
+        return None
+
+    logger.info(
+        f"Skills directory ready: {loaded}/{len(skill_names)} skills downloaded",
+        extra={"skillsDir": skills_dir, "loadedCount": loaded},
+    )
+    return skills_dir
 
 
 def create_agent(
@@ -59,6 +162,25 @@ def create_agent(
         enable_caching=True,
     )
 
+    # ── Load skills as AgentSkills plugin ────────────────────────────
+    # Download skills from S3 into a local temp directory with the
+    # standard ``<name>/SKILL.md`` layout, then pass the directory path
+    # to ``AgentSkills(skills=dir_path)``.  This uses the exact same
+    # SDK code path as local filesystem loading for deterministic behaviour.
+    plugins: list[Any] = []
+    if configuration.skills:
+        skills_dir = _download_skills_to_dir(configuration.skills, logger)
+        if skills_dir:
+            plugins.append(AgentSkills(skills=skills_dir))
+            logger.info(
+                "AgentSkills plugin loaded from directory",
+                extra={
+                    "skillsDir": skills_dir,
+                    "skillCount": len(configuration.skills),
+                    "skillNames": configuration.skills,
+                },
+            )
+
     agent = Agent(
         model=model,
         system_prompt=configuration.instructions,
@@ -70,6 +192,7 @@ def create_agent(
         session_manager=session_manager,
         trace_attributes=trace_attributes,
         state=state,
+        plugins=plugins if plugins else None,
     )
     callbacks = AgentCallbacks(logger, session_id, user_id)
 

--- a/src/agent-core/docker/src/types.py
+++ b/src/agent-core/docker/src/types.py
@@ -87,6 +87,7 @@ class AgentConfiguration(BaseModel):
         EConversationManagerType.SLIDING_WINDOW
     )
     structuredOutput: list[StructuredOutputFieldSpec] | None = None
+    skills: list[str] = []
 
     @model_validator(mode="after")
     def validate_tool_parameters(self):

--- a/src/api/functions/create-runtime-version/index.py
+++ b/src/api/functions/create-runtime-version/index.py
@@ -37,6 +37,7 @@ ACCOUNT_ID = os.environ["ACCOUNT_ID"]
 AGENTS_TABLE_NAME = os.environ.get("AGENTS_TABLE_NAME", "")
 AGENTS_SUMMARY_TABLE_NAME = os.environ.get("AGENTS_SUMMARY_TABLE_NAME", "")
 BEDROCK_ACCESS_ROLE_ARN = os.environ.get("BEDROCK_ACCESS_ROLE_ARN", "")
+SKILLS_BUCKET_NAME = os.environ.get("SKILLS_BUCKET_NAME", "")
 
 ENVIRONMENT_TAG = os.environ.get("ENVIRONMENT_TAG", None)
 STACK_TAG = os.environ.get("STACK_TAG", None)
@@ -258,6 +259,10 @@ def handler(event: InputModel, _) -> dict:
     ):
         logger.info(f"Attaching created AgentCore memory {event.memoryId}")
         api_args["environmentVariables"]["memoryId"] = event.memoryId
+
+    # Propagate skills bucket name for runtime skill loading
+    if SKILLS_BUCKET_NAME:
+        api_args["environmentVariables"]["skillsBucket"] = SKILLS_BUCKET_NAME
 
     # Propagate cross-account Bedrock access role ARN to runtime containers
     if BEDROCK_ACCESS_ROLE_ARN:

--- a/src/api/functions/http-api-handler/index.py
+++ b/src/api/functions/http-api-handler/index.py
@@ -15,6 +15,7 @@ from pydantic import ValidationError
 from routes.ai_tools import router as ai_tools_router
 from routes.feedback import router as feedback_router
 from routes.sessions import router as sessions_router
+from routes.skills import router as skills_router
 
 if TYPE_CHECKING:
     from aws_lambda_powertools.utilities.typing import LambdaContext
@@ -31,6 +32,7 @@ app = AppSyncResolver()
 app.include_router(sessions_router)
 app.include_router(feedback_router)
 app.include_router(ai_tools_router)
+app.include_router(skills_router)
 # -------------------------------------------- #
 
 

--- a/src/api/functions/http-api-handler/routes/skills.py
+++ b/src/api/functions/http-api-handler/routes/skills.py
@@ -1,0 +1,327 @@
+# ---------------------------------------------------------------------------- #
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# SPDX-License-Identifier: MIT-0
+# ---------------------------------------------------------------------------- #
+"""CRUD routes for Agent Skills (markdown instruction packages).
+
+Skills are stored as markdown files in S3 under the ``skills/`` prefix
+of the dedicated skills bucket. Each file uses YAML frontmatter for metadata::
+
+    ---
+    name: analog-alarms
+    description: Mapping rules for alarm limits and enables...
+    ---
+
+    # Analog Alarm Mapping
+    ...
+
+The ``name`` in the frontmatter is the canonical identifier.
+The S3 key is ``skills/{name}.md``.
+"""
+import os
+import re
+from datetime import datetime, timezone
+from typing import Mapping, Optional, Sequence
+
+import boto3
+from aws_lambda_powertools import Logger, Tracer
+from aws_lambda_powertools.event_handler.graphql_appsync.router import Router
+from botocore.exceptions import ClientError
+from genai_core.api_helper.auth import fetch_user_id
+
+# ------------------------- Lambda Powertools ------------------------ #
+tracer = Tracer()
+router = Router()
+logger = Logger(service="graphQL-skillsRoute")
+# -------------------------------------------------------------------- #
+
+# ----------------------- Environment Variables ---------------------- #
+SKILLS_BUCKET_NAME = os.environ.get("SKILLS_BUCKET_NAME", "")
+# -------------------------------------------------------------------- #
+
+SKILLS_PREFIX = "skills/"
+
+# ----------------------- Frontmatter Parsing ----------------------- #
+_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n(.*)", re.DOTALL)
+
+s3_client = boto3.client("s3")
+
+
+def _parse_frontmatter(content: str) -> tuple[dict[str, str], str]:
+    """Parse YAML frontmatter from a skill markdown file."""
+    match = _FRONTMATTER_RE.match(content)
+    if not match:
+        return {}, content
+
+    frontmatter, body = match.group(1), match.group(2)
+    meta: dict[str, str] = {}
+    for line in frontmatter.splitlines():
+        if ":" in line:
+            key, _, value = line.partition(":")
+            meta[key.strip()] = value.strip()
+    return meta, body.strip()
+
+
+def _build_skill_markdown(name: str, description: str, content: str) -> str:
+    """Build a complete SKILL.md file with frontmatter."""
+    return f"---\nname: {name}\ndescription: {description}\n---\n\n{content}\n"
+
+
+def _s3_key(name: str) -> str:
+    """Build the S3 key for a skill name."""
+    return f"{SKILLS_PREFIX}{name}.md"
+
+
+def _skill_to_graphql(
+    name: str, description: str, s3_key: str, last_modified: str = ""
+) -> dict:
+    """Map skill metadata to the GraphQL Skill type."""
+    return {
+        "name": name,
+        "description": description,
+        "s3Key": s3_key,
+        "lastModified": last_modified,
+    }
+
+
+# ---- Queries ---- #
+
+
+@router.resolver(field_name="listSkills")
+@tracer.capture_method
+@fetch_user_id(router)
+def list_skills(user_id: str) -> Sequence[Mapping]:
+    """List all skills from S3 by scanning the skills/ prefix.
+
+    Reads the frontmatter of each .md file to extract name and description.
+    """
+    logger.info(f"User {user_id} listing skills")
+
+    if not SKILLS_BUCKET_NAME:
+        logger.warning("Skills bucket not configured — cannot list skills")
+        return []
+
+    try:
+        skills: list[dict] = []
+        paginator = s3_client.get_paginator("list_objects_v2")
+        pages = paginator.paginate(Bucket=SKILLS_BUCKET_NAME, Prefix=SKILLS_PREFIX)
+
+        for page in pages:
+            for obj in page.get("Contents", []):
+                key = obj["Key"]
+                if not key.endswith(".md"):
+                    continue
+
+                # Derive name from key: skills/analog-alarms.md → analog-alarms
+                name = key[len(SKILLS_PREFIX) :].removesuffix(".md")
+                last_modified = obj.get("LastModified", "")
+                if hasattr(last_modified, "isoformat"):
+                    last_modified = last_modified.isoformat()
+
+                # Read the file to extract frontmatter metadata
+                try:
+                    resp = s3_client.get_object(Bucket=SKILLS_BUCKET_NAME, Key=key)
+                    content = resp["Body"].read().decode("utf-8")
+                    meta, _ = _parse_frontmatter(content)
+                    description = meta.get("description", "")
+                    display_name = meta.get("name") or name
+                except Exception as e:
+                    logger.warning(f"Failed to read skill '{key}': {e}")
+                    description = ""
+                    display_name = name
+
+                skills.append(
+                    _skill_to_graphql(
+                        name=display_name,
+                        description=description,
+                        s3_key=key,
+                        last_modified=str(last_modified),
+                    )
+                )
+
+        logger.info(f"Found {len(skills)} skills")
+        return skills
+
+    except ClientError as e:
+        logger.error(f"S3 error listing skills: {e}")
+        raise RuntimeError("Failed to list skills. Please try again later.")
+
+
+@router.resolver(field_name="getSkillContent")
+@tracer.capture_method
+@fetch_user_id(router)
+def get_skill_content(user_id: str, name: str) -> Optional[str]:
+    """Get the full markdown content of a skill by name."""
+    logger.info(f"User {user_id} getting skill content: {name}")
+
+    if not SKILLS_BUCKET_NAME:
+        raise ValueError("Skills bucket not configured")
+
+    key = _s3_key(name)
+    try:
+        resp = s3_client.get_object(Bucket=SKILLS_BUCKET_NAME, Key=key)
+        return resp["Body"].read().decode("utf-8")
+    except s3_client.exceptions.NoSuchKey:
+        return None
+    except ClientError as e:
+        logger.error(f"S3 error getting skill '{name}': {e}")
+        raise RuntimeError(
+            f"Failed to retrieve skill '{name}'. Please try again later."
+        )
+
+
+# ---- Mutations ---- #
+
+
+@router.resolver(field_name="createSkill")
+@tracer.capture_method
+@fetch_user_id(router)
+def create_skill(
+    user_id: str,
+    name: str,
+    description: str,
+    content: str,
+) -> Mapping:
+    """Create a new skill by uploading a markdown file to S3.
+
+    Args:
+        name: Skill identifier (used as the filename, e.g. 'analog-alarms')
+        description: Short description for the skill metadata
+        content: The markdown instructions (body only, without frontmatter)
+    """
+    logger.info(f"User {user_id} creating skill: {name}")
+
+    if not SKILLS_BUCKET_NAME:
+        raise ValueError("Skills bucket not configured")
+
+    if not name or not name.strip():
+        raise ValueError("Skill name is required")
+
+    # Validate name is a safe filename
+    if not re.match(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$", name):
+        raise ValueError(
+            "Skill name must start with a letter/digit and contain only "
+            "letters, digits, hyphens, and underscores (max 64 chars)"
+        )
+
+    key = _s3_key(name)
+
+    # Check if skill already exists
+    try:
+        s3_client.head_object(Bucket=SKILLS_BUCKET_NAME, Key=key)
+        raise ValueError(f"Skill '{name}' already exists")
+    except ClientError as e:
+        if e.response["Error"]["Code"] != "404":
+            raise
+
+    # Build full markdown with frontmatter
+    markdown = _build_skill_markdown(name, description, content)
+
+    try:
+        s3_client.put_object(
+            Bucket=SKILLS_BUCKET_NAME,
+            Key=key,
+            Body=markdown.encode("utf-8"),
+            ContentType="text/markdown; charset=utf-8",
+        )
+    except ClientError as e:
+        logger.error(f"S3 error creating skill '{name}': {e}")
+        raise RuntimeError(f"Failed to create skill '{name}'. Please try again later.")
+
+    logger.info(f"Created skill: {name}")
+    return _skill_to_graphql(
+        name=name,
+        description=description,
+        s3_key=key,
+        last_modified=datetime.now(timezone.utc).isoformat(),
+    )
+
+
+@router.resolver(field_name="updateSkill")
+@tracer.capture_method
+@fetch_user_id(router)
+def update_skill(
+    user_id: str,
+    name: str,
+    description: Optional[str] = None,
+    content: Optional[str] = None,
+) -> Mapping:
+    """Update an existing skill's content and/or description.
+
+    If only description is provided, the body is preserved.
+    If only content is provided, the existing description is preserved.
+    """
+    logger.info(f"User {user_id} updating skill: {name}")
+
+    if not SKILLS_BUCKET_NAME:
+        raise ValueError("Skills bucket not configured")
+
+    key = _s3_key(name)
+
+    # Read existing content
+    try:
+        resp = s3_client.get_object(Bucket=SKILLS_BUCKET_NAME, Key=key)
+        existing = resp["Body"].read().decode("utf-8")
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "NoSuchKey":
+            raise ValueError(f"Skill '{name}' not found")
+        raise
+
+    existing_meta, existing_body = _parse_frontmatter(existing)
+
+    # Merge: use new values if provided, else keep existing
+    final_description = (
+        description if description is not None else existing_meta.get("description", "")
+    )
+    final_body = content if content is not None else existing_body
+
+    markdown = _build_skill_markdown(name, final_description, final_body)
+
+    try:
+        s3_client.put_object(
+            Bucket=SKILLS_BUCKET_NAME,
+            Key=key,
+            Body=markdown.encode("utf-8"),
+            ContentType="text/markdown; charset=utf-8",
+        )
+    except ClientError as e:
+        logger.error(f"S3 error updating skill '{name}': {e}")
+        raise RuntimeError(f"Failed to update skill '{name}'. Please try again later.")
+
+    logger.info(f"Updated skill: {name}")
+    return _skill_to_graphql(
+        name=name,
+        description=final_description,
+        s3_key=key,
+        last_modified=datetime.now(timezone.utc).isoformat(),
+    )
+
+
+@router.resolver(field_name="deleteSkill")
+@tracer.capture_method
+@fetch_user_id(router)
+def delete_skill(user_id: str, name: str) -> bool:
+    """Delete a skill from S3."""
+    logger.info(f"User {user_id} deleting skill: {name}")
+
+    if not SKILLS_BUCKET_NAME:
+        raise ValueError("Skills bucket not configured")
+
+    key = _s3_key(name)
+
+    # Verify it exists
+    try:
+        s3_client.head_object(Bucket=SKILLS_BUCKET_NAME, Key=key)
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "404":
+            raise ValueError(f"Skill '{name}' not found")
+        raise
+
+    try:
+        s3_client.delete_object(Bucket=SKILLS_BUCKET_NAME, Key=key)
+        logger.info(f"Deleted skill: {name}")
+        return True
+    except ClientError as e:
+        logger.error(f"S3 error deleting skill '{name}': {e}")
+        raise RuntimeError(f"Failed to delete skill '{name}'. Please try again later.")

--- a/src/api/functions/http-api-handler/routes/skills.py
+++ b/src/api/functions/http-api-handler/routes/skills.py
@@ -5,19 +5,17 @@
 # ---------------------------------------------------------------------------- #
 """CRUD routes for Agent Skills (markdown instruction packages).
 
-Skills are stored as markdown files in S3 under the ``skills/`` prefix
-of the dedicated skills bucket. Each file uses YAML frontmatter for metadata::
+Skills are stored in S3 following the Agent Skills specification directory
+structure under the ``skills/`` prefix of the dedicated skills bucket::
 
-    ---
-    name: analog-alarms
-    description: Mapping rules for alarm limits and enables...
-    ---
-
-    # Analog Alarm Mapping
-    ...
+    skills/{name}/
+    ├── SKILL.md           # Required: YAML frontmatter + markdown instructions
+    ├── scripts/           # Optional: executable scripts
+    ├── references/        # Optional: reference documents
+    └── assets/            # Optional: static files
 
 The ``name`` in the frontmatter is the canonical identifier.
-The S3 key is ``skills/{name}.md``.
+The S3 key for the main file is ``skills/{name}/SKILL.md``.
 """
 import os
 import re
@@ -41,6 +39,10 @@ SKILLS_BUCKET_NAME = os.environ.get("SKILLS_BUCKET_NAME", "")
 # -------------------------------------------------------------------- #
 
 SKILLS_PREFIX = "skills/"
+MAX_RESOURCE_FILES = 20  # Agent Skills SDK default
+
+# ----------------------- Allowed resource directories --------------- #
+ALLOWED_RESOURCE_DIRS = ("scripts/", "references/", "assets/")
 
 # ----------------------- Frontmatter Parsing ----------------------- #
 _FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n(.*)", re.DOTALL)
@@ -68,9 +70,14 @@ def _build_skill_markdown(name: str, description: str, content: str) -> str:
     return f"---\nname: {name}\ndescription: {description}\n---\n\n{content}\n"
 
 
-def _s3_key(name: str) -> str:
-    """Build the S3 key for a skill name."""
-    return f"{SKILLS_PREFIX}{name}.md"
+def _skill_md_key(name: str) -> str:
+    """Build the S3 key for a skill's SKILL.md file (directory layout)."""
+    return f"{SKILLS_PREFIX}{name}/SKILL.md"
+
+
+def _skill_prefix(name: str) -> str:
+    """Build the S3 prefix for a skill directory."""
+    return f"{SKILLS_PREFIX}{name}/"
 
 
 def _skill_to_graphql(
@@ -85,17 +92,59 @@ def _skill_to_graphql(
     }
 
 
-# ---- Queries ---- #
+def _validate_skill_name(name: str) -> None:
+    """Validate that a skill name is safe for use as a directory name."""
+    if not name or not name.strip():
+        raise ValueError("Skill name is required")
+    if not re.match(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$", name):
+        raise ValueError(
+            "Skill name must start with a letter/digit and contain only "
+            "letters, digits, hyphens, and underscores (max 64 chars)"
+        )
+
+
+def _validate_resource_path(path: str) -> None:
+    """Validate that a resource path is safe (no traversal, correct prefix)."""
+    if not path:
+        raise ValueError("Resource path is required")
+    if ".." in path or path.startswith("/"):
+        raise ValueError(
+            "Invalid resource path: must be relative with no '..' components"
+        )
+    if not path.startswith(ALLOWED_RESOURCE_DIRS):
+        raise ValueError(
+            f"Resource path must start with one of: {', '.join(ALLOWED_RESOURCE_DIRS)}"
+        )
+    # Validate filename characters
+    filename = path.split("/")[-1]
+    if not re.match(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$", filename):
+        raise ValueError(
+            "Resource filename must start with a letter/digit and contain only "
+            "letters, digits, dots, hyphens, and underscores"
+        )
+
+
+def _skill_exists(name: str) -> bool:
+    """Check if a skill directory exists by looking for its SKILL.md."""
+    try:
+        s3_client.head_object(Bucket=SKILLS_BUCKET_NAME, Key=_skill_md_key(name))
+        return True
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "404":
+            return False
+        raise
+
+
+# ============================================================================ #
+# Queries
+# ============================================================================ #
 
 
 @router.resolver(field_name="listSkills")
 @tracer.capture_method
 @fetch_user_id(router)
 def list_skills(user_id: str) -> Sequence[Mapping]:
-    """List all skills from S3 by scanning the skills/ prefix.
-
-    Reads the frontmatter of each .md file to extract name and description.
-    """
+    """List all skills by scanning for skill directories (skills/*/SKILL.md)."""
     logger.info(f"User {user_id} listing skills")
 
     if not SKILLS_BUCKET_NAME:
@@ -104,38 +153,51 @@ def list_skills(user_id: str) -> Sequence[Mapping]:
 
     try:
         skills: list[dict] = []
+        # Use Delimiter to get top-level "directories" under skills/
         paginator = s3_client.get_paginator("list_objects_v2")
-        pages = paginator.paginate(Bucket=SKILLS_BUCKET_NAME, Prefix=SKILLS_PREFIX)
+        pages = paginator.paginate(
+            Bucket=SKILLS_BUCKET_NAME, Prefix=SKILLS_PREFIX, Delimiter="/"
+        )
 
         for page in pages:
-            for obj in page.get("Contents", []):
-                key = obj["Key"]
-                if not key.endswith(".md"):
+            for prefix_info in page.get("CommonPrefixes", []):
+                dir_prefix = prefix_info["Prefix"]
+                # Extract name: skills/analog-alarms/ → analog-alarms
+                name = dir_prefix[len(SKILLS_PREFIX) :].rstrip("/")
+                if not name:
                     continue
 
-                # Derive name from key: skills/analog-alarms.md → analog-alarms
-                name = key[len(SKILLS_PREFIX) :].removesuffix(".md")
-                last_modified = obj.get("LastModified", "")
-                if hasattr(last_modified, "isoformat"):
-                    last_modified = last_modified.isoformat()
-
-                # Read the file to extract frontmatter metadata
+                # Read SKILL.md from within the directory
+                skill_key = f"{dir_prefix}SKILL.md"
                 try:
-                    resp = s3_client.get_object(Bucket=SKILLS_BUCKET_NAME, Key=key)
+                    resp = s3_client.get_object(
+                        Bucket=SKILLS_BUCKET_NAME, Key=skill_key
+                    )
                     content = resp["Body"].read().decode("utf-8")
+                    last_modified = resp.get("LastModified", "")
+                    if hasattr(last_modified, "isoformat"):
+                        last_modified = last_modified.isoformat()
+
                     meta, _ = _parse_frontmatter(content)
                     description = meta.get("description", "")
                     display_name = meta.get("name") or name
+                except ClientError:
+                    # Directory exists but no SKILL.md — skip
+                    logger.warning(
+                        f"Skill directory '{name}' missing SKILL.md — skipping"
+                    )
+                    continue
                 except Exception as e:
-                    logger.warning(f"Failed to read skill '{key}': {e}")
+                    logger.warning(f"Failed to read skill '{skill_key}': {e}")
                     description = ""
                     display_name = name
+                    last_modified = ""
 
                 skills.append(
                     _skill_to_graphql(
                         name=display_name,
                         description=description,
-                        s3_key=key,
+                        s3_key=skill_key,
                         last_modified=str(last_modified),
                     )
                 )
@@ -152,26 +214,87 @@ def list_skills(user_id: str) -> Sequence[Mapping]:
 @tracer.capture_method
 @fetch_user_id(router)
 def get_skill_content(user_id: str, name: str) -> Optional[str]:
-    """Get the full markdown content of a skill by name."""
+    """Get the full markdown content (SKILL.md) of a skill by name."""
     logger.info(f"User {user_id} getting skill content: {name}")
 
     if not SKILLS_BUCKET_NAME:
         raise ValueError("Skills bucket not configured")
 
-    key = _s3_key(name)
+    key = _skill_md_key(name)
     try:
         resp = s3_client.get_object(Bucket=SKILLS_BUCKET_NAME, Key=key)
         return resp["Body"].read().decode("utf-8")
-    except s3_client.exceptions.NoSuchKey:
-        return None
     except ClientError as e:
+        if e.response["Error"]["Code"] == "NoSuchKey":
+            return None
         logger.error(f"S3 error getting skill '{name}': {e}")
         raise RuntimeError(
             f"Failed to retrieve skill '{name}'. Please try again later."
         )
 
 
-# ---- Mutations ---- #
+@router.resolver(field_name="listSkillResources")
+@tracer.capture_method
+@fetch_user_id(router)
+def list_skill_resources(user_id: str, name: str) -> Sequence[Mapping]:
+    """List resource files (scripts/, references/, assets/) for a skill."""
+    logger.info(f"User {user_id} listing resources for skill: {name}")
+
+    if not SKILLS_BUCKET_NAME:
+        raise ValueError("Skills bucket not configured")
+
+    prefix = _skill_prefix(name)
+    resources: list[dict] = []
+
+    paginator = s3_client.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=SKILLS_BUCKET_NAME, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            key = obj["Key"]
+            relative = key[len(prefix) :]
+            # Skip SKILL.md itself
+            if relative == "SKILL.md" or not relative:
+                continue
+            # Only include files in known subdirectories
+            if relative.startswith(ALLOWED_RESOURCE_DIRS):
+                last_modified = obj.get("LastModified", "")
+                if hasattr(last_modified, "isoformat"):
+                    last_modified = last_modified.isoformat()
+                resources.append(
+                    {
+                        "path": relative,
+                        "size": obj["Size"],
+                        "lastModified": str(last_modified),
+                    }
+                )
+
+    return resources
+
+
+@router.resolver(field_name="getSkillResource")
+@tracer.capture_method
+@fetch_user_id(router)
+def get_skill_resource(user_id: str, name: str, path: str) -> Optional[str]:
+    """Get the text content of a resource file within a skill directory."""
+    logger.info(f"User {user_id} getting resource '{path}' for skill: {name}")
+
+    if not SKILLS_BUCKET_NAME:
+        raise ValueError("Skills bucket not configured")
+
+    _validate_resource_path(path)
+
+    key = f"{SKILLS_PREFIX}{name}/{path}"
+    try:
+        resp = s3_client.get_object(Bucket=SKILLS_BUCKET_NAME, Key=key)
+        return resp["Body"].read().decode("utf-8")
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "NoSuchKey":
+            return None
+        raise RuntimeError(f"Failed to retrieve resource '{path}' for skill '{name}'.")
+
+
+# ============================================================================ #
+# Mutations
+# ============================================================================ #
 
 
 @router.resolver(field_name="createSkill")
@@ -183,10 +306,10 @@ def create_skill(
     description: str,
     content: str,
 ) -> Mapping:
-    """Create a new skill by uploading a markdown file to S3.
+    """Create a new skill by uploading SKILL.md to a skill directory in S3.
 
     Args:
-        name: Skill identifier (used as the filename, e.g. 'analog-alarms')
+        name: Skill identifier (used as the directory name, e.g. 'analog-alarms')
         description: Short description for the skill metadata
         content: The markdown instructions (body only, without frontmatter)
     """
@@ -195,28 +318,15 @@ def create_skill(
     if not SKILLS_BUCKET_NAME:
         raise ValueError("Skills bucket not configured")
 
-    if not name or not name.strip():
-        raise ValueError("Skill name is required")
-
-    # Validate name is a safe filename
-    if not re.match(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$", name):
-        raise ValueError(
-            "Skill name must start with a letter/digit and contain only "
-            "letters, digits, hyphens, and underscores (max 64 chars)"
-        )
-
-    key = _s3_key(name)
+    _validate_skill_name(name)
 
     # Check if skill already exists
-    try:
-        s3_client.head_object(Bucket=SKILLS_BUCKET_NAME, Key=key)
+    if _skill_exists(name):
         raise ValueError(f"Skill '{name}' already exists")
-    except ClientError as e:
-        if e.response["Error"]["Code"] != "404":
-            raise
 
     # Build full markdown with frontmatter
     markdown = _build_skill_markdown(name, description, content)
+    key = _skill_md_key(name)
 
     try:
         s3_client.put_object(
@@ -247,7 +357,7 @@ def update_skill(
     description: Optional[str] = None,
     content: Optional[str] = None,
 ) -> Mapping:
-    """Update an existing skill's content and/or description.
+    """Update an existing skill's SKILL.md content and/or description.
 
     If only description is provided, the body is preserved.
     If only content is provided, the existing description is preserved.
@@ -257,7 +367,7 @@ def update_skill(
     if not SKILLS_BUCKET_NAME:
         raise ValueError("Skills bucket not configured")
 
-    key = _s3_key(name)
+    key = _skill_md_key(name)
 
     # Read existing content
     try:
@@ -302,26 +412,131 @@ def update_skill(
 @tracer.capture_method
 @fetch_user_id(router)
 def delete_skill(user_id: str, name: str) -> bool:
-    """Delete a skill from S3."""
+    """Delete a skill and all its resource files from S3."""
     logger.info(f"User {user_id} deleting skill: {name}")
 
     if not SKILLS_BUCKET_NAME:
         raise ValueError("Skills bucket not configured")
 
-    key = _s3_key(name)
+    # Verify it exists
+    if not _skill_exists(name):
+        raise ValueError(f"Skill '{name}' not found")
+
+    # Delete all objects under the skill prefix (SKILL.md + resources)
+    prefix = _skill_prefix(name)
+    try:
+        paginator = s3_client.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=SKILLS_BUCKET_NAME, Prefix=prefix):
+            objects = [{"Key": obj["Key"]} for obj in page.get("Contents", [])]
+            if objects:
+                s3_client.delete_objects(
+                    Bucket=SKILLS_BUCKET_NAME, Delete={"Objects": objects}
+                )
+
+        logger.info(f"Deleted skill: {name}")
+        return True
+    except ClientError as e:
+        logger.error(f"S3 error deleting skill '{name}': {e}")
+        raise RuntimeError(f"Failed to delete skill '{name}'. Please try again later.")
+
+
+@router.resolver(field_name="uploadSkillResource")
+@tracer.capture_method
+@fetch_user_id(router)
+def upload_skill_resource(user_id: str, name: str, path: str, content: str) -> Mapping:
+    """Upload a resource file to a skill directory.
+
+    Args:
+        name: Skill name (directory must already exist with SKILL.md)
+        path: Relative path within the skill directory (e.g. 'scripts/extract.py')
+        content: Text content of the resource file
+    """
+    logger.info(f"User {user_id} uploading resource '{path}' for skill: {name}")
+
+    if not SKILLS_BUCKET_NAME:
+        raise ValueError("Skills bucket not configured")
+
+    _validate_resource_path(path)
+
+    # Verify skill exists
+    if not _skill_exists(name):
+        raise ValueError(f"Skill '{name}' not found — create the skill first")
+
+    # Enforce max resource files limit
+    prefix = _skill_prefix(name)
+    existing_resources = 0
+    paginator = s3_client.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=SKILLS_BUCKET_NAME, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            relative = obj["Key"][len(prefix) :]
+            if relative != "SKILL.md" and relative.startswith(ALLOWED_RESOURCE_DIRS):
+                existing_resources += 1
+
+    # Check if this is an update (file already exists) or a new file
+    target_key = f"{SKILLS_PREFIX}{name}/{path}"
+    is_update = False
+    try:
+        s3_client.head_object(Bucket=SKILLS_BUCKET_NAME, Key=target_key)
+        is_update = True
+    except ClientError:
+        pass
+
+    if not is_update and existing_resources >= MAX_RESOURCE_FILES:
+        raise ValueError(
+            f"Maximum resource files ({MAX_RESOURCE_FILES}) reached for skill '{name}'. "
+            f"Delete existing resources before uploading new ones."
+        )
+
+    # Enforce file size limit (1MB)
+    content_bytes = content.encode("utf-8")
+    if len(content_bytes) > 1_048_576:
+        raise ValueError("Resource file content exceeds maximum size of 1MB")
+
+    try:
+        s3_client.put_object(
+            Bucket=SKILLS_BUCKET_NAME,
+            Key=target_key,
+            Body=content_bytes,
+            ContentType="application/octet-stream",
+        )
+    except ClientError as e:
+        logger.error(f"S3 error uploading resource '{path}' for skill '{name}': {e}")
+        raise RuntimeError("Failed to upload resource. Please try again later.")
+
+    logger.info(f"Uploaded resource '{path}' for skill: {name}")
+    return {
+        "path": path,
+        "size": len(content_bytes),
+        "lastModified": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+@router.resolver(field_name="deleteSkillResource")
+@tracer.capture_method
+@fetch_user_id(router)
+def delete_skill_resource(user_id: str, name: str, path: str) -> bool:
+    """Delete a resource file from a skill directory."""
+    logger.info(f"User {user_id} deleting resource '{path}' for skill: {name}")
+
+    if not SKILLS_BUCKET_NAME:
+        raise ValueError("Skills bucket not configured")
+
+    _validate_resource_path(path)
+
+    key = f"{SKILLS_PREFIX}{name}/{path}"
 
     # Verify it exists
     try:
         s3_client.head_object(Bucket=SKILLS_BUCKET_NAME, Key=key)
     except ClientError as e:
         if e.response["Error"]["Code"] == "404":
-            raise ValueError(f"Skill '{name}' not found")
+            raise ValueError(f"Resource '{path}' not found in skill '{name}'")
         raise
 
     try:
         s3_client.delete_object(Bucket=SKILLS_BUCKET_NAME, Key=key)
-        logger.info(f"Deleted skill: {name}")
+        logger.info(f"Deleted resource '{path}' for skill: {name}")
         return True
     except ClientError as e:
-        logger.error(f"S3 error deleting skill '{name}': {e}")
-        raise RuntimeError(f"Failed to delete skill '{name}'. Please try again later.")
+        logger.error(f"S3 error deleting resource '{path}' for skill '{name}': {e}")
+        raise RuntimeError("Failed to delete resource. Please try again later.")

--- a/src/api/schema/schema.graphql
+++ b/src/api/schema/schema.graphql
@@ -99,6 +99,12 @@ type Skill @aws_cognito_user_pools {
     lastModified: String
 }
 
+type SkillResource @aws_cognito_user_pools {
+    path: String!
+    size: Int!
+    lastModified: String
+}
+
 type McpServer @aws_cognito_user_pools {
     name: String!
     mcpUrl: String!
@@ -264,6 +270,8 @@ type Mutation {
     createSkill(name: String!, description: String!, content: String!): Skill @aws_cognito_user_pools
     updateSkill(name: String!, description: String, content: String): Skill @aws_cognito_user_pools
     deleteSkill(name: String!): Boolean @aws_cognito_user_pools
+    uploadSkillResource(name: String!, path: String!, content: String!): SkillResource @aws_cognito_user_pools
+    deleteSkillResource(name: String!, path: String!): Boolean @aws_cognito_user_pools
     # MCP Server Registry
     registerMcpServer(name: String!, authType: McpAuthType!, runtimeId: String, gatewayId: String, qualifier: String, mcpUrl: String, description: String): AdminOpsResult @aws_cognito_user_pools
     deleteMcpServer(name: String!): AdminOpsResult @aws_cognito_user_pools
@@ -305,6 +313,8 @@ type Query {
     # Skills
     listSkills: [Skill!] @aws_cognito_user_pools
     getSkillContent(name: String!): String @aws_cognito_user_pools
+    listSkillResources(name: String!): [SkillResource!] @aws_cognito_user_pools
+    getSkillResource(name: String!, path: String!): String @aws_cognito_user_pools
     # AgentCore
     listAvailableTools: [Tool!] @aws_cognito_user_pools
     listAvailableMcpServers: [McpServer!] @aws_cognito_user_pools

--- a/src/api/schema/schema.graphql
+++ b/src/api/schema/schema.graphql
@@ -92,6 +92,13 @@ enum McpAuthType {
     NONE
 }
 
+type Skill @aws_cognito_user_pools {
+    name: String!
+    description: String!
+    s3Key: String!
+    lastModified: String
+}
+
 type McpServer @aws_cognito_user_pools {
     name: String!
     mcpUrl: String!
@@ -253,6 +260,10 @@ type Mutation {
     deleteEvaluator(evaluatorId: ID!): Boolean @aws_cognito_user_pools
     runEvaluation(evaluatorId: ID!): Evaluator @aws_cognito_user_pools
     publishEvaluationUpdate(evaluatorId: String!, status: String!): EvaluationNotification @aws_iam
+    # Skills
+    createSkill(name: String!, description: String!, content: String!): Skill @aws_cognito_user_pools
+    updateSkill(name: String!, description: String, content: String): Skill @aws_cognito_user_pools
+    deleteSkill(name: String!): Boolean @aws_cognito_user_pools
     # MCP Server Registry
     registerMcpServer(name: String!, authType: McpAuthType!, runtimeId: String, gatewayId: String, qualifier: String, mcpUrl: String, description: String): AdminOpsResult @aws_cognito_user_pools
     deleteMcpServer(name: String!): AdminOpsResult @aws_cognito_user_pools
@@ -291,6 +302,9 @@ type Query {
     checkOnSyncInProgress(kbId: String!): Boolean @aws_cognito_user_pools
     # Metadata
     getDocumentMetadata(documentId: String!): String! @aws_cognito_user_pools
+    # Skills
+    listSkills: [Skill!] @aws_cognito_user_pools
+    getSkillContent(name: String!): String @aws_cognito_user_pools
     # AgentCore
     listAvailableTools: [Tool!] @aws_cognito_user_pools
     listAvailableMcpServers: [McpServer!] @aws_cognito_user_pools

--- a/src/shared/layers/python-sdk/genai_core/api_helper/types.py
+++ b/src/shared/layers/python-sdk/genai_core/api_helper/types.py
@@ -234,6 +234,7 @@ class AgentConfiguration(BaseModel):
         EConversationManagerType.SLIDING_WINDOW
     )
     useMemory: bool = False
+    skills: list[str] = []
     structuredOutput: Optional[list[StructuredOutputFieldSpec]] = None
 
     @model_validator(mode="after")

--- a/src/user-interface/react-app/src/API.ts
+++ b/src/user-interface/react-app/src/API.ts
@@ -105,6 +105,14 @@ export type EvaluationNotification = {
   status?: string | null,
 };
 
+export type Skill = {
+  __typename: "Skill",
+  name: string,
+  description: string,
+  s3Key: string,
+  lastModified?: string | null,
+};
+
 export enum McpAuthType {
   SIGV4 = "SIGV4",
   NONE = "NONE",
@@ -605,6 +613,46 @@ export type PublishEvaluationUpdateMutation = {
   } | null,
 };
 
+export type CreateSkillMutationVariables = {
+  name: string,
+  description: string,
+  content: string,
+};
+
+export type CreateSkillMutation = {
+  createSkill?:  {
+    __typename: "Skill",
+    name: string,
+    description: string,
+    s3Key: string,
+    lastModified?: string | null,
+  } | null,
+};
+
+export type UpdateSkillMutationVariables = {
+  name: string,
+  description?: string | null,
+  content?: string | null,
+};
+
+export type UpdateSkillMutation = {
+  updateSkill?:  {
+    __typename: "Skill",
+    name: string,
+    description: string,
+    s3Key: string,
+    lastModified?: string | null,
+  } | null,
+};
+
+export type DeleteSkillMutationVariables = {
+  name: string,
+};
+
+export type DeleteSkillMutation = {
+  deleteSkill?: boolean | null,
+};
+
 export type RegisterMcpServerMutationVariables = {
   name: string,
   authType: McpAuthType,
@@ -851,6 +899,27 @@ export type GetDocumentMetadataQueryVariables = {
 
 export type GetDocumentMetadataQuery = {
   getDocumentMetadata: string,
+};
+
+export type ListSkillsQueryVariables = {
+};
+
+export type ListSkillsQuery = {
+  listSkills?:  Array< {
+    __typename: "Skill",
+    name: string,
+    description: string,
+    s3Key: string,
+    lastModified?: string | null,
+  } > | null,
+};
+
+export type GetSkillContentQueryVariables = {
+  name: string,
+};
+
+export type GetSkillContentQuery = {
+  getSkillContent?: string | null,
 };
 
 export type ListAvailableToolsQueryVariables = {

--- a/src/user-interface/react-app/src/API.ts
+++ b/src/user-interface/react-app/src/API.ts
@@ -113,6 +113,13 @@ export type Skill = {
   lastModified?: string | null,
 };
 
+export type SkillResource = {
+  __typename: "SkillResource",
+  path: string,
+  size: number,
+  lastModified?: string | null,
+};
+
 export enum McpAuthType {
   SIGV4 = "SIGV4",
   NONE = "NONE",
@@ -653,6 +660,30 @@ export type DeleteSkillMutation = {
   deleteSkill?: boolean | null,
 };
 
+export type UploadSkillResourceMutationVariables = {
+  name: string,
+  path: string,
+  content: string,
+};
+
+export type UploadSkillResourceMutation = {
+  uploadSkillResource?:  {
+    __typename: "SkillResource",
+    path: string,
+    size: number,
+    lastModified?: string | null,
+  } | null,
+};
+
+export type DeleteSkillResourceMutationVariables = {
+  name: string,
+  path: string,
+};
+
+export type DeleteSkillResourceMutation = {
+  deleteSkillResource?: boolean | null,
+};
+
 export type RegisterMcpServerMutationVariables = {
   name: string,
   authType: McpAuthType,
@@ -920,6 +951,28 @@ export type GetSkillContentQueryVariables = {
 
 export type GetSkillContentQuery = {
   getSkillContent?: string | null,
+};
+
+export type ListSkillResourcesQueryVariables = {
+  name: string,
+};
+
+export type ListSkillResourcesQuery = {
+  listSkillResources?:  Array< {
+    __typename: "SkillResource",
+    path: string,
+    size: number,
+    lastModified?: string | null,
+  } > | null,
+};
+
+export type GetSkillResourceQueryVariables = {
+  name: string,
+  path: string,
+};
+
+export type GetSkillResourceQuery = {
+  getSkillResource?: string | null,
 };
 
 export type ListAvailableToolsQueryVariables = {

--- a/src/user-interface/react-app/src/app.tsx
+++ b/src/user-interface/react-app/src/app.tsx
@@ -20,6 +20,7 @@ import EvaluationsWizardPage from "./pages/admin/evaluations-wizard-page";
 import ExperimentsManagerPage from "./pages/admin/experiments-manager";
 import KnowledgeBaseManagerPage from "./pages/admin/kb-manager";
 import McpServerManagerPage from "./pages/admin/mcp-server-manager-page";
+import SkillManagerPage from "./pages/admin/skill-manager-page";
 import SessionPage from "./pages/chatbot/sessions";
 
 function AppRoutes() {
@@ -37,6 +38,7 @@ function AppRoutes() {
             <Route path="/agent-core" element={<AgentCoreManagerPage />} />
             <Route path="/agent-core/create" element={<AgentCoreWizardPage />} />
             <Route path="/agent-core/mcp-servers" element={<McpServerManagerPage />} />
+            <Route path="/agent-core/skills" element={<SkillManagerPage />} />
             <Route path="/evaluations" element={<EvaluationsManagerPage />} />
             <Route path="/evaluations/create" element={<EvaluationsWizardPage />} />
             {experimentsBatchEnabled && (

--- a/src/user-interface/react-app/src/components/admin/agent-core-runtime-manager.tsx
+++ b/src/user-interface/react-app/src/components/admin/agent-core-runtime-manager.tsx
@@ -590,6 +590,13 @@ export default function AgentCoreEndpointManager(props: AgentManagerProps) {
                                         Manage MCPs
                                     </Button>
                                     <Button
+                                        iconName="edit"
+                                        variant="inline-link"
+                                        onClick={() => navigate("/agent-core/skills")}
+                                    >
+                                        Manage Skills
+                                    </Button>
+                                    <Button
                                         disabled={
                                             selectedItems.length !== 1 ||
                                             selectedItems[0].status.toLowerCase() !== "ready"

--- a/src/user-interface/react-app/src/components/admin/agent-core/view-version-modal.tsx
+++ b/src/user-interface/react-app/src/components/admin/agent-core/view-version-modal.tsx
@@ -7,6 +7,7 @@ import {
     Box,
     Button,
     ColumnLayout,
+    ExpandableSection,
     FormField,
     Modal,
     Select,
@@ -15,6 +16,7 @@ import {
     Table,
     Textarea,
 } from "@cloudscape-design/components";
+import CopyToClipboard from "@cloudscape-design/components/copy-to-clipboard";
 import { generateClient } from "aws-amplify/api";
 import { useContext, useEffect, useState } from "react";
 import { McpServer } from "../../../API";
@@ -734,8 +736,24 @@ export default function ViewVersionModal({
                                 <Box padding="m">{renderMemoryStatus(agentConfig.useMemory)}</Box>
                             </FormField>
 
-                            <FormField label="Agent Instructions">
-                                <Textarea value={agentConfig.instructions} disabled rows={6} />
+                            <FormField label={
+                                <SpaceBetween direction="horizontal" size="xs" alignItems="center">
+                                    <span>Agent Instructions</span>
+                                    <CopyToClipboard
+                                        textToCopy={agentConfig.instructions}
+                                        variant="icon"
+                                        copySuccessText="Instructions copied"
+                                        copyErrorText="Failed to copy"
+                                    />
+                                </SpaceBetween>
+                            }>
+                                <ExpandableSection headerText="Show instructions" defaultExpanded={false}>
+                                    <Box padding="m" variant="code">
+                                        <pre style={{ margin: 0, whiteSpace: "pre-wrap", wordWrap: "break-word" }}>
+                                            {agentConfig.instructions}
+                                        </pre>
+                                    </Box>
+                                </ExpandableSection>
                             </FormField>
 
                             {toolTableItems.length > 0 && (
@@ -765,6 +783,14 @@ export default function ViewVersionModal({
                                             },
                                         ]}
                                     />
+                                </FormField>
+                            )}
+
+                            {agentConfig.skills && agentConfig.skills.length > 0 && (
+                                <FormField label="Skills">
+                                    <Box padding="m">
+                                        {agentConfig.skills.join(", ")}
+                                    </Box>
                                 </FormField>
                             )}
 

--- a/src/user-interface/react-app/src/components/admin/skill-manager.tsx
+++ b/src/user-interface/react-app/src/components/admin/skill-manager.tsx
@@ -14,18 +14,23 @@ import {
     Header,
     Input,
     Modal,
+    Select,
     SpaceBetween,
     Table,
+    Tabs,
     Textarea,
 } from "@cloudscape-design/components";
 
 import {
     createSkill as createSkillMut,
     deleteSkill as deleteSkillMut,
+    deleteSkillResource as deleteSkillResourceMut,
     updateSkill as updateSkillMut,
+    uploadSkillResource as uploadSkillResourceMut,
 } from "../../graphql/mutations";
 import {
     getSkillContent as getSkillContentQuery,
+    listSkillResources as listSkillResourcesQuery,
     listSkills as listSkillsQuery,
 } from "../../graphql/queries";
 
@@ -254,7 +259,7 @@ export default function SkillManager() {
                 visible={editorVisible}
                 onDismiss={() => setEditorVisible(false)}
                 header={editMode === "create" ? "Create Skill" : `Edit Skill: ${editName}`}
-                size="large"
+                size="max"
                 footer={
                     <Box float="right">
                         <SpaceBetween direction="horizontal" size="xs">
@@ -303,17 +308,39 @@ export default function SkillManager() {
                         />
                     </FormField>
 
-                    <FormField
-                        label="Instructions (Markdown)"
-                        description="The full skill instructions loaded on-demand by the agent. Use markdown formatting."
-                    >
-                        <Textarea
-                            value={editContent}
-                            onChange={({ detail }) => setEditContent(detail.value)}
-                            placeholder="# Analog Alarm Mapping\n\n## Fields Covered\n..."
-                            rows={18}
-                        />
-                    </FormField>
+                    <Tabs
+                        tabs={[
+                            {
+                                id: "instructions",
+                                label: "Instructions",
+                                content: (
+                                    <FormField
+                                        label="Instructions (Markdown)"
+                                        description="The full skill instructions loaded on-demand by the agent. Use markdown formatting."
+                                    >
+                                        <Textarea
+                                            value={editContent}
+                                            onChange={({ detail }) => setEditContent(detail.value)}
+                                            placeholder="# Analog Alarm Mapping\n\n## Fields Covered\n..."
+                                            rows={18}
+                                        />
+                                    </FormField>
+                                ),
+                            },
+                            {
+                                id: "resources",
+                                label: "Resources",
+                                disabled: editMode === "create",
+                                disabledReason: "Save the skill first, then re-open it to manage resource files",
+                                content: (
+                                    <SkillResourceManager
+                                        skillName={editName}
+                                        apiClient={apiClient}
+                                    />
+                                ),
+                            },
+                        ]}
+                    />
                 </SpaceBetween>
             </Modal>
 
@@ -341,5 +368,214 @@ export default function SkillManager() {
                 </Box>
             </Modal>
         </>
+    );
+}
+
+// ── Resource Manager Sub-Component ────────────────────────────────────
+// Manages resource files (scripts/, references/, assets/) within a skill directory.
+
+interface SkillResource {
+    path: string;
+    size: number;
+    lastModified?: string;
+}
+
+function SkillResourceManager({
+    skillName,
+    apiClient,
+}: {
+    skillName: string;
+    apiClient: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+}) {
+    const [resources, setResources] = useState<SkillResource[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    // Upload form state
+    const [uploadDir, setUploadDir] = useState<string>("scripts/");
+    const [uploadFilename, setUploadFilename] = useState("");
+    const [uploadContent, setUploadContent] = useState("");
+    const [uploading, setUploading] = useState(false);
+
+    const fetchResources = useCallback(async () => {
+        if (!skillName) return;
+        setLoading(true);
+        setError(null);
+        try {
+            const result = await apiClient.graphql({
+                query: listSkillResourcesQuery,
+                variables: { name: skillName },
+            });
+            setResources(((result.data as any)?.listSkillResources as SkillResource[]) || []);
+        } catch (err: any) {
+            setError(`Failed to load resources: ${err.message || err}`);
+        } finally {
+            setLoading(false);
+        }
+    }, [apiClient, skillName]);
+
+    useEffect(() => {
+        fetchResources();
+    }, [fetchResources]);
+
+    const handleUpload = async () => {
+        if (!uploadFilename.trim() || !uploadContent.trim()) return;
+        setUploading(true);
+        setError(null);
+        try {
+            const path = `${uploadDir}${uploadFilename.trim()}`;
+            await apiClient.graphql({
+                query: uploadSkillResourceMut,
+                variables: { name: skillName, path, content: uploadContent },
+            });
+            setUploadFilename("");
+            setUploadContent("");
+            await fetchResources();
+        } catch (err: any) {
+            setError(`Failed to upload resource: ${err.message || err}`);
+        } finally {
+            setUploading(false);
+        }
+    };
+
+    const handleDeleteResource = async (path: string) => {
+        setError(null);
+        try {
+            await apiClient.graphql({
+                query: deleteSkillResourceMut,
+                variables: { name: skillName, path },
+            });
+            await fetchResources();
+        } catch (err: any) {
+            setError(`Failed to delete resource: ${err.message || err}`);
+        }
+    };
+
+    const formatBytes = (bytes: number): string => {
+        if (bytes < 1024) return `${bytes} B`;
+        if (bytes < 1048576) return `${(bytes / 1024).toFixed(1)} KB`;
+        return `${(bytes / 1048576).toFixed(1)} MB`;
+    };
+
+    return (
+        <SpaceBetween direction="vertical" size="m">
+            {error && (
+                <Alert type="error" dismissible onDismiss={() => setError(null)}>
+                    {error}
+                </Alert>
+            )}
+
+            <Table
+                items={resources}
+                loading={loading}
+                loadingText="Loading resources..."
+                header={
+                    <Header
+                        variant="h3"
+                        description="Resource files available to the agent when this skill is activated (max 20 files, 1MB each)"
+                        actions={
+                            <Button iconName="refresh" onClick={fetchResources}>
+                                Refresh
+                            </Button>
+                        }
+                    >
+                        Resource Files ({resources.length}/20)
+                    </Header>
+                }
+                empty={
+                    <Box textAlign="center" color="text-body-secondary" padding="s">
+                        No resource files. Upload scripts, references, or assets below.
+                    </Box>
+                }
+                columnDefinitions={[
+                    {
+                        id: "path",
+                        header: "Path",
+                        cell: (item) => (
+                            <span style={{ fontFamily: "monospace", fontSize: 13 }}>
+                                {item.path}
+                            </span>
+                        ),
+                    },
+                    {
+                        id: "size",
+                        header: "Size",
+                        cell: (item) => formatBytes(item.size),
+                        width: 100,
+                    },
+                    {
+                        id: "lastModified",
+                        header: "Modified",
+                        cell: (item) =>
+                            item.lastModified
+                                ? new Date(item.lastModified).toLocaleDateString()
+                                : "—",
+                        width: 120,
+                    },
+                    {
+                        id: "actions",
+                        header: "",
+                        cell: (item) => (
+                            <Button
+                                variant="inline-link"
+                                onClick={() => handleDeleteResource(item.path)}
+                            >
+                                Delete
+                            </Button>
+                        ),
+                        width: 80,
+                    },
+                ]}
+            />
+
+            {/* Upload form */}
+            <Header variant="h3">Upload Resource</Header>
+            <SpaceBetween direction="vertical" size="s">
+                <SpaceBetween direction="horizontal" size="s">
+                    <FormField label="Directory">
+                        <Select
+                            selectedOption={{ label: uploadDir, value: uploadDir }}
+                            onChange={({ detail }) =>
+                                setUploadDir(detail.selectedOption?.value || "scripts/")
+                            }
+                            options={[
+                                { value: "scripts/", label: "scripts/" },
+                                { value: "references/", label: "references/" },
+                                { value: "assets/", label: "assets/" },
+                            ]}
+                        />
+                    </FormField>
+                    <FormField label="Filename">
+                        <Input
+                            value={uploadFilename}
+                            onChange={({ detail }) => setUploadFilename(detail.value)}
+                            placeholder={
+                                uploadDir === "scripts/"
+                                    ? "e.g. extract.py"
+                                    : uploadDir === "references/"
+                                      ? "e.g. API-reference.md"
+                                      : "e.g. mapping-template.json"
+                            }
+                        />
+                    </FormField>
+                </SpaceBetween>
+                <FormField label="Content">
+                    <Textarea
+                        value={uploadContent}
+                        onChange={({ detail }) => setUploadContent(detail.value)}
+                        placeholder="Paste file content here..."
+                        rows={10}
+                    />
+                </FormField>
+                <Button
+                    variant="primary"
+                    onClick={handleUpload}
+                    loading={uploading}
+                    disabled={!uploadFilename.trim() || !uploadContent.trim()}
+                >
+                    Upload
+                </Button>
+            </SpaceBetween>
+        </SpaceBetween>
     );
 }

--- a/src/user-interface/react-app/src/components/admin/skill-manager.tsx
+++ b/src/user-interface/react-app/src/components/admin/skill-manager.tsx
@@ -1,0 +1,345 @@
+// ----------------------------------------------------------------------
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: MIT-0
+// ----------------------------------------------------------------------
+import { generateClient } from "aws-amplify/api";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import {
+    Alert,
+    Box,
+    Button,
+    FormField,
+    Header,
+    Input,
+    Modal,
+    SpaceBetween,
+    Table,
+    Textarea,
+} from "@cloudscape-design/components";
+
+import {
+    createSkill as createSkillMut,
+    deleteSkill as deleteSkillMut,
+    updateSkill as updateSkillMut,
+} from "../../graphql/mutations";
+import {
+    getSkillContent as getSkillContentQuery,
+    listSkills as listSkillsQuery,
+} from "../../graphql/queries";
+
+interface Skill {
+    name: string;
+    description: string;
+    s3Key: string;
+    lastModified?: string;
+}
+
+export default function SkillManager() {
+    const apiClient = useMemo(() => generateClient(), []);
+
+    const [skills, setSkills] = useState<Skill[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    // Editor state
+    const [editorVisible, setEditorVisible] = useState(false);
+    const [editMode, setEditMode] = useState<"create" | "edit">("create");
+    const [editName, setEditName] = useState("");
+    const [editDescription, setEditDescription] = useState("");
+    const [editContent, setEditContent] = useState("");
+    const [saving, setSaving] = useState(false);
+
+    // Delete state
+    const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+    const [deleting, setDeleting] = useState(false);
+
+    const fetchSkills = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const result = await apiClient.graphql({ query: listSkillsQuery });
+            setSkills(((result.data as any)?.listSkills as Skill[]) || []);
+        } catch (err: any) {
+            setError(`Failed to load skills: ${err.message || err}`);
+        } finally {
+            setLoading(false);
+        }
+    }, [apiClient]);
+
+    useEffect(() => {
+        fetchSkills();
+    }, [fetchSkills]);
+
+    const handleCreate = () => {
+        setEditMode("create");
+        setEditName("");
+        setEditDescription("");
+        setEditContent("");
+        setEditorVisible(true);
+    };
+
+    const handleEdit = async (skill: Skill) => {
+        setEditMode("edit");
+        setEditName(skill.name);
+        setEditDescription(skill.description);
+        setEditContent("Loading...");
+        setEditorVisible(true);
+
+        try {
+            const result = await apiClient.graphql({
+                query: getSkillContentQuery,
+                variables: { name: skill.name },
+            });
+            const fullContent = (result.data as any)?.getSkillContent || "";
+            // Strip frontmatter to get just the body
+            const bodyMatch = fullContent.match(/^---\s*\n.*?\n---\s*\n(.*)/s);
+            setEditContent(bodyMatch ? bodyMatch[1].trim() : fullContent);
+        } catch (err: any) {
+            setEditContent(`Error loading content: ${err.message || err}`);
+        }
+    };
+
+    const handleSave = async () => {
+        setSaving(true);
+        setError(null);
+        try {
+            if (editMode === "create") {
+                await apiClient.graphql({
+                    query: createSkillMut,
+                    variables: {
+                        name: editName,
+                        description: editDescription,
+                        content: editContent,
+                    },
+                });
+            } else {
+                await apiClient.graphql({
+                    query: updateSkillMut,
+                    variables: {
+                        name: editName,
+                        description: editDescription,
+                        content: editContent,
+                    },
+                });
+            }
+            setEditorVisible(false);
+            await fetchSkills();
+        } catch (err: any) {
+            setError(`Failed to save skill: ${err.message || err}`);
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const handleDelete = async () => {
+        if (!deleteTarget) return;
+        setDeleting(true);
+        setError(null);
+        try {
+            await apiClient.graphql({
+                query: deleteSkillMut,
+                variables: { name: deleteTarget },
+            });
+            setDeleteTarget(null);
+            await fetchSkills();
+        } catch (err: any) {
+            setError(`Failed to delete skill: ${err.message || err}`);
+        } finally {
+            setDeleting(false);
+        }
+    };
+
+    const isFormValid =
+        editName.trim() !== "" &&
+        /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/.test(editName) &&
+        editDescription.trim() !== "" &&
+        editContent.trim() !== "";
+
+    return (
+        <>
+            {/* Main skills list */}
+            <SpaceBetween direction="vertical" size="m">
+                {error && (
+                    <Alert type="error" dismissible onDismiss={() => setError(null)}>
+                        {error}
+                    </Alert>
+                )}
+
+                <Table
+                    items={skills}
+                    loading={loading}
+                    loadingText="Loading skills..."
+                    header={
+                        <Header
+                            variant="h2"
+                            actions={
+                                <SpaceBetween direction="horizontal" size="xs">
+                                    <Button iconName="refresh" onClick={fetchSkills}>
+                                        Refresh
+                                    </Button>
+                                    <Button
+                                        iconName="add-plus"
+                                        variant="primary"
+                                        onClick={handleCreate}
+                                    >
+                                        Create Skill
+                                    </Button>
+                                </SpaceBetween>
+                            }
+                            description="Manage skill instruction packages that agents can activate on-demand"
+                        >
+                            Skills
+                        </Header>
+                    }
+                    empty={
+                        <Box textAlign="center" color="text-body-secondary" padding="l">
+                            No skills yet. Click &quot;Create Skill&quot; to add your first
+                            skill.
+                        </Box>
+                    }
+                    columnDefinitions={[
+                        {
+                            id: "name",
+                            header: "Name",
+                            cell: (item) => item.name,
+                            sortingField: "name",
+                            width: 200,
+                        },
+                        {
+                            id: "description",
+                            header: "Description",
+                            cell: (item) =>
+                                item.description.length > 100
+                                    ? item.description.substring(0, 100) + "..."
+                                    : item.description,
+                        },
+                        {
+                            id: "lastModified",
+                            header: "Last Modified",
+                            cell: (item) =>
+                                item.lastModified
+                                    ? new Date(item.lastModified).toLocaleDateString()
+                                    : "—",
+                            width: 140,
+                        },
+                        {
+                            id: "actions",
+                            header: "Actions",
+                            cell: (item) => (
+                                <SpaceBetween direction="horizontal" size="xs">
+                                    <Button
+                                        variant="inline-link"
+                                        onClick={() => handleEdit(item)}
+                                    >
+                                        Edit
+                                    </Button>
+                                    <Button
+                                        variant="inline-link"
+                                        onClick={() => setDeleteTarget(item.name)}
+                                    >
+                                        Delete
+                                    </Button>
+                                </SpaceBetween>
+                            ),
+                            width: 160,
+                        },
+                    ]}
+                />
+            </SpaceBetween>
+
+            {/* Skill editor modal */}
+            <Modal
+                visible={editorVisible}
+                onDismiss={() => setEditorVisible(false)}
+                header={editMode === "create" ? "Create Skill" : `Edit Skill: ${editName}`}
+                size="large"
+                footer={
+                    <Box float="right">
+                        <SpaceBetween direction="horizontal" size="xs">
+                            <Button variant="link" onClick={() => setEditorVisible(false)}>
+                                Cancel
+                            </Button>
+                            <Button
+                                variant="primary"
+                                onClick={handleSave}
+                                loading={saving}
+                                disabled={!isFormValid}
+                            >
+                                {editMode === "create" ? "Create" : "Save"}
+                            </Button>
+                        </SpaceBetween>
+                    </Box>
+                }
+            >
+                <SpaceBetween direction="vertical" size="l">
+                    <FormField
+                        label="Skill Name"
+                        description="Unique identifier (letters, digits, hyphens, underscores)"
+                        errorText={
+                            editName && !/^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/.test(editName)
+                                ? "Must start with a letter/digit, max 64 chars, only letters/digits/hyphens/underscores"
+                                : undefined
+                        }
+                    >
+                        <Input
+                            value={editName}
+                            onChange={({ detail }) => setEditName(detail.value)}
+                            placeholder="e.g. analog-alarms"
+                            disabled={editMode === "edit"}
+                        />
+                    </FormField>
+
+                    <FormField
+                        label="Description"
+                        description="Short description shown to the agent as skill metadata"
+                    >
+                        <Textarea
+                            value={editDescription}
+                            onChange={({ detail }) => setEditDescription(detail.value)}
+                            placeholder="Mapping rules for alarm limits and enables..."
+                            rows={2}
+                        />
+                    </FormField>
+
+                    <FormField
+                        label="Instructions (Markdown)"
+                        description="The full skill instructions loaded on-demand by the agent. Use markdown formatting."
+                    >
+                        <Textarea
+                            value={editContent}
+                            onChange={({ detail }) => setEditContent(detail.value)}
+                            placeholder="# Analog Alarm Mapping\n\n## Fields Covered\n..."
+                            rows={18}
+                        />
+                    </FormField>
+                </SpaceBetween>
+            </Modal>
+
+            {/* Delete confirmation */}
+            <Modal
+                visible={deleteTarget !== null}
+                onDismiss={() => setDeleteTarget(null)}
+                header="Delete Skill"
+                footer={
+                    <Box float="right">
+                        <SpaceBetween direction="horizontal" size="xs">
+                            <Button variant="link" onClick={() => setDeleteTarget(null)}>
+                                Cancel
+                            </Button>
+                            <Button variant="primary" onClick={handleDelete} loading={deleting}>
+                                Delete
+                            </Button>
+                        </SpaceBetween>
+                    </Box>
+                }
+            >
+                <Box>
+                    Are you sure you want to delete the skill <strong>{deleteTarget}</strong>? This
+                    action cannot be undone.
+                </Box>
+            </Modal>
+        </>
+    );
+}

--- a/src/user-interface/react-app/src/components/wizard/agent-core-runtime-wizard.tsx
+++ b/src/user-interface/react-app/src/components/wizard/agent-core-runtime-wizard.tsx
@@ -166,6 +166,7 @@ export default function AgentCoreRuntimeCreatorWizard({
         mcpServers: initialData?.mcpServers || [],
         conversationManager: initialData?.conversationManager || "sliding_window",
         useMemory: initialData?.useMemory ?? true,
+        skills: initialData?.skills || [],
         modelInferenceParameters: initialData?.modelInferenceParameters || {
             modelId: "",
             parameters: { temperature: 0.2, maxTokens: 3000 },

--- a/src/user-interface/react-app/src/components/wizard/architectures/single-agent-steps.tsx
+++ b/src/user-interface/react-app/src/components/wizard/architectures/single-agent-steps.tsx
@@ -3,6 +3,9 @@
 //
 // SPDX-License-Identifier: MIT-0
 // ----------------------------------------------------------------------
+import { generateClient } from "aws-amplify/api";
+import { useEffect, useMemo, useState } from "react";
+
 import {
     Alert,
     Box,
@@ -16,8 +19,10 @@ import {
     Select,
     SpaceBetween,
     Textarea,
+    TokenGroup,
 } from "@cloudscape-design/components";
 import { KnowledgeBase, McpServer, Tool } from "../../../API";
+import { listSkills as listSkillsQuery } from "../../../graphql/queries";
 import { AgentCoreRuntimeConfiguration } from "../types";
 import { AdditionalToolsSection, AgentConfigSection } from "../wizard-shared-components";
 import { PYTHON_TYPE_OPTIONS, STEP_MIN_HEIGHT, getReasoningType } from "../wizard-utils";
@@ -485,31 +490,36 @@ export function getSingleAgentSteps({
         },
     ];
 
-    // Conditionally insert the Tools step before Review
+    // Conditionally insert the Tools & Skills step before Review
     if (hasToolsStep) {
         steps.splice(steps.length - 1, 0, {
-            title: "Tools",
+            title: "Tools & Skills",
             content: (
                 <div style={{ minHeight: STEP_MIN_HEIGHT }}>
-                    <AdditionalToolsSection
-                        title="Tools"
-                        description="Add tools, knowledge bases, and MCP servers to extend your agent's capabilities"
-                        hasCustomTools={hasCustomTools}
-                        hasMcpServers={hasMcpServers}
-                        knowledgeBaseIsSupported={knowledgeBaseIsSupported}
-                        availableToolsOptions={availableToolsOptions}
-                        availableKnowledgeBasesOptions={availableKnowledgeBasesOptions}
-                        availableMcpServersOptions={availableMcpServersOptions}
-                        selectedTools={selectedToolsData}
-                        selectedKnowledgeBases={selectedKnowledgeBasesData}
-                        selectedMcpServers={config.mcpServers.map((s) => ({ name: s }))}
-                        onAddTool={addTool}
-                        onRemoveTool={removeTool}
-                        onAddKnowledgeBase={addKnowledgeBase}
-                        onAddMcpServer={addMcpServer}
-                        onRemoveMcpServer={removeMcpServer}
-                        onConfigureKnowledgeBase={openConfigureModal}
-                    />
+                    <SpaceBetween direction="vertical" size="l">
+                        <AdditionalToolsSection
+                            title="Tools"
+                            description="Add tools, knowledge bases, and MCP servers to extend your agent's capabilities"
+                            hasCustomTools={hasCustomTools}
+                            hasMcpServers={hasMcpServers}
+                            knowledgeBaseIsSupported={knowledgeBaseIsSupported}
+                            availableToolsOptions={availableToolsOptions}
+                            availableKnowledgeBasesOptions={availableKnowledgeBasesOptions}
+                            availableMcpServersOptions={availableMcpServersOptions}
+                            selectedTools={selectedToolsData}
+                            selectedKnowledgeBases={selectedKnowledgeBasesData}
+                            selectedMcpServers={config.mcpServers.map((s) => ({ name: s }))}
+                            onAddTool={addTool}
+                            onRemoveTool={removeTool}
+                            onAddKnowledgeBase={addKnowledgeBase}
+                            onAddMcpServer={addMcpServer}
+                            onRemoveMcpServer={removeMcpServer}
+                            onConfigureKnowledgeBase={openConfigureModal}
+                        />
+
+                        {/* ── Skills ────────────────────────────────────── */}
+                        <SkillsSection config={config} setConfig={setConfig} />
+                    </SpaceBetween>
                 </div>
             ),
         });
@@ -576,4 +586,110 @@ export function isSingleAgentStepValid(
     // Step 1: Additional Tools — always valid (optional)
     // Step 2: Review — always valid
     return true;
+}
+
+// ── Skills attachment section ──────────────────────────────────────
+// Self-contained component that fetches available skills and lets
+// the user attach/detach them from the agent configuration.
+
+function SkillsSection({
+    config,
+    setConfig,
+}: {
+    config: AgentCoreRuntimeConfiguration;
+    setConfig: React.Dispatch<React.SetStateAction<AgentCoreRuntimeConfiguration>>;
+}) {
+    const apiClient = useMemo(() => generateClient(), []);
+    const [availableSkills, setAvailableSkills] = useState<{ name: string; description: string }[]>(
+        [],
+    );
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        const fetchSkills = async () => {
+            setLoading(true);
+            try {
+                const result = await apiClient.graphql({ query: listSkillsQuery });
+                setAvailableSkills(
+                    ((result.data as any)?.listSkills || []).map((s: any) => ({
+                        name: s.name,
+                        description: s.description || "",
+                    })),
+                );
+            } catch (err) {
+                console.error("Failed to fetch skills:", err);
+            } finally {
+                setLoading(false);
+            }
+        };
+        fetchSkills();
+    }, [apiClient]);
+
+    const attachedSkills = config.skills || [];
+
+    const unattachedOptions = availableSkills
+        .filter((s) => !attachedSkills.includes(s.name))
+        .map((s) => ({
+            label: s.name,
+            value: s.name,
+            description: s.description,
+        }));
+
+    const addSkill = (name: string | undefined) => {
+        if (!name || attachedSkills.includes(name)) return;
+        setConfig((prev) => ({ ...prev, skills: [...(prev.skills || []), name] }));
+    };
+
+    const removeSkill = (name: string) => {
+        setConfig((prev) => ({
+            ...prev,
+            skills: (prev.skills || []).filter((s) => s !== name),
+        }));
+    };
+
+    return (
+        <Container
+            header={
+                <Header
+                    variant="h2"
+                    description="Attach skills to give the agent on-demand access to specialized instructions. Skills are loaded only when the agent activates them."
+                >
+                    Skills
+                </Header>
+            }
+        >
+            <SpaceBetween direction="vertical" size="m">
+                <FormField label="Add a skill">
+                    <Select
+                        placeholder={loading ? "Loading skills..." : "Select a skill to attach..."}
+                        options={unattachedOptions}
+                        onChange={({ detail }) => addSkill(detail.selectedOption?.value)}
+                        selectedOption={null}
+                        disabled={loading || unattachedOptions.length === 0}
+                        filteringType="auto"
+                    />
+                </FormField>
+
+                {attachedSkills.length > 0 ? (
+                    <TokenGroup
+                        items={attachedSkills.map((name) => {
+                            const skill = availableSkills.find((s) => s.name === name);
+                            return {
+                                label: name,
+                                description: skill?.description,
+                                dismissLabel: `Remove ${name}`,
+                            };
+                        })}
+                        onDismiss={({ detail }) => {
+                            removeSkill(attachedSkills[detail.itemIndex]);
+                        }}
+                    />
+                ) : (
+                    <Box textAlign="center" color="text-body-secondary" padding="s">
+                        No skills attached. The agent will work without specialized instructions.
+                    </Box>
+                )}
+            </SpaceBetween>
+        </Container>
+    );
 }

--- a/src/user-interface/react-app/src/components/wizard/types.ts
+++ b/src/user-interface/react-app/src/components/wizard/types.ts
@@ -61,6 +61,7 @@ export interface AgentCoreRuntimeConfiguration {
     mcpServers: string[];
     conversationManager: "null" | "sliding_window" | "summarizing";
     useMemory?: boolean;
+    skills?: string[];
     structuredOutput?: StructuredOutputField[];
     architectureType?: ArchitectureType;
     swarmConfig?: SwarmConfiguration;

--- a/src/user-interface/react-app/src/graphql/mutations.ts
+++ b/src/user-interface/react-app/src/graphql/mutations.ts
@@ -387,6 +387,39 @@ export const publishEvaluationUpdate = /* GraphQL */ `mutation PublishEvaluation
   APITypes.PublishEvaluationUpdateMutationVariables,
   APITypes.PublishEvaluationUpdateMutation
 >;
+export const createSkill = /* GraphQL */ `mutation CreateSkill($name: String!, $description: String!, $content: String!) {
+  createSkill(name: $name, description: $description, content: $content) {
+    name
+    description
+    s3Key
+    lastModified
+    __typename
+  }
+}
+` as GeneratedMutation<
+  APITypes.CreateSkillMutationVariables,
+  APITypes.CreateSkillMutation
+>;
+export const updateSkill = /* GraphQL */ `mutation UpdateSkill($name: String!, $description: String, $content: String) {
+  updateSkill(name: $name, description: $description, content: $content) {
+    name
+    description
+    s3Key
+    lastModified
+    __typename
+  }
+}
+` as GeneratedMutation<
+  APITypes.UpdateSkillMutationVariables,
+  APITypes.UpdateSkillMutation
+>;
+export const deleteSkill = /* GraphQL */ `mutation DeleteSkill($name: String!) {
+  deleteSkill(name: $name)
+}
+` as GeneratedMutation<
+  APITypes.DeleteSkillMutationVariables,
+  APITypes.DeleteSkillMutation
+>;
 export const registerMcpServer = /* GraphQL */ `mutation RegisterMcpServer(
   $name: String!
   $authType: McpAuthType!

--- a/src/user-interface/react-app/src/graphql/mutations.ts
+++ b/src/user-interface/react-app/src/graphql/mutations.ts
@@ -420,6 +420,29 @@ export const deleteSkill = /* GraphQL */ `mutation DeleteSkill($name: String!) {
   APITypes.DeleteSkillMutationVariables,
   APITypes.DeleteSkillMutation
 >;
+export const uploadSkillResource = /* GraphQL */ `mutation UploadSkillResource(
+  $name: String!
+  $path: String!
+  $content: String!
+) {
+  uploadSkillResource(name: $name, path: $path, content: $content) {
+    path
+    size
+    lastModified
+    __typename
+  }
+}
+` as GeneratedMutation<
+  APITypes.UploadSkillResourceMutationVariables,
+  APITypes.UploadSkillResourceMutation
+>;
+export const deleteSkillResource = /* GraphQL */ `mutation DeleteSkillResource($name: String!, $path: String!) {
+  deleteSkillResource(name: $name, path: $path)
+}
+` as GeneratedMutation<
+  APITypes.DeleteSkillResourceMutationVariables,
+  APITypes.DeleteSkillResourceMutation
+>;
 export const registerMcpServer = /* GraphQL */ `mutation RegisterMcpServer(
   $name: String!
   $authType: McpAuthType!

--- a/src/user-interface/react-app/src/graphql/queries.ts
+++ b/src/user-interface/react-app/src/graphql/queries.ts
@@ -174,6 +174,25 @@ export const getSkillContent = /* GraphQL */ `query GetSkillContent($name: Strin
   APITypes.GetSkillContentQueryVariables,
   APITypes.GetSkillContentQuery
 >;
+export const listSkillResources = /* GraphQL */ `query ListSkillResources($name: String!) {
+  listSkillResources(name: $name) {
+    path
+    size
+    lastModified
+    __typename
+  }
+}
+` as GeneratedQuery<
+  APITypes.ListSkillResourcesQueryVariables,
+  APITypes.ListSkillResourcesQuery
+>;
+export const getSkillResource = /* GraphQL */ `query GetSkillResource($name: String!, $path: String!) {
+  getSkillResource(name: $name, path: $path)
+}
+` as GeneratedQuery<
+  APITypes.GetSkillResourceQueryVariables,
+  APITypes.GetSkillResourceQuery
+>;
 export const listAvailableTools = /* GraphQL */ `query ListAvailableTools {
   listAvailableTools {
     name

--- a/src/user-interface/react-app/src/graphql/queries.ts
+++ b/src/user-interface/react-app/src/graphql/queries.ts
@@ -154,6 +154,26 @@ export const getDocumentMetadata = /* GraphQL */ `query GetDocumentMetadata($doc
   APITypes.GetDocumentMetadataQueryVariables,
   APITypes.GetDocumentMetadataQuery
 >;
+export const listSkills = /* GraphQL */ `query ListSkills {
+  listSkills {
+    name
+    description
+    s3Key
+    lastModified
+    __typename
+  }
+}
+` as GeneratedQuery<
+  APITypes.ListSkillsQueryVariables,
+  APITypes.ListSkillsQuery
+>;
+export const getSkillContent = /* GraphQL */ `query GetSkillContent($name: String!) {
+  getSkillContent(name: $name)
+}
+` as GeneratedQuery<
+  APITypes.GetSkillContentQueryVariables,
+  APITypes.GetSkillContentQuery
+>;
 export const listAvailableTools = /* GraphQL */ `query ListAvailableTools {
   listAvailableTools {
     name

--- a/src/user-interface/react-app/src/pages/admin/skill-manager-page.tsx
+++ b/src/user-interface/react-app/src/pages/admin/skill-manager-page.tsx
@@ -1,0 +1,109 @@
+// -----------------------------------------------------------------------
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: MIT-0
+// -----------------------------------------------------------------------
+import { BreadcrumbGroup, Header, HelpPanel, SpaceBetween } from "@cloudscape-design/components";
+import { useState } from "react";
+import { CHATBOT_NAME } from "../../common/constants";
+import useOnFollow from "../../common/hooks/use-on-follow";
+import SkillManager from "../../components/admin/skill-manager";
+import BaseAppLayout from "../../components/base-app-layout";
+
+export default function SkillManagerPage() {
+    const [toolsOpen, setToolsOpen] = useState(false);
+    const onFollow = useOnFollow();
+
+    return (
+        <BaseAppLayout
+            contentType="table"
+            toolsOpen={toolsOpen}
+            onToolsChange={(e) => setToolsOpen(e.detail.open)}
+            breadcrumbs={
+                <BreadcrumbGroup
+                    onFollow={onFollow}
+                    items={[
+                        {
+                            text: CHATBOT_NAME,
+                            href: "/",
+                        },
+                        {
+                            text: "AgentCore Manager",
+                            href: "/agent-core",
+                        },
+                        {
+                            text: "Skills",
+                            href: "/agent-core/skills",
+                        },
+                    ]}
+                />
+            }
+            info={
+                <HelpPanel header={<Header variant="h3">Agent Skills</Header>}>
+                    <SpaceBetween direction="vertical" size="l">
+                        <div>
+                            <h4>Overview</h4>
+                            <p>
+                                Skills give agents on-demand access to specialized instructions
+                                without bloating the system prompt. Instead of front-loading every
+                                possible instruction, you define modular skill packages that the
+                                agent discovers and activates only when relevant.
+                            </p>
+                        </div>
+                        <div>
+                            <h4>How Skills Work</h4>
+                            <ul>
+                                <li>
+                                    <strong>Discovery</strong> — Skill names and descriptions are
+                                    injected into the system prompt
+                                </li>
+                                <li>
+                                    <strong>Activation</strong> — The agent calls a{" "}
+                                    <code>skills</code> tool to load full instructions on-demand
+                                </li>
+                                <li>
+                                    <strong>Execution</strong> — The agent follows the loaded
+                                    instructions for the conversation
+                                </li>
+                            </ul>
+                        </div>
+                        <div>
+                            <h4>Actions</h4>
+                            <ul>
+                                <li>
+                                    <strong>Create</strong> — Add a new skill with a name,
+                                    description, and markdown instructions
+                                </li>
+                                <li>
+                                    <strong>Edit</strong> — Update a skill&apos;s description or
+                                    instructions
+                                </li>
+                                <li>
+                                    <strong>Delete</strong> — Remove a skill from the system
+                                </li>
+                            </ul>
+                        </div>
+                        <div>
+                            <h4>Tips</h4>
+                            <ul>
+                                <li>
+                                    Keep descriptions concise — they appear in the agent&apos;s
+                                    system prompt
+                                </li>
+                                <li>
+                                    Use markdown formatting in instructions for clarity
+                                </li>
+                                <li>
+                                    Attach skills to agents in the agent wizard (&quot;Tools &amp;
+                                    Skills&quot; step)
+                                </li>
+                            </ul>
+                        </div>
+                    </SpaceBetween>
+                </HelpPanel>
+            }
+            toolsWidth={300}
+            content={<SkillManager />}
+        />
+    );
+}


### PR DESCRIPTION
## Summary

Implements AI Skills for single agents following the [Agent Skills specification](https://agentskills.io/specification) via the Strands SDK `AgentSkills` plugin. Skills give agents on-demand access to specialized instructions without bloating the system prompt — the agent discovers available skills from their descriptions and activates them via a tool call only when relevant.

## What's included

### Infrastructure (CDK)
- Dedicated S3 bucket (`SkillsBucket`) with access logging, versioning, and lifecycle rules
- IAM: read/write for HTTP API Lambda, read-only for ECS execution role
- Environment variable propagation chain: CDK → Lambda (`SKILLS_BUCKET_NAME`) → ECS containers (`skillsBucket`)
- CDK NAG suppression for the expected wildcard S3 read on the execution role

### API Layer (GraphQL + Python)
- **Skill CRUD**: `createSkill`, `updateSkill`, `deleteSkill`, `listSkills`, `getSkillContent`
- **Resource file CRUD**: `uploadSkillResource`, `deleteSkillResource`, `listSkillResources`, `getSkillResource`
- Full directory layout per the Agent Skills spec: `skills/{name}/SKILL.md` + `scripts/` + `references/` + `assets/`
- Path validation (no traversal, allowed prefixes only), 1MB file limit, max 20 resources per skill
- YAML frontmatter parsing for skill metadata

### Agent Runtime (Python)
- Factory downloads skill directories from S3 with flat-file backward compatibility
- `AgentSkills(skills=temp_dir)` plugin loaded with progressive disclosure
- `skills: list[str]` field added to `AgentConfiguration` in both docker types and shared SDK layer

### Frontend (React + Cloudscape)
- **Skills Manager page** (`/agent-core/skills`) with table, create/edit/delete
- **Skill editor** with tabbed UI: Instructions tab + Resources tab (upload, list, delete resource files)
- **Skills attachment** in single-agent wizard ("Tools & Skills" step) via dropdown + TokenGroup
- **Agent View modal**: skills displayed, instructions collapsible with copy-to-clipboard
- Dynamic filename placeholder hints based on selected resource directory
- Help panel with documentation

### Documentation
- `docs/src/skills.md`: comprehensive guide covering skill creation, SKILL.md format, resource files (supported types, limits), attaching to agents, runtime behavior, best practices, and limitations

## Limitations
- Voice mode (BidiAgent) does not support skills yet — TODO comment added pending Strands SDK plugin support for BidiAgent
- Binary resource files not supported via UI (text-only upload)
- No inter-skill dependencies

## Testing
- Created and tested `aws-doc-search` and `aws-regional-availability` skills end-to-end
- Verified skill loading via CloudWatch logs (`AgentSkills plugin loaded from directory`)
- Confirmed progressive disclosure flow (agent activates skills via tool call when instructed)

---


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
