### PR TITLE
  📝 (docs+tooling): document S3 Vectors KB backend, add iac-config-generator skill, fix tf-clean

### DIFF
--- a/.claude/skills/iac-config-generator/SKILL.md
+++ b/.claude/skills/iac-config-generator/SKILL.md
@@ -1,0 +1,95 @@
+---
+description: Generate matching CDK config.yaml and Terraform terraform.tfvars files from a short description of the features the user wants to deploy (Knowledge Base, Data Processing, AgentCore Runtime, Observability, Experiments, MCP servers, Evaluator, etc.). Use whenever the user says things like "generate a config", "create my config.yaml", "set up tfvars", "I want a config with KB enabled", "give me a deploy config for X", "what config do I need for Y", or any variation that asks for IaC inputs derived from project features. Outputs always go to cache/local-cfg/ at the repo root, in BOTH CDK and Terraform shapes, kept in sync.
+user_invocable: true
+---
+
+# IaC config generator (CDK + Terraform, in sync)
+
+This project ships two parallel IaC implementations — CDK is primary, Terraform mirrors it — and both are driven by the same conceptual feature set. Hand-writing `iac-cdk/bin/config.yaml` or `iac-terraform/terraform.tfvars` is error-prone: there are nested optional blocks, inter-feature dependencies (KB needs Data Processing, Experiments needs a VPC story, etc.), and the two formats name things differently (camelCase vs snake_case, YAML vs HCL, optional fields expressed as `?` in CDK types vs `optional()` / commented blocks in TF).
+
+This skill turns a short user description into a matched pair of config files, written into the repo's `cache/local-cfg/` folder, ready for the user to copy into place.
+
+## When to use
+
+- The user wants to bootstrap a deployment with a specific feature set ("config for KB + observability", "tfvars without experiments", "give me the minimal config").
+- The user is exploring scenarios and wants alternative configs side-by-side.
+- The user is migrating between CDK and Terraform and needs the equivalent variables.
+- Any phrasing that signals "generate config from features", even if the user doesn't name the file explicitly.
+
+Don't use this skill for: editing `iac-cdk/bin/config.ts` defaults, generating runtime/Docker config, or producing AWS account-level setup (e.g. Bedrock model access). Those live elsewhere.
+
+## How it works
+
+### 1. Capture intent — short prompt + targeted follow-ups
+
+Read what the user said. Most requests carry partial signal ("I want a config with KB and observability, no experiments"). Your job is to:
+
+1. **Parse** what the user already declared.
+2. **Identify gaps** that must be filled to produce a valid config — see the [Required-vs-optional table](#required-vs-optional).
+3. **Ask only about what's missing or ambiguous.** Bundle related questions into one round-trip with `AskUserQuestion`. Don't interrogate the user for fields that have safe defaults — pick the default and tell them what you picked.
+
+The features and their dependencies live in [references/feature-matrix.md](references/feature-matrix.md). Read it once at the start of a session — it's the source of truth for what features exist and how they interact.
+
+### Required vs optional
+
+| Always need from the user | Has safe default — only ask if relevant |
+|---|---|
+| `prefix` (resource name prefix, e.g. `dev`, `aca`, project name) | `aws_region` (us-east-1) |
+| Which features to enable (KB, Observability, Experiments, AgentRuntime, MCP) | Lambda architecture (arm64) |
+| For each enabled feature: the few fields that have no defaults (see feature-matrix.md) | Geo restrictions (off) |
+
+If the user already said "minimal config" or "all defaults", don't ask anything — just pick safe defaults and produce the output.
+
+### 2. Resolve dependencies
+
+Some features imply others. Apply these silently and tell the user what you inferred:
+
+- **Knowledge Base ⇒ Data Processing.** KB ingests from a data source prefix that the data processing pipeline produces. Enabling KB without Data Processing is a misconfig.
+- **Experiments ⇒ VPC story.** Either `deployBatchInfrastructure: false` (CRUD only, no synthetic generation), `vpcId` set (reuse), or omit both (auto-create VPC). Pick based on the user's stated permissions / preferences.
+- **AgentRuntime ⇒ at least one tool in `toolRegistry`.** If the user enables AgentRuntime but lists no tools, default to `invoke_subagent`.
+- **AgentRuntime referencing `retrieve_from_kb` ⇒ KB must be enabled.** Otherwise drop the tool with a note.
+
+If you have to drop or alter something the user requested, surface it explicitly in your final summary ("I had to disable X because Y").
+
+### 3. Generate both files in sync
+
+The two formats are not 1:1 string-for-string equivalent — they share semantics, not syntax. Use the field-mapping table in [references/cdk-tf-mapping.md](references/cdk-tf-mapping.md) so the generated files describe the same deployment.
+
+Always emit both:
+- `cache/local-cfg/config.yaml` — CDK shape (camelCase, YAML)
+- `cache/local-cfg/terraform.tfvars` — Terraform shape (snake_case, HCL)
+
+If `cache/` or `cache/local-cfg/` doesn't exist, create them. Use `mkdir -p`.
+
+If files already exist there, **do not silently overwrite.** Show a diff-summary of what would change, then ask the user whether to overwrite, write to a sibling timestamped folder, or abort. The cache folder may contain hand-tuned configs from prior sessions and clobbering them is high-blast-radius.
+
+### 4. Sanity-check before writing
+
+Before the file is written, check it against these gotchas (none of these are caught by the type system):
+
+- Model IDs: keep the `[REGION-PREFIX]` placeholder for cross-region inference profiles. Don't bake `us.` / `eu.` / `apac.` into the file unless the user asked for a specific region pin.
+- `dataSourcePrefix` must match between `dataProcessingParameters` and `knowledgeBaseParameters` (default: `knowledge-base-data-source`).
+- KB `chunkingStrategy.type` must match the `*ChunkingProps` block actually filled in (FIXED_SIZE → `fixedChunkingProps`, etc.).
+- `toolRegistry` entries with `invokesSubAgent: true` only make sense for the agents-as-tools or graph patterns — if the user described single-agent deployment, drop them.
+- Terraform side: comment out blocks for features the user didn't enable (don't emit empty objects — the variable defaults expect `null` or absent). Match the convention in `iac-terraform/terraform.tfvars.example`.
+- `experimentsConfig` / `experiments_config`: respect the three-mode system (disabled → omit / null, auto-VPC → `{}`, reuse VPC → `{ vpc_id = "…" }`).
+
+### 5. Report back
+
+After writing, tell the user:
+- Where the files landed (full paths from repo root).
+- Which features were enabled, and any features they asked for that were dropped or altered, with reasons.
+- The exact next step to use the config: e.g. `cp cache/local-cfg/config.yaml iac-cdk/bin/config.yaml` then `make deploy`, or `cp cache/local-cfg/terraform.tfvars iac-terraform/terraform.tfvars` then `make tf-deploy`.
+
+Keep this summary short — the files are the artifact, the explanation is just orientation.
+
+## Reference files
+
+- [references/feature-matrix.md](references/feature-matrix.md) — Every feature, its required/optional fields, defaults, and inter-feature dependencies. Read this whenever the user names a feature you're not sure about.
+- [references/cdk-tf-mapping.md](references/cdk-tf-mapping.md) — Field-by-field translation table between `config.yaml` and `terraform.tfvars`. Read this before generating to make sure the two outputs describe the same deployment.
+
+These references are kept separate from `SKILL.md` because they're long, lookup-style content — keep `SKILL.md` skimmable and consult the references on demand.
+
+## Why this design (theory of mind for the agent running this skill)
+
+You're being asked to compress a feature description into a structured config. There's a temptation to ping-pong with the user for every field — don't. The user knows roughly what they want; they hit you up because they don't want to read 300 lines of `tfvars.example`. Pick sensible defaults aggressively, ask only when the choice has real consequences (e.g. KB embedding model dimension, Experiments VPC mode), and write the file. If you got something wrong, the diff-summary at write time gives the user a chance to course-correct before commitment. That's faster and friendlier than 12 questions up front.

--- a/.claude/skills/iac-config-generator/references/cdk-tf-mapping.md
+++ b/.claude/skills/iac-config-generator/references/cdk-tf-mapping.md
@@ -1,0 +1,141 @@
+# CDK ↔ Terraform field mapping
+
+Use this when you've decided what to enable and you need to render the same configuration in both formats. The two outputs must describe the same deployment — not the same syntax.
+
+When in doubt about exact HCL/YAML syntax, look at:
+- CDK reference: `cache/configs/config-kb.yaml` (a real working example with KB enabled).
+- Terraform reference: `iac-terraform/terraform.tfvars.example` (a real working example with all blocks commented).
+
+## Naming convention
+
+| CDK YAML | Terraform HCL |
+|---|---|
+| `camelCase` | `snake_case` |
+| `key: value` | `key = value` |
+| string `"value"` or `value` | string `"value"` (quotes required for strings) |
+| list `[a, b]` or block-form | list `[a, b]` |
+| nested object | inline `{ }` block |
+| optional missing → omit key | optional missing → leave variable at default (often `null`) — usually means commenting the block out in `terraform.tfvars` |
+| multiline string `\|` | heredoc `<<-EOT … EOT` |
+
+## Top-level mapping
+
+| CDK | Terraform | Notes |
+|---|---|---|
+| `prefix` | `prefix` | Direct. |
+| (no CDK field) | `aws_region` | TF only — CDK reads region from CLI/profile. |
+| (no CDK field) | `environment` | TF only — combined with `prefix`. |
+| (no CDK field) | `aws_profile` | TF only. |
+| (no CDK field) | `lambda_architecture` | TF only — `arm64` default. |
+| `bedrockAccessRoleArn` | `bedrock_access_role_arn` | Cross-account Bedrock STS role. |
+| `enableGeoRestrictions`, `allowedGeoRegions` | (no TF mirror today) | CDK only. Skip in TF. |
+| `supportedModels` | `supported_models` | Same map shape; quote display names with spaces in HCL. |
+| `rerankingModels` | (no TF mirror) | CDK only. Skip in TF. |
+| `toolRegistry` | `tool_registry` | Field rename: `invokesSubAgent` → `invokes_sub_agent`. |
+| `mcpServerRegistry` | `mcp_server_registry` | Field renames: `runtimeId` → `runtime_id`, `gatewayId` → `gateway_id`. CDK supports `url` + `authType` for direct HTTP MCP; TF variable does not — flag a gap if needed. |
+| `ingestionLambdaProps` | (no TF mirror — defaults bake in) | CDK only. |
+| `agentCoreObservability` | `observability` (different name!) | `enableTransactionSearch` → `enable_transaction_search`; `indexingPercentage` → `indexing_percentage`. |
+| `dataProcessingParameters` | `data_processing` (different name!) | All field-by-field mapping in [feature-matrix.md](feature-matrix.md). |
+| `knowledgeBaseParameters` | `knowledge_base` (different name!) | Chunking strategy is structured differently — see below. |
+| `agentRuntimeConfig` | `agent_runtime_config` | Heredoc for `instructions`. |
+| `evaluatorConfig` | `evaluator_config` | Heredoc for each rubric. |
+| `experimentsConfig` | `experiments_config` | Three-mode flag — see feature-matrix.md. |
+| `stateClassRegistry`, `deterministicNodeRegistry`, `structuredOutputRegistry` | (no TF mirror) | CDK only. |
+
+## Chunking strategy — the format diverges
+
+CDK nests typed sub-objects under the strategy:
+
+```yaml
+knowledgeBaseParameters:
+  chunkingStrategy:
+    type: HIERARCHICAL
+    hierarchicalChunkingProps:
+      overlapTokens: 60
+      maxParentTokenSize: 1500
+      maxChildTokenSize: 300
+```
+
+Terraform flattens to a string + a separate sibling block:
+
+```hcl
+knowledge_base = {
+  chunking_strategy = "HIERARCHICAL"
+  hierarchical_chunking_config = {
+    overlap_tokens        = 60
+    max_parent_token_size = 1500
+    max_child_token_size  = 300
+  }
+  # …
+}
+```
+
+Same for `FIXED_SIZE` (`fixedChunkingProps` ↔ `fixed_chunking_config`) and `SEMANTIC` (`semanticChunkingProps` ↔ `semantic_chunking_config`). When generating TF, only emit the one config block matching the chosen strategy.
+
+## Multiline strings
+
+CDK YAML:
+```yaml
+agentRuntimeConfig:
+  instructions: |
+    You are a helpful AI assistant.
+    Be concise.
+```
+
+Terraform HCL:
+```hcl
+agent_runtime_config = {
+  instructions = <<-EOT
+    You are a helpful AI assistant.
+    Be concise.
+  EOT
+}
+```
+
+The `<<-EOT` form (with the dash) lets you indent the heredoc body for readability — Terraform strips the leading whitespace based on the closing `EOT` line. Always use `<<-EOT`, never `<<EOT`, in generated configs.
+
+## Optional / disabled features — emit nothing, not empty
+
+For features the user did **not** enable:
+
+- **CDK**: omit the key entirely. Don't emit `knowledgeBaseParameters: null` or `experimentsConfig: {}` — the loader treats absence as "feature off".
+- **Terraform**: leave the variable at its `default` from `variables.tf`. In `terraform.tfvars` this means commenting the block out (preferred — keeps the user oriented) or omitting it. Never write `experiments_config = null` if the variable's default is already `null` — it's noise.
+
+The one exception is `experiments_config = {}` in TF, which is the documented signal for "enabled with auto-VPC". Same in CDK: `experimentsConfig: {supportedModels: …}` is "enabled". Don't shorten this to `experimentsConfig: {}` in CDK — `supportedModels` is required when enabled.
+
+## Tool registry rendering
+
+CDK YAML:
+```yaml
+toolRegistry:
+  - name: "invoke_subagent"
+    description: "Invoke a sub-agent…"
+    invokesSubAgent: true
+```
+
+Terraform HCL:
+```hcl
+tool_registry = [
+  {
+    name              = "invoke_subagent"
+    description       = "Invoke a sub-agent…"
+    invokes_sub_agent = true
+  }
+]
+```
+
+Note the alignment in HCL — Terraform's `terraform fmt` would reformat to aligned `=` anyway. Generating it pre-aligned is friendlier.
+
+## MCP registry rendering
+
+CDK supports three discriminated union shapes (`runtimeId`, `gatewayId`, or `url`+`authType`). Terraform's variable today is a single object with all fields `optional()` — the `url`/`authType` form is unsupported in TF.
+
+If the user wants a direct HTTP MCP server, emit the CDK form normally and **flag a gap** in the report ("Terraform doesn't support `url`/`authType` MCP entries today; this server is omitted from `terraform.tfvars`. Use the AgentCore Runtime or Gateway form, or extend `iac-terraform/variables.tf`.").
+
+## Sanity checklist before writing
+
+1. CDK YAML parses (no tabs, consistent indent, all maps have keys).
+2. Terraform HCL parses (`=` between keys and values, strings quoted, lists with commas).
+3. Cross-references resolve: every name in `agentRuntimeConfig.tools` is in `toolRegistry`, every name in `agentRuntimeConfig.mcpServers` is in `mcpServerRegistry`.
+4. `dataSourcePrefix` matches between Data Processing and Knowledge Base (in *both* files).
+5. The same set of features is enabled in both files. (E.g., if you enable Experiments in CDK but forgot to uncomment `experiments_config = {}` in TF, that's a sync bug.)

--- a/.claude/skills/iac-config-generator/references/feature-matrix.md
+++ b/.claude/skills/iac-config-generator/references/feature-matrix.md
@@ -1,0 +1,142 @@
+# Feature matrix
+
+This is the source of truth for which features exist, what they require, and how they interact. The authoritative type definitions live in `iac-cdk/lib/shared/types.ts`. The Terraform variable types live in `iac-terraform/variables.tf`. When in doubt, re-read those files — this matrix is a digest, not a replacement.
+
+## Top-level required fields
+
+| Field (CDK) | Field (TF) | Type | Default | Notes |
+|---|---|---|---|---|
+| `prefix` | `prefix` | string | none — must ask | Used in resource names. Letters/digits/hyphens; starts with a letter. |
+| `enableGeoRestrictions` | (no direct TF mirror) | bool | `false` | CloudFront geo block. |
+| `allowedGeoRegions` | (no direct TF mirror) | string[] | `[]` | ISO 3166-1 alpha-2 codes. Only used when `enableGeoRestrictions: true`. |
+| `supportedModels` | `supported_models` | map<display→modelId> | three Bedrock models (see `config.ts`) | Keep `[REGION-PREFIX]` placeholder unless the user pins a region. |
+| `toolRegistry` | `tool_registry` | array of `{name, description, invokesSubAgent/invokes_sub_agent}` | `[]` | If `agentRuntimeConfig` is set, default to `[{name: "invoke_subagent", description: "...", invokesSubAgent: true}]`. |
+| `mcpServerRegistry` | `mcp_server_registry` | array | `[]` | See MCP section below. |
+| `ingestionLambdaProps` | (no direct TF mirror — defaults bake in) | `{timeoutInMinutes, reservedConcurrency?}` | `{3, 20}` | CDK-only construct. |
+| (TF only) `aws_region` | — | string | `us-east-1` |  |
+| (TF only) `environment` | — | string | `""` | Combined with prefix → `aca-dev-xxx`. |
+| (TF only) `lambda_architecture` | — | `"arm64"` \| `"x86_64"` | `arm64` |  |
+| (TF only) `bedrock_access_role_arn` | — | string | `null` | Cross-account Bedrock STS role. |
+
+## Optional features
+
+Each block below is omitted entirely when the feature is disabled. In CDK, leave the field out of the YAML. In Terraform, leave the variable at its default (`null` or `{}` per `variables.tf`) — usually that means commenting the block out in `terraform.tfvars`.
+
+### Data Processing (`dataProcessingParameters` / `data_processing`)
+
+Required if Knowledge Base is enabled. Otherwise optional.
+
+| Field | Default | Notes |
+|---|---|---|
+| `inputPrefix` / `input_prefix` | `inputs` | S3 prefix for raw uploads. |
+| `dataSourcePrefix` / `data_source_prefix` | `knowledge-base-data-source` | Output prefix; **must equal** the KB block's `dataSourcePrefix`. |
+| `processingPrefix` / `processing_prefix` | `processing` | Intermediate storage. |
+| `stagingMidfix` / `staging_midfix` | `staging` (TF) / `input` (CDK example) | Internal path component; rarely changed. |
+| `transcribeMidfix` / `transcribe_midfix` | `transcribe` | For audio/video transcription. |
+| `languageCode` / `language_code` | `en-US` (CDK) / `auto` (TF example) | Amazon Transcribe language. |
+
+### Knowledge Base (`knowledgeBaseParameters` / `knowledge_base`)
+
+Requires Data Processing.
+
+| Field | Default | Notes |
+|---|---|---|
+| `chunkingStrategy.type` / `chunking_strategy` | `FIXED_SIZE` | One of `FIXED_SIZE`, `HIERARCHICAL`, `SEMANTIC`, `NONE`. |
+| `chunkingStrategy.fixedChunkingProps` | `{maxTokens: 300, overlapPercentage: 20}` | Required when type is `FIXED_SIZE`. |
+| `chunkingStrategy.hierarchicalChunkingProps` | `{overlapTokens: 60, maxParentTokenSize: 1500, maxChildTokenSize: 300}` | Required when type is `HIERARCHICAL`. |
+| `chunkingStrategy.semanticChunkingProps` | `{bufferSize: 0, breakpointPercentileThreshold: 95, maxTokens: 300}` | Required when type is `SEMANTIC`. |
+| `embeddingModel.modelId` / `embedding_model_id` | `amazon.titan-embed-text-v2:0` | Allowed: titan v2, cohere english, cohere multilingual. |
+| `embeddingModel.vectorDimension` / `vector_dimension` | `1024` | Must be 256, 512, or 1024 for titan; 1024 for cohere. |
+| `dataSourcePrefix` / `data_source_prefix` | `knowledge-base-data-source` | Must equal Data Processing's `dataSourcePrefix`. |
+| `description` | `Knowledge Base for searching helpful information.` | Free text. |
+| `vectorStoreType` / `vector_store_type` | `OPENSEARCH_SERVERLESS` | `S3_VECTORS` is dramatically cheaper for low-QPS document KBs. Recommend it unless the user needs OpenSearch features. |
+
+### Reranking (`rerankingModels`)
+
+Optional. CDK-only field; not exposed in current Terraform variables.
+
+Default suggestion if the user enables it: `{Cohere Rerank 3.5: cohere.rerank-v3-5:0, Amazon Rerank 1.0: amazon.rerank-v1:0}`.
+
+### Observability (`agentCoreObservability` / `observability`)
+
+| Field | Default | Notes |
+|---|---|---|
+| `enableTransactionSearch` / `enable_transaction_search` | `false` | **Account-level X-Ray setting.** Set to `true` only if the user confirms it's not already enabled in their account, or it'll cause a deploy error. See `docs/src/troubleshooting.md`. |
+| `indexingPercentage` / `indexing_percentage` | `10` | 1–100, % of traces indexed. |
+
+When in doubt, leave `enableTransactionSearch: false`.
+
+### Agent Runtime (`agentRuntimeConfig` / `agent_runtime_config`)
+
+Pre-creates a Bedrock AgentCore Runtime via IaC. If omitted, users build agents through the Agent Factory UI instead.
+
+| Field | Default | Notes |
+|---|---|---|
+| `modelInferenceParameters.modelId` | one of `supportedModels` | Pick a Claude / Nova model. |
+| `modelInferenceParameters.parameters.temperature` | `0.7` |  |
+| `modelInferenceParameters.parameters.maxTokens` / `max_tokens` | `4096` |  |
+| `modelInferenceParameters.parameters.stopSequences` / `stop_sequences` | `null` |  |
+| `instructions` | brief generic system prompt | Multiline; HCL uses heredoc, YAML uses `|`. |
+| `tools` | `["invoke_subagent"]` for orchestrator patterns; `[]` otherwise | Names must exist in `toolRegistry`. |
+| `toolParameters` / `tool_parameters` | `{}` | Tool-name-keyed dict-of-dicts. |
+| `mcpServers` / `mcp_servers` | `[]` | Names must exist in `mcpServerRegistry`. |
+| `conversationManager` / `conversation_manager` | `sliding_window` | One of `sliding_window`, `summarization`, `none`. |
+| `description` | optional | Free text. |
+| `memoryCfg.retentionDays` / `memory_config.retention_days` | omit unless user asks | 7–365. |
+| `lifecycleCfg.idleRuntimeSessionTimeoutInMinutes` | `15` | Idle timeout. |
+| `lifecycleCfg.maxLifetimeInHours` | `24` | Hard cap. |
+
+### Evaluator (`evaluatorConfig` / `evaluator_config`)
+
+| Field | Default | Notes |
+|---|---|---|
+| `supportedModels` / `supported_models` | same as top-level `supportedModels` | Models used for LLM-judged evaluations. |
+| `passThreshold` / `pass_threshold` | `0.8` | 0.0–1.0. |
+| `defaultRubrics` / `default_rubrics` | the three rubrics from `config.ts` (OutputEvaluator, TrajectoryEvaluator, InteractionsEvaluator) | Multiline. |
+
+### Experiments (`experimentsConfig` / `experiments_config`)
+
+Three-mode flag. Choose one:
+
+| Mode | CDK | TF | When |
+|---|---|---|---|
+| Disabled | omit `experimentsConfig` | leave `experiments_config = null` | User doesn't want synthetic test generation. |
+| CRUD-only | `experimentsConfig: {supportedModels: …, deployBatchInfrastructure: false}` | `experiments_config = {deploy_batch_infrastructure = false}` | User wants the UI / data model but no Batch infra (no VPC permissions). |
+| Auto-VPC | `experimentsConfig: {supportedModels: …}` | `experiments_config = {}` | Default when enabled. Creates a fresh VPC. |
+| Reuse VPC | `experimentsConfig: {supportedModels: …, vpcId: "vpc-…"}` | `experiments_config = {vpc_id = "vpc-…"}` | User has an existing VPC with private subnets + NAT. |
+
+`supportedModels` is required when enabled and defaults to the same three Bedrock models as the top-level `supportedModels`.
+
+### MCP Servers (`mcpServerRegistry` / `mcp_server_registry`)
+
+Each entry must have **exactly one** of:
+- `runtimeId` / `runtime_id` (AgentCore Runtime-hosted MCP) — also accepts optional `qualifier` (default `"DEFAULT"`).
+- `gatewayId` / `gateway_id` (AgentCore Gateway-hosted MCP).
+- `url` + `authType` (CDK only) — direct Streamable HTTP endpoint, `authType` is `"SIGV4"` or `"NONE"`.
+
+Common entry fields: `name`, `description`.
+
+### Pattern-specific registries (CDK-only optional fields)
+
+These are only meaningful when running graph or swarm agent patterns. If the user describes a single-agent or agents-as-tools deployment, leave them out.
+
+- `stateClassRegistry`: `[{key, label, description, fields[]}]`
+- `deterministicNodeRegistry`: `[{key, label, description}]`
+- `structuredOutputRegistry`: `[{key, label, description, fields[]}]`
+
+These don't have a Terraform mirror in `variables.tf` today. If the user explicitly asks for them in TF, flag the gap rather than inventing variables.
+
+## Inter-feature constraints (the "did you mean" rules)
+
+| If the user enables… | Make sure… |
+|---|---|
+| `knowledgeBaseParameters` | `dataProcessingParameters` is also set, and the two `dataSourcePrefix` values match. |
+| `toolRegistry` includes `retrieve_from_kb` | `knowledgeBaseParameters` is set. |
+| `agentRuntimeConfig.tools` references a name | that name appears in `toolRegistry`. |
+| `agentRuntimeConfig.mcpServers` references a name | that name appears in `mcpServerRegistry`. |
+| `experimentsConfig` with `vpcId` | the VPC exists with private subnets + NAT. (Can't verify; just remind the user.) |
+| `agentCoreObservability.enableTransactionSearch: true` | the user has confirmed Transaction Search is *not* already enabled at the account level. |
+
+When you find a violation, prefer **silent auto-fix + tell the user** over **ask first**. Examples:
+- User says "KB enabled" without mentioning data processing → auto-add Data Processing block with defaults, mention it in the summary.
+- User lists `retrieve_from_kb` in tools but no KB → either add the KB block (if they implied a knowledge use case) or drop the tool. Pick the choice that best matches the user's intent and explain.

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,8 @@ tf-checkov:
 
 # Clean Terraform build artifacts
 tf-clean:
-	rm -rf iac-terraform/build iac-terraform/.terraform
+	rm -rf iac-terraform/build
+	find iac-terraform -type d -name .terraform -exec rm -rf {} +
 
 # Full validation (format + validate + checkov)
 tf-lint: tf-fmt tf-validate tf-checkov

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -100,7 +100,7 @@ Enabled when `knowledgeBaseParameters` and `dataProcessingParameters` are config
 |----------|------|
 | Amazon S3 (Document Bucket) | Document upload storage |
 | Step Function — Document Processing | Orchestrates chunking, embedding, and ingestion into Knowledge Base |
-| Amazon Bedrock Knowledge Base | Semantic/hybrid search for RAG |
+| Amazon Bedrock Knowledge Base | Semantic/hybrid search for RAG. Backend selectable via `vectorStoreType`: Amazon OpenSearch Serverless (default, supports hybrid search) or Amazon S3 Vectors (cheaper, semantic-only) — see [Vector Store Backend](./kb-management.md#vector-store-backend) |
 | Lambda functions | Document processing steps (chunking, metadata extraction) |
 
 ## Observability & Monitoring

--- a/docs/src/how-to-deploy.md
+++ b/docs/src/how-to-deploy.md
@@ -48,7 +48,7 @@ The CDK stack is configured through the `SystemConfig` interface defined in [`ia
 - **enableGeoRestrictions**: Boolean flag for geographic access restrictions
 - **allowedGeoRegions**: Array of allowed geographic regions when restrictions are enabled
 - **dataProcessingParameters**: *(Optional)* Configuration for data processing workflows including file prefixes and language settings. If omitted, the data processing pipeline will not be deployed.
-- **knowledgeBaseParameters**: *(Optional)* Knowledge base configuration including chunking strategies (FIXED_SIZE, HIERARCHICAL, SEMANTIC, NONE), embedding models, and descriptions. If omitted, the Knowledge Base feature will not be deployed.
+- **knowledgeBaseParameters**: *(Optional)* Knowledge base configuration including chunking strategies (FIXED_SIZE, HIERARCHICAL, SEMANTIC, NONE), embedding models, descriptions, and the optional `vectorStoreType` (`OPENSEARCH_SERVERLESS` (default) or `S3_VECTORS`). See [Vector Store Backend](./kb-management.md#vector-store-backend) for tradeoffs. If omitted, the Knowledge Base feature will not be deployed.
 - **supportedModels**: Map of foundation model names to Bedrock model identifiers used by agents, with [REGION-PREFIX] placeholder for cross-region inference profiles
 - **rerankingModels**: *(Optional)* Map of reranking model names to Bedrock model identifiers for improving knowledge base retrieval relevance. Supported models include Cohere Rerank 3.5 and Amazon Rerank 1.0.
 - **toolRegistry**: Array of available tools with name, description, and sub-agent invocation flags

--- a/docs/src/kb-management.md
+++ b/docs/src/kb-management.md
@@ -75,6 +75,45 @@ As shown in the GIF, users can also manage document metadata. For example, they 
 
 Users can create new Bedrock Knowledge Bases to attach to agents. This allows users to test different chunking and vector embedding options. Knowledge bases created by a user are only visible to that user by default. Note that the CDK will clean up Bedrock Knowledge Bases created from the application upon destruction using a [custom cleanup Lambda function](../../src/cleanup/functions/cleanup-handler/index.py).
 
+## Vector Store Backend
+
+The CDK-provisioned knowledge base supports two backends, selected via the `vectorStoreType` field on `knowledgeBaseParameters` in `bin/config.yaml`:
+
+| Value | Resource provisioned | When to use |
+|-------|---------------------|-------------|
+| `OPENSEARCH_SERVERLESS` *(default)* | Amazon OpenSearch Serverless vector collection + index | Higher-QPS workloads, hybrid search, or when you already operate OSS |
+| `S3_VECTORS` | Amazon S3 Vectors bucket + index (cosine distance) | Low-QPS document KBs — dramatically cheaper than OSS for typical demo/PoC traffic |
+
+```yaml
+knowledgeBaseParameters:
+    vectorStoreType: S3_VECTORS    # omit or set to OPENSEARCH_SERVERLESS for the default
+    chunkingStrategy:
+        type: HIERARCHICAL
+        # ...
+    embeddingModel:
+        modelId: amazon.titan-embed-text-v2:0
+        vectorDimension: 1024
+    dataSourcePrefix: knowledge-base-data-source
+```
+
+The Terraform mirror exposes the same option as `vector_store_type` on `knowledge_base_parameters` in `terraform.tfvars`.
+
+The setting only affects the **default knowledge base provisioned by the stack**. Knowledge bases created from the UI ([Creating New Knowledge Bases](#creating-new-knowledge-bases)) are not affected by this flag.
+
+### S3 Vectors limitations
+
+S3 Vectors is optimized for **cost over latency** and is best suited for infrequent-query RAG workloads. Before switching from OpenSearch Serverless, be aware of the following constraints (per the [Bedrock Knowledge Bases documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/knowledge-base-setup.html) and [S3 Vectors limits](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-vectors-limitations.html)):
+
+- **Hybrid search is not supported.** Per AWS: *"Hybrid search is only supported for Amazon RDS, Amazon OpenSearch Serverless, and MongoDB vector stores."* If you set `overrideSearchType: HYBRID` on a query against an S3 Vectors KB, Bedrock silently falls back to semantic search.
+- **Binary vector embeddings are not supported** — only floating-point (`float32`). Only OpenSearch (Serverless and Managed) supports binary vectors.
+- **Metadata filtering operators are limited.** `startsWith` and `stringContains` are not supported on S3 Vectors. The other operators (`equals`, `notEquals`, range, `in`, `notIn`, `listContains`) work, with up to 2 KB filterable metadata + 10 non-filterable metadata keys per vector.
+- **Per-vector metadata size cap (Bedrock KB-specific)**: up to **1 KB** of custom metadata and **35 metadata keys** per vector. Hierarchical chunking with very large parent/child token sizes can exceed this and fail ingestion — the parent–child relationships are stored as non-filterable metadata.
+- **Distance metrics**: Cosine or Euclidean only (the CDK construct provisions Cosine).
+- **Throughput ceiling**: combined PutVectors + DeleteVectors capped at 1,000 req/s per index, with up to 2,500 vectors written/deleted per second per index. Fine for batch ingestion; not for high-write streaming use cases.
+- **Reranking still works** — it's applied post-retrieval and is independent of the vector backend (see [Reranking Configuration](#reranking-configuration) below).
+
+> ⚠️ **Switching `vectorStoreType` on an existing deployment replaces the underlying vector store**, so previously ingested embeddings are dropped and the knowledge base must be re-synced from `dataSourcePrefix`. There is no in-place migration path between vector stores in Bedrock — the recommended approach is to redeploy and re-ingest.
+
 ## Reranking Configuration
 
 Reranking improves retrieval relevance by re-scoring documents after the initial vector search. When enabled, the system first retrieves a larger set of candidate documents using vector similarity, then applies a reranking model to reorder them based on semantic relevance to the query.

--- a/docs/src/kb-management.md
+++ b/docs/src/kb-management.md
@@ -96,7 +96,7 @@ knowledgeBaseParameters:
     dataSourcePrefix: knowledge-base-data-source
 ```
 
-The Terraform mirror exposes the same option as `vector_store_type` on `knowledge_base_parameters` in `terraform.tfvars`.
+The Terraform mirror exposes the same option as `vector_store_type` on `knowledge_base` in `terraform.tfvars`.
 
 The setting only affects the **default knowledge base provisioned by the stack**. Knowledge bases created from the UI ([Creating New Knowledge Bases](#creating-new-knowledge-bases)) are not affected by this flag.
 


### PR DESCRIPTION
## Summary

Three small, related improvements to the developer experience around IaC config and the Knowledge Base feature: a new `kb-management.md` section that documents the `vectorStoreType` option (OpenSearch Serverless vs. S3 Vectors) and its real-world limitations, a new `iac-config-generator`
skill that produces matched `config.yaml` + `terraform.tfvars` pairs from a feature description, and a one-line `tf-clean` fix so the target actually wipes nested module `.terraform/` dirs.

## Changes

- **Docs (`docs/src/kb-management.md`, `architecture.md`, `how-to-deploy.md`):** new "Vector Store Backend" section with a comparison table, an example YAML snippet, and a "Limitations" subsection sourced from the Bedrock KB and S3 Vectors AWS docs (no hybrid search, no binary embeddings,
limited filter operators, 1 KB per-vector metadata cap, throughput ceiling, switch-replaces-store warning). Cross-linked from `architecture.md` and `how-to-deploy.md`.
- **Skill (`.claude/skills/iac-config-generator/`):** `SKILL.md` plus two reference files — `feature-matrix.md` (every feature, required vs. optional fields, defaults, inter-feature constraints) and `cdk-tf-mapping.md` (CDK ↔ Terraform field translation table, including the
chunking-strategy shape divergence and the MCP `url`/`authType` gap on the Terraform side). Outputs always go to `cache/local-cfg/` in both shapes.
- **Tooling (`Makefile`):** `tf-clean` now does `find iac-terraform -type d -name .terraform -exec rm -rf {} +` so it recurses into module subdirectories instead of only deleting the top-level `iac-terraform/.terraform`.

## Test plan

- [x] `make tf-clean` removes `.terraform/` dirs in nested modules (e.g. `iac-terraform/modules/*/`), not just the root.
- [x] Render `docs/src/kb-management.md` in the docs site and confirm the new section + table render correctly and the cross-links from `architecture.md` / `how-to-deploy.md` resolve to the right anchor.
- [x] Invoke the `iac-config-generator` skill with a sample prompt (e.g. "minimal config with KB and observability"); confirm it writes both `cache/local-cfg/config.yaml` and `cache/local-cfg/terraform.tfvars` and that the `dataSourcePrefix` matches between the Data Processing and KB
blocks in each file.
- [x] No code paths changed — no need to redeploy.

## Notes

- ASH was skipped: all changed files are `.md`, `.claude/**`, or a 2-line shell tweak in the `Makefile` — none are in scanner scope (no `.py`/`.ts`/`.tf`/`.yaml` under `iac-*/`, no Dockerfiles).
- Code review surfaced one issue, fixed in commit `6899fb0`: `kb-management.md` referred to the Terraform variable as `knowledge_base_parameters`; the actual variable is `knowledge_base` (per `iac-terraform/variables.tf`). Users copying the wording would have hit a "reference to undeclared
input variable" error.