### PR TITLE
🐛 add default stack name fallback in build script

### DIFF
--- a/iac-cdk/scripts/build.sh
+++ b/iac-cdk/scripts/build.sh
@@ -62,9 +62,8 @@ if [[ -z "$STACK_NAME" ]]; then
     fi
 
     if [[ -z "$STACK_NAME" ]]; then
-        err "Stack name required. Use --stack-name or set CDK_STACK_NAME."
-        err "Alternatively, set 'prefix' in iac-cdk/bin/config.yaml."
-        exit 1
+        STACK_NAME="dev-aca-builder"
+        info "No stack name provided and no config.yaml found. Falling back to default: ${STACK_NAME}"
     fi
 fi
 


### PR DESCRIPTION
Replace error exit with a default stack name ("dev-aca-builder") when no stack name is provided via --stack-name, CDK_STACK_NAME env var, or config.yaml. This improves the developer experience by allowing the build script to proceed without explicit configuration.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
