### PR TITLE
⬆️ migrate AgentCore from alpha to stable aws-cdk-lib module

### DIFF
--- a/iac-cdk/lib/agent-core/index.ts
+++ b/iac-cdk/lib/agent-core/index.ts
@@ -3,8 +3,8 @@
 //
 // SPDX-License-Identifier: MIT-0
 // ----------------------------------------------------------------------
-import * as agentcore from "@aws-cdk/aws-bedrock-agentcore-alpha";
-import { RuntimeNetworkConfiguration } from "@aws-cdk/aws-bedrock-agentcore-alpha";
+import * as agentcore from "aws-cdk-lib/aws-bedrockagentcore";
+import { RuntimeNetworkConfiguration } from "aws-cdk-lib/aws-bedrockagentcore";
 import * as cdk from "aws-cdk-lib";
 import { CfnOutput } from "aws-cdk-lib";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";

--- a/iac-cdk/package-lock.json
+++ b/iac-cdk/package-lock.json
@@ -8,10 +8,9 @@
             "name": "aca-stack",
             "version": "1.0.0",
             "dependencies": {
-                "@aws-cdk/aws-bedrock-agentcore-alpha": "^2.232.1-alpha.0",
                 "@aws-cdk/aws-cognito-identitypool-alpha": "^2.181.1-alpha.0",
                 "@cdklabs/generative-ai-cdk-constructs": "^0.1.315",
-                "aws-cdk-lib": "^2.253.1",
+                "aws-cdk-lib": "^2.255.0",
                 "cdk-nag": "^2.37.55",
                 "constructs": "^10.5.1",
                 "js-yaml": "^4.1.1",
@@ -60,34 +59,6 @@
             "integrity": "sha512-We4bmHaowOPHr+IQR4/FyTGjRfjgBj4ICMjtqmJeBDWad3Q/6St12NT07leNtyuukv2qMhtSZJQorD8KpKTwRA==",
             "license": "Apache-2.0"
         },
-        "node_modules/@aws-cdk/aws-bedrock-agentcore-alpha": {
-            "version": "2.232.1-alpha.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-bedrock-agentcore-alpha/-/aws-bedrock-agentcore-alpha-2.232.1-alpha.0.tgz",
-            "integrity": "sha512-TcDgi6RBbBXxAnji2BhzQ+Ku+Tchm9RMqAIapNUR4yBg3iw5Db6Xo1BbAEtDvvDm6yzStAhPJbUczScpXqc7Aw==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">= 18.0.0"
-            },
-            "peerDependencies": {
-                "@aws-cdk/aws-bedrock-alpha": "2.232.1-alpha.0",
-                "aws-cdk-lib": "^2.232.1",
-                "constructs": "^10.0.0"
-            }
-        },
-        "node_modules/@aws-cdk/aws-bedrock-alpha": {
-            "version": "2.232.1-alpha.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-bedrock-alpha/-/aws-bedrock-alpha-2.232.1-alpha.0.tgz",
-            "integrity": "sha512-ZmoitxcczaULrrf5ydYujHqDjY0HocGPGUkyyko0BfYVHEjYAePH6SfYdCfXkMpOK9d9f/W+WZle29TvdeAo2g==",
-            "license": "Apache-2.0",
-            "peer": true,
-            "engines": {
-                "node": ">= 18.0.0"
-            },
-            "peerDependencies": {
-                "aws-cdk-lib": "^2.232.1",
-                "constructs": "^10.0.0"
-            }
-        },
         "node_modules/@aws-cdk/aws-cognito-identitypool-alpha": {
             "version": "2.181.1-alpha.0",
             "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cognito-identitypool-alpha/-/aws-cognito-identitypool-alpha-2.181.1-alpha.0.tgz",
@@ -103,25 +74,24 @@
             }
         },
         "node_modules/@aws-cdk/cloud-assembly-schema": {
-            "version": "53.22.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.22.0.tgz",
-            "integrity": "sha512-2GLhjjf7Db697rRyYt6rjN06fwbBIiewPo/jxSCyUN259ejF7NQQRwvrdAQb9Aq2jPaIIp1cfHSoEdXyA6Bb7Q==",
+            "version": "53.27.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.27.0.tgz",
+            "integrity": "sha512-OTxe/L2Vc60r2nYih7kFaFpn93sa7shJu9T0tQZsryeDE3HHOAuazKNmS6tLInOjJjVx/dvM5XGyUA+lZAiKxA==",
             "bundleDependencies": [
                 "jsonschema",
                 "semver"
             ],
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
-                "jsonschema": "~1.4.1",
-                "semver": "^7.7.4"
+                "jsonschema": "^1.5.0",
+                "semver": "^7.8.0"
             },
             "engines": {
                 "node": ">= 18.0.0"
             }
         },
         "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-            "version": "1.4.1",
+            "version": "1.5.0",
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -129,7 +99,7 @@
             }
         },
         "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-            "version": "7.7.4",
+            "version": "7.8.0",
             "inBundle": true,
             "license": "ISC",
             "bin": {
@@ -1053,7 +1023,6 @@
             "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -3287,7 +3256,6 @@
             "integrity": "sha512-jrTfRC7FM6nChvU7X2KqcrgquofrWLFDeYC1hKfwNWomVvrn7JIksqf344WN2X/y8xrgqBd2dJATZV4GbatBfg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~6.19.2"
             }
@@ -3425,9 +3393,9 @@
             }
         },
         "node_modules/aws-cdk-lib": {
-            "version": "2.253.1",
-            "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.253.1.tgz",
-            "integrity": "sha512-vy+hA15/ZfSQpivkNdlIn2ZDA2hesp3WJgmtIZJDFwu6xzwv7wH7glbAdu5xCHGcOjepOaTKZSvCPC6sN+0/Vw==",
+            "version": "2.257.0",
+            "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.257.0.tgz",
+            "integrity": "sha512-GoHfWklrBJcMwLtDlY64pvaT7cD2KyDXC8sik89DR6jHl6nQsBtYTKSJCM+C/k4jgXaecbv8myNX75FySejq0A==",
             "bundleDependencies": [
                 "@balena/dockerignore",
                 "@aws-cdk/cloud-assembly-api",
@@ -3443,12 +3411,11 @@
                 "mime-types"
             ],
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-cdk/asset-awscli-v1": "2.2.273",
                 "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-                "@aws-cdk/cloud-assembly-api": "^2.2.2",
-                "@aws-cdk/cloud-assembly-schema": "^53.18.0",
+                "@aws-cdk/cloud-assembly-api": "^2.2.4",
+                "@aws-cdk/cloud-assembly-schema": "^53.25.0",
                 "@balena/dockerignore": "^1.0.2",
                 "case": "1.6.3",
                 "fs-extra": "^11.3.3",
@@ -3469,22 +3436,29 @@
             }
         },
         "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-            "version": "2.2.2",
-            "bundleDependencies": [
-                "jsonschema",
-                "semver"
-            ],
+            "version": "2.2.4",
             "inBundle": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "jsonschema": "~1.4.1",
-                "semver": "^7.7.4"
+                "jsonschema": "^1.5.0",
+                "semver": "^7.8.0"
             },
             "engines": {
                 "node": ">= 18.0.0"
             },
             "peerDependencies": {
-                "@aws-cdk/cloud-assembly-schema": ">=53.15.0"
+                "@aws-cdk/cloud-assembly-schema": ">=53.25.0"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
+            "version": "7.8.0",
+            "inBundle": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
@@ -3591,7 +3565,7 @@
             "license": "MIT"
         },
         "node_modules/aws-cdk-lib/node_modules/fast-uri": {
-            "version": "3.1.0",
+            "version": "3.1.2",
             "funding": [
                 {
                     "type": "github",
@@ -3985,7 +3959,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -4227,8 +4200,7 @@
             "version": "10.5.1",
             "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.5.1.tgz",
             "integrity": "sha512-f/TfFXiS3G/yVIXDjOQn9oTlyu9Wo7Fxyjj7lb8r92iO81jR2uST+9MstxZTmDGx/CgIbxCXkFXgupnLTNxQZg==",
-            "license": "Apache-2.0",
-            "peer": true
+            "license": "Apache-2.0"
         },
         "node_modules/convert-source-map": {
             "version": "2.0.0",
@@ -5009,7 +4981,6 @@
             "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/core": "^29.7.0",
                 "@jest/types": "^29.6.3",
@@ -6667,7 +6638,6 @@
             "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@cspotcode/source-map-support": "^0.8.0",
                 "@tsconfig/node10": "^1.0.7",
@@ -6742,7 +6712,6 @@
             "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"

--- a/iac-cdk/package.json
+++ b/iac-cdk/package.json
@@ -33,10 +33,9 @@
         "typescript": "~5.6.3"
     },
     "dependencies": {
-        "@aws-cdk/aws-bedrock-agentcore-alpha": "^2.232.1-alpha.0",
         "@aws-cdk/aws-cognito-identitypool-alpha": "^2.181.1-alpha.0",
         "@cdklabs/generative-ai-cdk-constructs": "^0.1.315",
-        "aws-cdk-lib": "^2.253.1",
+        "aws-cdk-lib": "^2.255.0",
         "cdk-nag": "^2.37.55",
         "constructs": "^10.5.1",
         "js-yaml": "^4.1.1",


### PR DESCRIPTION
Migrate from the separate @aws-cdk/aws-bedrock-agentcore-alpha package to the stable aws-cdk-lib/aws-bedrockagentcore submodule, now available as of AWS CDK v2.255.0.

Changes:
- Remove @aws-cdk/aws-bedrock-agentcore-alpha dependency
- Bump aws-cdk-lib from ^2.253.1 to ^2.255.0
- Update imports in lib/agent-core/index.ts to use aws-cdk-lib/aws-bedrockagentcore

This eliminates the -alpha suffix dependency and gives us full CDK stability guarantees for AgentCore L2 constructs (Runtime, Memory, Gateway, etc.).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
