### PR TITLE
✨ (agent-creator): add Claude Code plugin to drive Agent Factory

### DIFF
--- a/.claude/.claude-plugin/marketplace.json
+++ b/.claude/.claude-plugin/marketplace.json
@@ -1,0 +1,11 @@
+{
+  "name": "agent-creator-marketplace",
+  "owner": { "name": "Paolo Irrera" },
+  "plugins": [
+    {
+      "name": "agent-creator",
+      "source": "./plugins/agent-creator",
+      "description": "Create and update AgentCore runtime agents in a deployed instance of this accelerator via the Agent Factory API."
+    }
+  ]
+}

--- a/.claude/plugins/agent-creator/.claude-plugin/plugin.json
+++ b/.claude/plugins/agent-creator/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "agent-creator",
+  "description": "Create and update AgentCore runtime agents in a DEPLOYED instance of this accelerator. Use whenever the user wants to create a new agent, build an orchestrator/swarm/graph agent, add or remove tools/MCP-servers/skills from an existing agent, change an agent's model or system prompt, or otherwise modify a live runtime agent via the Agent Factory API. NOT for generating IaC config.yaml/tfvars — that is iac-config-generator.",
+  "author": { "name": "Paolo Irrera" }
+}

--- a/.claude/plugins/agent-creator/README.md
+++ b/.claude/plugins/agent-creator/README.md
@@ -1,5 +1,108 @@
 # agent-creator
 
-Create and update AgentCore runtime agents in a **deployed** instance of this accelerator. Use whenever the user wants to create a new agent, build an orchestrator/swarm/graph agent, add or remove tools/MCP-servers/skills from an existing agent, change an agent's model or system prompt, or otherwise modify a live runtime agent via the Agent Factory API.
+A Claude Code plugin that creates and modifies **live AgentCore runtime agents** in a
+**deployed** instance of this accelerator — the same agents you'd otherwise build by
+clicking through the Agent Factory UI, driven instead from a conversation in your editor.
 
-**Not** for generating IaC `config.yaml`/`tfvars` — that is the `iac-config-generator` skill.
+You describe what you want ("an orchestrator that consults an AWS-docs specialist and a
+cost specialist, then writes the recommendation"); the plugin picks the right agentic
+pattern, wires it from the building-blocks already in your running system (tools, MCP
+servers, skills, existing agents), validates the config with parity to the server, and
+submits it through the same GraphQL mutation the UI uses — polling until the runtime is
+**Ready**.
+
+> **This plugin talks to a *deployed* stack over the Agent Factory API.** It does **not**
+> generate IaC. For build-time, baked-into-the-stack config (`config.yaml` / `tfvars`),
+> use the `iac-config-generator` skill instead.
+
+## When to use it
+
+Invoke it (via `/agent-creator:agent-creator`, or just describe the task) when you want to:
+
+- **Create** a new runtime agent — single, or a multi-agent orchestrator / swarm / graph.
+- **Modify** a live agent — change its model or system prompt, add/remove tools, MCP
+  servers, or skills.
+- **Diagnose** a misbehaving agent from traces / eval output, and apply the config-level fix.
+- **Author a skill** — a reusable, loadable instruction package an agent picks up at start,
+  live with no redeploy.
+
+## The four paths
+
+| Path | You say… | What it does |
+|---|---|---|
+| **Create** | "build an agent that…" | Picks the architecture pattern, assembles from registries, validates, submits, polls to Ready. |
+| **Modify** | "change the model on…", "remove skills from…" | Read–modify–write: fetches the **full** current config, changes only what you asked, re-submits the whole config as a new version. |
+| **Diagnose** | "it picks the wrong tool, here are the traces" | Maps observed misbehavior to a config root cause, then applies the fix via the modify path. |
+| **Author a skill** | "create a skill that teaches the agent to…" | CRUD on the live skill registry (S3) — no redeploy — then attaches the skill to an agent. |
+
+## Architecture patterns it can build
+
+The plugin classifies your request into one of four patterns (it decides — you don't have
+to name it):
+
+- **Single** — one agent, one job (tools + MCP + skills, optional structured output).
+- **Agents as Tools** — a coordinator that delegates to specialist sub-agents it chooses at
+  runtime.
+- **Swarm** — peer agents that hand control to each other collaboratively, with emergent
+  order.
+- **Graph** — a fixed, author-defined workflow of nodes and edges with shared state.
+
+Multi-agent patterns reference sub-agents that must already exist (and, for Agents-as-Tools
+and Graph, have an **A2A twin**), so the plugin builds bottom-up: specialists first, the
+coordinator last.
+
+## What makes it safe to iterate
+
+The server's config validation is strict and **silent** — a bad config is rejected by
+returning an empty string with no reason. The plugin's local validator (`validate_config.py`)
+has **parity with the server**, so problems are caught locally with an explanation instead
+of as a silent server reject. And because there is no partial-update mutation, every
+modification is a **full-config replacement** that mints a new version — which is why the
+modify path always re-submits the whole config, never a patch.
+
+> Every submit is validated and polled to Ready, but **not behaviorally tested** — static
+> validation only. After a create or modify, run the agent in the UI to confirm it actually
+> behaves as intended.
+
+## How it's invoked
+
+The plugin's scripts share Cognito auth and endpoint discovery against your deployed stack;
+the first call prompts once for credentials and caches them in a gitignored `.env`. The
+skill (`skills/agent-creator/SKILL.md`) drives the whole flow — you interact in natural
+language and confirm before anything is submitted.
+
+## Sample prompts
+
+You don't name the architecture — the plugin infers it from the shape of what you describe.
+The four prompts below each steer it toward a different pattern; use them as starting points.
+
+**Single — one agent, one job:**
+
+> "Create an agent that answers AWS questions from the official docs — it should search the
+> documentation, cite a URL for every claim, and say so when the docs don't cover something."
+
+**Agents as Tools — a coordinator that decides who to consult at runtime:**
+
+> "Build something that, given a workload description, recommends an AWS architecture. One
+> part digs through the AWS docs to pick services and cite best practices; another reasons
+> about cost and sizing. Add a layer on top that decides which to consult, then writes up
+> the final recommendation."
+
+**Graph — a fixed pipeline, same steps every time:**
+
+> "I want a fixed pipeline for AWS workload reviews. For every workload, always run a
+> docs/architecture specialist and a cost specialist in parallel, then merge their two
+> outputs into one combined recommendation. The steps never change."
+
+**Swarm — peers that hand off collaboratively, no fixed order:**
+
+> "Let a docs/architecture specialist and a cost specialist collaborate on AWS workload
+> reviews with no fixed script — hand the problem back and forth, the cost one pushing back
+> on anything too expensive, until they converge on a recommendation together."
+
+Modify, diagnose, and skill-authoring requests are just as conversational — e.g. "remove the
+skills from `pubmed_study_ideator`", "it keeps picking the wrong tool, here are the traces:
+…", or "create a skill that teaches the agent PubMed search craft."
+
+After a build, the plugin can suggest behavioral prompts to run the new agent against in the
+UI — confirming it actually routes, merges, or hands off as intended before you rely on it.

--- a/.claude/plugins/agent-creator/README.md
+++ b/.claude/plugins/agent-creator/README.md
@@ -1,0 +1,5 @@
+# agent-creator
+
+Create and update AgentCore runtime agents in a **deployed** instance of this accelerator. Use whenever the user wants to create a new agent, build an orchestrator/swarm/graph agent, add or remove tools/MCP-servers/skills from an existing agent, change an agent's model or system prompt, or otherwise modify a live runtime agent via the Agent Factory API.
+
+**Not** for generating IaC `config.yaml`/`tfvars` — that is the `iac-config-generator` skill.

--- a/.claude/plugins/agent-creator/skills/agent-creator/SKILL.md
+++ b/.claude/plugins/agent-creator/skills/agent-creator/SKILL.md
@@ -25,6 +25,9 @@ Read the user's phrasing and pick one branch before doing anything else:
 - **Modify** — "remove skills from agent XYZ", "change the model on my orchestrator",
   "add a tool to …" → the **Modify path** below. This is read-modify-write and has one
   rule that dominates everything (see there).
+- **Diagnose** — "the agent keeps doing X wrong, here's the eval / session / logs", "fix
+  this from these traces", "it picks the wrong tool" → the **Diagnose path** below. This
+  is a smarter front-end on the modify path.
 - **IaC redirect** — if the user wants a *build-time / baked-in* agent ("add this agent
   to config.yaml", "deploy a default agent with the stack") → **stop**. That is
   `iac-config-generator`'s job (edit config → redeploy). agent-creator only touches the
@@ -122,6 +125,44 @@ if XYZ was created by a *different stack/environment*, the update is blocked ser
 `submit_runtime.py` detects a terminal failure on an update and explains this — don't
 present it as a raw error.
 
+## Diagnose path (traces → config fix)
+
+The user hands you traces showing the agent misbehaving; you diagnose the **config-level**
+root cause and propose config edits, then re-submit via the modify path. The only new
+work here is *diagnosis* — everything after it is the modify path verbatim. The full
+symptom→fix table, trace-tier matrix, and the config-vs-tool-code-bug boundary are in
+[references/diagnosis.md](references/diagnosis.md); read it before diagnosing.
+
+**Scope honesty, state it to the user up front:** you edit *config*, so you fix issues
+whose root cause is config (prompt, tools, model params, conversation manager,
+architecture). A **bug inside a tool's implementation** is code, not config — flag it as
+out of scope and point at [custom-code.md](references/custom-code.md); don't pretend a
+config edit fixes it.
+
+Steps:
+
+1. **Identify the trace source & tier.** Tiers 0–1 are **profile-free**: tier 0 = a trace
+   the user pastes (no script); tier 1 = `scripts/fetch_traces.py --session <id>` or
+   `--evaluator <id>` (Cognito JWT). Tier 2 (deep) needs an **AWS profile**:
+   `--evaluator <id> --deep` (S3 trajectory) or `--xray --session-id <s>` (span logs). If
+   the user asks for a deep diagnosis and no profile is available, `fetch_traces.py`
+   degrades gracefully with a clear message — relay it and offer the tier-0/1 alternative
+   rather than treating it as a hard failure.
+2. **Fetch** (or read the pasted trace). The script emits normalized
+   `{tier, source, issues_observed, raw}`.
+3. **Diagnose** — map each observed issue to a config root cause using the table in
+   [references/diagnosis.md](references/diagnosis.md). State your confidence per finding,
+   and explicitly flag anything that looks like a tool-code bug (out of scope).
+4. `scripts/fetch_agent_config.py --agent XYZ` → the full current config.
+5. **Propose targeted edits to the FULL config** (never a patch — same rule as the modify
+   path). Show before/after and explain *why* each edit addresses which observed issue.
+6. `scripts/validate_config.py` → on confirmation, `scripts/submit_runtime.py` → poll to
+   Ready.
+7. **Tell the user the fix is live but UNVERIFIED** (static-validation scope, D2). Give a
+   concrete way to confirm it actually helped: re-run the failing eval cases, or do a
+   manual UI run of the scenario from the trace. Closing that loop behaviorally is out of
+   scope for now.
+
 ## Reference files
 
 - [references/architectures.md](references/architectures.md) — the 4 patterns, the
@@ -136,6 +177,8 @@ present it as a raw error.
   schema field-shape traps (source of truth: `src/api/schema/schema.graphql`).
 - [references/custom-code.md](references/custom-code.md) — scaffolding a missing tool /
   state class / deterministic node, with the redeploy warning (task 07).
+- [references/diagnosis.md](references/diagnosis.md) — the diagnose path: symptom→config-fix
+  table, the trace-tier/profile matrix, and the config-vs-tool-code-bug boundary (task 08).
 
 ## Why this design
 

--- a/.claude/plugins/agent-creator/skills/agent-creator/SKILL.md
+++ b/.claude/plugins/agent-creator/skills/agent-creator/SKILL.md
@@ -28,6 +28,10 @@ Read the user's phrasing and pick one branch before doing anything else:
 - **Diagnose** — "the agent keeps doing X wrong, here's the eval / session / logs", "fix
   this from these traces", "it picks the wrong tool" → the **Diagnose path** below. This
   is a smarter front-end on the modify path.
+- **Author a skill** — "create a skill for X", "add a skill that teaches the agent to …",
+  "update the `pubmed-search-craft` skill", "make a reusable instruction package" → the
+  **Skill-authoring path** below. A skill is loadable *expertise* (prose/procedure), live
+  with no redeploy — distinct from custom code (a tool/state/node needs a redeploy).
 - **IaC redirect** — if the user wants a *build-time / baked-in* agent ("add this agent
   to config.yaml", "deploy a default agent with the stack") → **stop**. That is
   `iac-config-generator`'s job (edit config → redeploy). agent-creator only touches the
@@ -163,6 +167,54 @@ Steps:
    manual UI run of the scenario from the trace. Closing that loop behaviorally is out of
    scope for now.
 
+## Skill-authoring path (live skill registry CRUD)
+
+A **skill** is a markdown instruction package the agent loads at start — reusable
+*expertise* (a procedure, a domain rubric, search heuristics), not code. It lives in the
+skills S3 bucket and any SINGLE agent references it by name in `skills[]`. Authoring or
+editing one is **live, no redeploy** (contrast: a tool/state/node is code baked into the
+container image — see [references/custom-code.md](references/custom-code.md)). All ops go
+through `scripts/manage_skill.py` (list/get/create/update/delete/resources/put-resource),
+which reuses the same Cognito JWT auth as every other script. Full mechanics, the
+decision table, and the merge-vs-replace contrast are in
+[references/skill-authoring.md](references/skill-authoring.md).
+
+1. **Decide skill-vs-prompt-vs-tool.** A skill earns its keep when the guidance is
+   reusable across agents/turns and too long to live inline in one agent's
+   `instructions`. If it's one agent's one-off behavior → just edit that agent's
+   `instructions` (modify path). If it needs to *execute code* → that's a tool
+   ([custom-code.md](references/custom-code.md), redeploy). Only genuine loadable
+   *expertise* → a skill.
+2. **Draft the body.** Imperative voice, explain *why*, progressive disclosure. Keep it
+   self-contained in the single `SKILL.md` body — resources (`scripts/`, `references/`)
+   are supported but **lightly exercised** (see the caveat in skill-authoring.md), so a
+   one-file body is the most reliable artifact.
+3. **Create** — write the body to a file, then `manage_skill.py create --name X
+   --description "…" --body-file body.md`. The script sends **body-only** content (strips
+   an accidental frontmatter block and warns — the registry owns frontmatter), validates
+   the name regex locally, and pre-checks uniqueness (clean "use `update` instead" rather
+   than a raw server error). Confirm, write. For an **update**, `manage_skill.py update`
+   **MERGES** — omit `--description` to keep it, omit `--body-file` to keep the body. This
+   is the **opposite** of the agent full-config-replace rule; don't carry that habit here.
+4. **Verify it registered** — `manage_skill.py list` (or `list_building_blocks.py --filter
+   skills`) shows it immediately; it's now a referenceable name.
+5. **Attach it** — hand off to the **modify path** for the target agent: fetch the FULL
+   config, append the new name to `skills[]`, re-submit the WHOLE config, poll to Ready.
+   The skill is live in S3 the instant it's created, but an *existing* agent only picks it
+   up at its next start — re-submitting the agent config mints a fresh version that loads
+   it.
+6. **Tell the user it's live but behaviorally UNVERIFIED** (static/registration confirmation
+   only). Suggest a UI run to confirm the agent actually loads and uses the skill.
+
+**Worked example (the canonical end-to-end demo):** `pubmed_study_ideator` has MeSH-term
+expansion, RCT/systematic-review field-tag filters, a date-window rule, and a PICO
+study-design rubric crammed into its `instructions`. Author a `pubmed-search-craft` skill
+encoding that guidance (`manage_skill.py create`), verify it lists, then attach it to
+`pubmed_study_ideator` via the modify path (fetch full config → add `"pubmed-search-craft"`
+to `skills[]` → `submit_runtime.py` → poll to Ready), and trim the now-redundant prose from
+`instructions` in the same re-submit. End by telling the user to run the agent in the UI to
+confirm it loads and uses the skill.
+
 ## Reference files
 
 - [references/architectures.md](references/architectures.md) — the 4 patterns, the
@@ -177,6 +229,9 @@ Steps:
   schema field-shape traps (source of truth: `src/api/schema/schema.graphql`).
 - [references/custom-code.md](references/custom-code.md) — scaffolding a missing tool /
   state class / deterministic node, with the redeploy warning (task 07).
+- [references/skill-authoring.md](references/skill-authoring.md) — the skill-authoring
+  path: skill-vs-prompt-vs-tool decision table, body-only/frontmatter-ownership rule,
+  merge-not-replace contrast, the resource caveat, and the skill GraphQL doc set (task 09).
 - [references/diagnosis.md](references/diagnosis.md) — the diagnose path: symptom→config-fix
   table, the trace-tier/profile matrix, and the config-vs-tool-code-bug boundary (task 08).
 

--- a/.claude/plugins/agent-creator/skills/agent-creator/SKILL.md
+++ b/.claude/plugins/agent-creator/skills/agent-creator/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: agent-creator
+description: Create and update AgentCore runtime agents in a DEPLOYED instance of this accelerator. Use whenever the user wants to create a new agent, build an orchestrator/swarm/graph agent, add or remove tools/MCP-servers/skills from an existing agent, change an agent's model or system prompt, or otherwise modify a live runtime agent via the Agent Factory API. NOT for generating IaC config.yaml/tfvars — that is iac-config-generator.
+---
+
+# Agent Creator
+
+<!-- body authored in task 6 -->

--- a/.claude/plugins/agent-creator/skills/agent-creator/SKILL.md
+++ b/.claude/plugins/agent-creator/skills/agent-creator/SKILL.md
@@ -5,4 +5,144 @@ description: Create and update AgentCore runtime agents in a DEPLOYED instance o
 
 # Agent Creator
 
-<!-- body authored in task 6 -->
+Create and update AgentCore runtime agents in a **live, deployed** accelerator. You
+assemble a configuration from building-blocks that already exist in the running system,
+validate it locally with parity to the server, and submit it through the same GraphQL
+mutation the Agent Factory UI uses. The artifact is a validated config that becomes a
+provisioned runtime — not prose, not IaC.
+
+All scripts live in `scripts/`. Run them with the project's Python env (`uv run python
+scripts/<name>.py …` from the repo root, or whatever invocation the user's environment
+uses for the other plugin scripts). They share auth/endpoint discovery — the first call
+prompts once for Cognito credentials and caches them in a gitignored `.env`.
+
+## Phase 0 — Fork: create, modify, or redirect (decide first)
+
+Read the user's phrasing and pick one branch before doing anything else:
+
+- **Create** — "make a new agent", "build an orchestrator that…", "I need an agent for X"
+  → the **Create path** below.
+- **Modify** — "remove skills from agent XYZ", "change the model on my orchestrator",
+  "add a tool to …" → the **Modify path** below. This is read-modify-write and has one
+  rule that dominates everything (see there).
+- **IaC redirect** — if the user wants a *build-time / baked-in* agent ("add this agent
+  to config.yaml", "deploy a default agent with the stack") → **stop**. That is
+  `iac-config-generator`'s job (edit config → redeploy). agent-creator only touches the
+  **live runtime** via the API. Say so and point them there.
+
+If the phrasing is ambiguous between create and modify, ask — the paths diverge
+immediately.
+
+## Create path — four phases
+
+### Phase 1 — Capture intent & pick architecture
+
+Interview the user, then drive the decision tree in
+[references/architectures.md](references/architectures.md). The short version:
+
+- one agent doing one job → **SINGLE**
+- a coordinator delegating to specialist sub-agents → **AGENTS_AS_TOOLS**
+- peer agents handing off collaboratively, no fixed order → **SWARM**
+- a fixed multi-step workflow with branching/state → **GRAPH**
+
+Capture: the model + inference params, the system prompt (`instructions`), the
+conversation manager, whether the agent needs memory, and a rough capability list (which
+becomes tools / MCP servers / skills in Phase 2). Don't over-interview — pick sensible
+defaults (e.g. `sliding_window` conversation manager, `useMemory: false`) and tell the
+user what you chose. The field-by-field shapes are in
+[references/config-schemas.md](references/config-schemas.md).
+
+### Phase 2 — Assemble from registries
+
+Run `scripts/list_building_blocks.py` and **save its output to a file** — both you and
+`validate_config.py` consume it. Map the user's capability list onto **existing** tools,
+MCP servers, skills, and (for orchestrator / graph / swarm) existing runtime agents.
+
+This is the real "writing" of an agent: wiring real, referenceable parts. If everything
+the user needs already exists in the registries, **no Python is required** — assemble and
+move to Phase 4. What each registry holds and how configs reference it is in
+[references/registries.md](references/registries.md).
+
+For orchestrator / graph patterns, note the **A2A-twin** requirement: a sub-agent can
+only be referenced if it has an A2A twin runtime (`agentRuntimeArnA2A` is non-null in the
+building-blocks `agents` list). `validate_config.py` enforces this; flag it here so the
+user isn't surprised.
+
+### Phase 3 — Scaffold custom Python (only if a block is missing)
+
+If a needed tool / graph state class / deterministic node is **not** in the registry,
+branch to [references/custom-code.md](references/custom-code.md) (task 07).
+
+**Warn up front**, before scaffolding: this requires editing `src/agent-core/` and a
+**full redeploy** before the agent can use the new block — it breaks the live-system
+immediacy that makes this plugin fast. Always offer the alternative of picking an
+existing block or reframing the capability. Only scaffold if the user accepts the
+redeploy cost.
+
+### Phase 4 — Validate & submit
+
+1. Assemble the full config JSON for the chosen architecture.
+2. `scripts/validate_config.py --config <file> --architecture <T> --building-blocks <Phase-2 file>`.
+   Fix everything it flags — it has parity with the server, which otherwise rejects bad
+   configs by silently returning `""`.
+3. *(Optional)* spawn the [config-reviewer](agents/config-reviewer.md) subagent for a
+   soft "is this any good" pass — does the prompt match the tools, are there unused
+   tools, is the conversation manager appropriate. Advisory only.
+4. Show the user the final config and get explicit confirmation. Then
+   `scripts/submit_runtime.py --config <file> --architecture <T> --agent <name>`. It
+   re-runs validation as a guard, submits, and **polls until the runtime is Ready** (the
+   mutation is fire-and-forget — a return doesn't mean live).
+5. Report the runtime summary it prints (id, version, ARNs, qualifier) and tell the user
+   it's now visible in the UI. **Remind them this version was not behaviorally tested** —
+   static validation only. Suggest a manual run in the UI before relying on it.
+
+## Modify path (read-modify-write)
+
+> **The one rule that dominates this path: fetch the FULL current config, change ONLY
+> what the user asked, and re-submit the WHOLE config.** Never assemble a partial. An
+> update is a full replacement that mints a new version — any field you omit is *wiped*.
+> If the user says "remove skills", you fetch the whole config, drop the `skills` field,
+> and submit everything else unchanged.
+
+Steps:
+
+1. `scripts/fetch_agent_config.py --agent XYZ` → the full current config + its
+   `architectureType`. This is the canonical DEFAULT-qualifier config.
+2. Show the user the current config and confirm the exact change ("remove skills" → drop
+   `skills`; "change model" → edit `modelInferenceParameters.modelId`; "add tool Z" →
+   append to `tools`, and add Z's entry to `toolParameters` if it needs params).
+3. Apply the edit to the **in-memory full config** — keep every other field as-is.
+4. `scripts/validate_config.py` on the modified full config (with building-blocks).
+5. `scripts/submit_runtime.py --agent XYZ` → new version, polled to Ready.
+6. *(Optional)* point an endpoint at the new version with `--tag <qualifier>` (DEFAULT
+   advances automatically; this is only for additional qualifiers).
+
+**Tag-match guard caveat** (see [references/update-semantics.md](references/update-semantics.md)):
+if XYZ was created by a *different stack/environment*, the update is blocked server-side.
+`submit_runtime.py` detects a terminal failure on an update and explains this — don't
+present it as a raw error.
+
+## Reference files
+
+- [references/architectures.md](references/architectures.md) — the 4 patterns, the
+  decision tree, and the config block each needs.
+- [references/config-schemas.md](references/config-schemas.md) — the 4 config shapes
+  field-by-field, each with a filled example. The human companion to `validate_config.py`.
+- [references/registries.md](references/registries.md) — what each registry holds, how
+  configs reference it, and which GraphQL query lists each.
+- [references/update-semantics.md](references/update-semantics.md) — read-modify-write,
+  full-config-not-patch, new-version-per-update, the tag-match guard, DEFAULT advancement.
+- [references/queries.md](references/queries.md) — curated GraphQL documents and the
+  schema field-shape traps (source of truth: `src/api/schema/schema.graphql`).
+- [references/custom-code.md](references/custom-code.md) — scaffolding a missing tool /
+  state class / deterministic node, with the redeploy warning (task 07).
+
+## Why this design
+
+The hard part of an agent here isn't prose — it's picking the right **architecture
+pattern** and wiring **real registry building-blocks** into a config the server will
+accept. The server's validation is unforgiving and *silent* (it returns `""` with no
+reason), so local validation parity is the safety net that lets you iterate without
+guessing. And because there's no separate update mutation, every modification is a
+full-config replacement — which is why the modify path's full-config rule is stated so
+emphatically: a careless partial silently destroys an agent's configuration.

--- a/.claude/plugins/agent-creator/skills/agent-creator/agents/config-reviewer.md
+++ b/.claude/plugins/agent-creator/skills/agent-creator/agents/config-reviewer.md
@@ -1,0 +1,95 @@
+# Config Reviewer Agent
+
+Sanity-check an assembled agent config the way a careful reviewer would, **before** it's
+submitted. This is the soft "is this any good?" pass — advisory only.
+
+## Role
+
+`validate_config.py` is the hard gate: it decides whether the server will *accept* the
+config. You answer a different question — whether the config is *sensible*. A config can
+pass validation and still be poorly assembled (a prompt that never uses its tools, a
+conversation manager that fights the model, an orchestrator whose sub-agents don't cover
+the job it describes). You surface those issues so the human can fix them before
+provisioning a mediocre agent.
+
+You do **not** block submission and you do **not** re-run schema validation. You report;
+the human decides.
+
+## Inputs
+
+You receive in your prompt:
+
+- **config**: the assembled config JSON (or a path to it).
+- **architecture**: `SINGLE | SWARM | GRAPH | AGENTS_AS_TOOLS`.
+- **building_blocks**: the `list_building_blocks.py` JSON (or a path), so you can read
+  tool/sub-agent descriptions rather than guessing what a name does.
+- **intent** (optional): the user's description of what the agent is for.
+
+## What to check
+
+Adapt to the architecture, but cover these dimensions:
+
+**Prompt ↔ tools coherence**
+- Does `instructions` actually direct the agent to use the tools/MCP/skills it lists?
+- Are there tools listed that the prompt never references (dead capability)?
+- Does the prompt ask for behavior that *needs* a tool that isn't listed (missing
+  capability)?
+
+**Model & inference fit**
+- Is the conversation manager appropriate? (`summarizing` for long multi-turn;
+  `sliding_window` default; `null` only for stateless one-shots.)
+- Do `maxTokens` / `temperature` suit the job? (low temperature for analysis/extraction;
+  higher for creative; enough `maxTokens` for the expected output + any structured
+  fields.)
+- If `structuredOutput` is set, does the prompt tell the model to produce those fields?
+- Is `reasoningBudget` consistent with the model family (int vs effort string)?
+
+**Architecture-specific**
+- **AGENTS_AS_TOOLS**: read each sub-agent's `description` from building_blocks — do the
+  referenced sub-agents actually cover the job the orchestrator's prompt describes? Is
+  the orchestrator prompt clear about *when* to delegate to which?
+- **SWARM**: is the `entryAgent` the right starting point? Are the handoff/iteration
+  limits sane for the collaboration described?
+- **GRAPH**: does the node/edge flow match the described process? Any node whose
+  `promptTemplate` references state fields not in `stateSchema`/`stateClass`? Dead-end or
+  unreachable nodes that still technically validate?
+
+**General smells**
+- Vague or empty `instructions`.
+- `useMemory: true` for an agent with no multi-turn need (cost with no benefit), or
+  `false` where the job clearly needs continuity.
+- Over-broad tool sets ("kitchen sink" agents).
+
+## Output format
+
+Return a short structured report — findings, not a rewrite:
+
+```json
+{
+  "verdict": "ship | revise | reconsider",
+  "summary": "One or two sentences on overall fit.",
+  "findings": [
+    {
+      "severity": "high | medium | low",
+      "dimension": "prompt-tools | model-fit | architecture | general",
+      "issue": "Specific, cites the field/name.",
+      "suggestion": "Concrete change."
+    }
+  ]
+}
+```
+
+- `ship` — no material issues; safe to submit.
+- `revise` — works, but has fixable issues worth addressing first.
+- `reconsider` — likely won't do the job as assembled (e.g. sub-agents don't cover the
+  task); rethink before submitting.
+
+## Guidelines
+
+- **Advisory, not gatekeeping.** Never say "do not submit"; say what you'd improve and why.
+- **Be specific.** Cite the field or name (`tools[2] "web_search"`, `nodes "review"`).
+- **Read descriptions, don't assume.** Use building_blocks to know what a tool/sub-agent
+  actually does before judging coherence.
+- **Don't duplicate `validate_config.py`.** Schema/registry/A2A correctness is its job —
+  only mention those if you spot something it would *not* catch (e.g. a semantic mismatch).
+- **Brevity.** A few sharp findings beat an exhaustive list.

--- a/.claude/plugins/agent-creator/skills/agent-creator/references/architectures.md
+++ b/.claude/plugins/agent-creator/skills/agent-creator/references/architectures.md
@@ -1,0 +1,77 @@
+# Architecture patterns & decision tree
+
+Four architecture types, set by the `architectureType` argument to
+`createAgentCoreRuntime` (`SINGLE | SWARM | GRAPH | AGENTS_AS_TOOLS`, default `SINGLE`).
+Each maps to a different Pydantic config shape (see
+[config-schemas.md](config-schemas.md)) and a different Docker container in
+`src/agent-core/`. Pick the pattern *first* — it determines every field that follows.
+
+## Decision tree
+
+```
+Is there more than one agent involved?
+├─ No → SINGLE
+│        One agent, one job. Tools + MCP + skills, optional structured output.
+│        Most agents are this. Start here unless the user clearly needs multiple agents.
+│
+└─ Yes → How do the agents relate?
+    ├─ One coordinator calls specialists as tools, decides who/when → AGENTS_AS_TOOLS
+    │        The orchestrator is the only agent the user talks to; sub-agents are
+    │        invisible "tools". The orchestrator's LLM chooses which to call.
+    │
+    ├─ Peers hand control to each other, no fixed order, collaborative → SWARM
+    │        Agents pass the conversation between themselves until one finishes.
+    │        Order emerges at runtime; there's an entry agent but no script.
+    │
+    └─ A fixed, author-defined flow of steps with branching / shared state → GRAPH
+             A directed graph: nodes (agents or deterministic functions) wired by
+             edges, possibly conditional. Use when the steps and their order are known
+             up front (e.g. "research → draft → review → maybe revise → done").
+```
+
+Tie-breakers:
+
+- **AGENTS_AS_TOOLS vs SWARM**: is there a clear boss? If one agent should stay in
+  control and merely *delegate*, that's agents-as-tools. If the agents are peers that
+  genuinely hand off ("now you take over"), that's a swarm.
+- **SWARM vs GRAPH**: is the flow *emergent* (let the agents decide) or *prescribed*
+  (the author knows the steps)? Emergent → swarm. Prescribed → graph.
+- **When unsure, prefer SINGLE.** Multi-agent patterns add latency, cost, and failure
+  surface. Only reach for them when one agent genuinely can't do the job.
+
+## A2A-twin requirement (orchestrator & graph)
+
+`AGENTS_AS_TOOLS` and `GRAPH` invoke their sub-agents over **A2A** (agent-to-agent).
+Every referenced sub-agent must therefore have an **A2A twin runtime** — surfaced as a
+non-null `agentRuntimeArnA2A` in `list_building_blocks.py`'s `agents` list. A sub-agent
+without a twin cannot be referenced; the server rejects the config (and
+`validate_config.py` catches it locally). If a needed sub-agent lacks a twin, recreate it
+so the twin is provisioned. `SWARM` references agents by name/endpoint and does not
+require a twin in the same way, but the referenced agents must still exist.
+
+## Per-pattern config block (what's distinctive)
+
+Full field lists and examples are in [config-schemas.md](config-schemas.md). The
+distinguishing piece of each:
+
+| Architecture | Model the resolver validates against | Distinctive field(s) |
+|---|---|---|
+| `SINGLE` | `AgentConfiguration` | `tools`, `toolParameters`, `mcpServers`, `skills`, optional `structuredOutput` |
+| `AGENTS_AS_TOOLS` | `AgentsAsToolsConfiguration` | `agentsAsTools[]` (sub-agent `runtimeId` + `endpoint`); orchestrator's own `instructions` + model; optional extra `tools`/`mcpServers` |
+| `SWARM` | `SwarmConfiguration` | `agentReferences[]` (agentName + endpointName), `entryAgent`, `orchestrator` (handoff/iteration limits) |
+| `GRAPH` | `GraphConfiguration` | `nodes[]` (agent / deterministic / fork / dynamic_map), `edges[]` (optionally conditional), `entryPoint`, `stateSchema`/`stateClass`, `orchestrator` |
+
+Notes that affect assembly:
+
+- **AGENTS_AS_TOOLS** sub-agents are referenced by `runtimeId` (the HTTP runtime ID the
+  UI surfaces). The server rewrites this to the A2A twin ARN at save time — you submit
+  the HTTP id, not the ARN. On re-submit of an already-saved config the `runtimeId` may
+  already be an ARN; that's fine (idempotent).
+- **GRAPH** nodes come in kinds: an *agent* node (`agentName` set, invokes a runtime), a
+  *deterministic* node (`deterministicNodeKey` set, pure-Python from the registry), a
+  *fork* node, and a *dynamic_map* node. Only agent nodes need an A2A twin. Every
+  non-terminal, non-dynamic_map node needs at least one outgoing edge; `__end__` is the
+  terminal target. Custom state classes / deterministic nodes that don't exist yet
+  require scaffolding (Phase 3 / [custom-code.md](custom-code.md)).
+- **SWARM** `entryAgent` must be one of the `agentReferences[]` names (enforced by the
+  model). Handoff/iteration/timeout limits live in `orchestrator` and have safe defaults.

--- a/.claude/plugins/agent-creator/skills/agent-creator/references/config-schemas.md
+++ b/.claude/plugins/agent-creator/skills/agent-creator/references/config-schemas.md
@@ -1,0 +1,208 @@
+# Config schemas — field by field
+
+The human companion to `validate_config.py`. Source of truth: the Pydantic models in
+`src/shared/layers/python-sdk/genai_core/api_helper/types.py` (which `validate_config.py`
+imports directly, so this file and the validator can't disagree on *rules* — but keep
+this doc in sync when the models change). The `configValue` you submit is the
+JSON-serialized form of one of these models, chosen by `architectureType`.
+
+## Contents
+
+- [Shared building blocks](#shared-building-blocks) — `ModelConfiguration`,
+  `InferenceConfig`, `conversationManager`, `StructuredOutputFieldSpec`
+- [SINGLE — `AgentConfiguration`](#single--agentconfiguration)
+- [AGENTS_AS_TOOLS — `AgentsAsToolsConfiguration`](#agents_as_tools--agentsastoolsconfiguration)
+- [SWARM — `SwarmConfiguration`](#swarm--swarmconfiguration)
+- [GRAPH — `GraphConfiguration`](#graph--graphconfiguration)
+
+---
+
+## Shared building blocks
+
+### `modelInferenceParameters` (`ModelConfiguration`)
+
+```jsonc
+{
+  "modelId": "us.amazon.nova-2-lite-v1:0",   // Bedrock model id / inference profile
+  "parameters": {                             // InferenceConfig
+    "maxTokens": 3000,
+    "temperature": 0.2,
+    "stopSequences": null                     // optional list[str]
+  },
+  "reasoningBudget": null                      // optional: int (>=1024) OR "low"/"medium"/"high"
+}
+```
+
+- `reasoningBudget`: omit / null = no reasoning. An integer (min 1024) for token-budget
+  models, or a string effort level for effort-based models. Match it to the model family.
+
+### `conversationManager` (`EConversationManagerType`)
+
+One of `"null"` (no history), `"sliding_window"` (default — recent messages),
+`"summarizing"` (summarize older messages). Default to `sliding_window` unless the user
+has a reason otherwise.
+
+### `structuredOutput` (`list[StructuredOutputFieldSpec]`, SINGLE only, optional)
+
+Each field: `{ "name": "...", "pythonType": "str", "description": "...", "optional": false }`.
+`pythonType` is a string like `"str"`, `"int"`, `"list[str]"`. Use when the agent must
+return machine-parseable fields rather than free text.
+
+---
+
+## SINGLE — `AgentConfiguration`
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `modelInferenceParameters` | `ModelConfiguration` | ✅ | see above |
+| `instructions` | `str` | ✅ | the system prompt |
+| `tools` | `list[str]` | ✅ (may be `[]`) | tool-registry names |
+| `toolParameters` | `dict[str, dict]` | ✅ (may be `{}`) | **every key must be a name in `tools`** |
+| `mcpServers` | `list[str]` | ✅ (may be `[]`) | MCP-registry names |
+| `conversationManager` | enum | default `sliding_window` | |
+| `useMemory` | `bool` | default `false` | attach AgentCore Memory |
+| `skills` | `list[str]` | default `[]` | skill names |
+| `structuredOutput` | `list[StructuredOutputFieldSpec]` | optional | |
+| `description` | `str` | optional | shown to other agents over A2A (agent-card description) |
+
+```json
+{
+  "modelInferenceParameters": {
+    "modelId": "us.amazon.nova-2-lite-v1:0",
+    "parameters": { "maxTokens": 3000, "temperature": 0.2, "stopSequences": null },
+    "reasoningBudget": null
+  },
+  "instructions": "Analyze the given topic from an economic perspective.",
+  "tools": [],
+  "toolParameters": {},
+  "mcpServers": [],
+  "conversationManager": "sliding_window",
+  "useMemory": false,
+  "skills": [],
+  "structuredOutput": null,
+  "description": "Handles analysis from an economic point of view"
+}
+```
+
+**Validator:** every `toolParameters` key must appear in `tools` — else
+`toolParameters keys {…} not found in tools`.
+
+---
+
+## AGENTS_AS_TOOLS — `AgentsAsToolsConfiguration`
+
+The orchestrator. `agentsAsTools[]` are sub-agents exposed to it as tools.
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `agentsAsTools` | `list[AgentAsToolReference]` | ✅ (≥1) | each `{ "runtimeId": "...", "endpoint": "..." }` |
+| `modelInferenceParameters` | `ModelConfiguration` | ✅ | orchestrator's model |
+| `instructions` | `str` (non-empty) | ✅ | orchestrator's system prompt |
+| `tools` | `list[str]` | optional | extra non-agent tools |
+| `toolParameters` | `dict[str, dict]` | optional | |
+| `mcpServers` | `list[str]` | optional | |
+| `conversationManager` | enum | default `sliding_window` | |
+| `useMemory` | `bool` | default `false` | |
+
+```json
+{
+  "agentsAsTools": [
+    { "runtimeId": "economical_analyst-aMBZbUFDFd", "endpoint": "DEFAULT" },
+    { "runtimeId": "creative_writer-Mk7vps6n4i", "endpoint": "DEFAULT" }
+  ],
+  "modelInferenceParameters": {
+    "modelId": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "parameters": { "maxTokens": 4096, "temperature": 0.3 }
+  },
+  "instructions": "You coordinate specialists. Delegate analysis to the economical_analyst and prose to the creative_writer; synthesize their outputs.",
+  "tools": null,
+  "toolParameters": null,
+  "mcpServers": null,
+  "useMemory": false
+}
+```
+
+**Validators:** `tools` and `toolParameters` must both be present or both omitted; any
+`toolParameters` key must be in `tools`. Each `runtimeId` must resolve to a runtime with
+an **A2A twin** (the server rewrites `runtimeId` → A2A ARN; missing twin = rejection).
+Submit the HTTP `runtimeId`, not the ARN.
+
+---
+
+## SWARM — `SwarmConfiguration`
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `agentReferences` | `list[AgentReference]` | ✅ (≥1) | each `{ "agentName": "...", "endpointName": "..." }` |
+| `entryAgent` | `str` | ✅ | **must be one of the `agentReferences` names** |
+| `orchestrator` | `SwarmOrchestratorConfig` | default | handoff/iteration/timeout limits |
+| `conversationManager` | enum | default `sliding_window` | |
+
+`orchestrator` defaults: `maxHandoffs=20`, `maxIterations=20`,
+`executionTimeoutSeconds=900`, `nodeTimeoutSeconds=300`,
+`repetitiveHandoffDetectionWindow=8`, `repetitiveHandoffMinUniqueAgents=3`. Constraints:
+`nodeTimeoutSeconds ≤ executionTimeoutSeconds`; `detectionWindow > minUniqueAgents`.
+
+```json
+{
+  "agentReferences": [
+    { "agentName": "economical_analyst", "endpointName": "DEFAULT" },
+    { "agentName": "creative_writer", "endpointName": "DEFAULT" }
+  ],
+  "entryAgent": "economical_analyst",
+  "orchestrator": {
+    "maxHandoffs": 20, "maxIterations": 20,
+    "executionTimeoutSeconds": 900.0, "nodeTimeoutSeconds": 300.0,
+    "repetitiveHandoffDetectionWindow": 8, "repetitiveHandoffMinUniqueAgents": 3
+  },
+  "conversationManager": "sliding_window"
+}
+```
+
+**Validators:** `entryAgent` ∈ `agentReferences` names; reference names unique; the
+`orchestrator` timeout/window constraints above.
+
+---
+
+## GRAPH — `GraphConfiguration`
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `nodes` | `list[GraphNodeDefinition]` | ✅ (≥1) | see node kinds below |
+| `edges` | `list[GraphEdgeDefinition]` | default `[]` | `{ "source", "target", "condition?" }` |
+| `entryPoint` | `str` | ✅ | **must be a node id** |
+| `stateSchema` | `dict[str,str]` | default `{}` | ad-hoc shared-state fields |
+| `stateClass` | `str` | optional | a registered state class key (instead of `stateSchema`) |
+| `orchestrator` | `GraphOrchestratorConfig` | default | `maxIterations=50`, `executionTimeoutSeconds=300`, `nodeTimeoutSeconds=60` |
+
+**Node kinds** (`GraphNodeDefinition`, mutually exclusive identity):
+
+- **Agent node** — `agentName` set (+ `endpointName`, default `"DEFAULT"`). Invokes a
+  runtime; needs an A2A twin.
+- **Deterministic node** — `deterministicNodeKey` set; a registered pure-Python function.
+- **Fork node** — `nodeType: "fork"`; pass-through fan-out.
+- **Dynamic map node** — `nodeType: "dynamic_map"` (+ `dynamicMapConfig`); `Send()`-based
+  fan-out. Handles its own outgoing edges.
+
+Optional per node: `label`, `promptTemplate` (with `{variable}` placeholders).
+
+```json
+{
+  "nodes": [
+    { "id": "research", "agentName": "economical_analyst", "endpointName": "DEFAULT" },
+    { "id": "write", "agentName": "creative_writer", "endpointName": "DEFAULT" }
+  ],
+  "edges": [
+    { "source": "research", "target": "write" },
+    { "source": "write", "target": "__end__" }
+  ],
+  "entryPoint": "research",
+  "stateSchema": {},
+  "orchestrator": { "maxIterations": 50, "executionTimeoutSeconds": 300.0, "nodeTimeoutSeconds": 60.0 }
+}
+```
+
+**Validators:** node ids unique; `entryPoint` is a node id; every edge `source` is a node
+and `target` is a node or `__end__`; every non-terminal, non-`dynamic_map` node has ≥1
+outgoing edge; `nodeTimeoutSeconds ≤ executionTimeoutSeconds`. Plus the server checks
+every agent node references an existing agent **with an A2A twin**.

--- a/.claude/plugins/agent-creator/skills/agent-creator/references/custom-code.md
+++ b/.claude/plugins/agent-creator/skills/agent-creator/references/custom-code.md
@@ -1,0 +1,259 @@
+# Custom-code scaffolding — the escape hatch
+
+The common case is pure assembly: everything the agent needs already exists in the
+registries, zero Python. This file is for the **minority case** where a needed
+building-block doesn't exist yet.
+
+> ## ⚠️ Read this before scaffolding anything
+>
+> **Tools, graph state classes, and deterministic nodes live in the container image.
+> Adding one requires editing `src/agent-core/` *and* `config.yaml`, then a full
+> `make deploy` (rebuilds + redeploys the image) before the new block exists in the
+> system.** This breaks agent-creator's whole premise of modifying a *live* runtime
+> instantly — the agent that needs the new block cannot be created/updated until the
+> redeploy finishes.
+>
+> Before going down this path: **offer the alternatives.** Can an existing block do the
+> job? Can the capability be reframed onto an existing tool? Can it be an **MCP server**
+> or **skill** instead (those add to a live system with *no redeploy* — see below)? Only
+> scaffold container code if the user accepts the redeploy cost.
+>
+> And whatever you scaffold is a **stub with `TODO`s** — the wiring, not the business
+> logic. Never tell the user a scaffolded tool is usable by a live agent until they've
+> filled in the logic *and* redeployed.
+
+## Route decision table
+
+"I need capability X that isn't in the registry" → pick the route:
+
+| Capability | Route | Where it lives | Redeploy? |
+|---|---|---|---|
+| A Python tool function | **New tool** | `src/agent-core/shared/base_registry.py` + `config.yaml` `toolRegistry` | **Yes** |
+| Shared state for a graph workflow | **New state class** | `src/agent-core/docker-graph/src/states/` + `config.yaml` `stateClassRegistry` | **Yes** |
+| A pure-Python graph step (no LLM) | **New deterministic node** | `src/agent-core/docker-graph/src/states/` + `config.yaml` `deterministicNodeRegistry` | **Yes** |
+| External tool surface over MCP | **New MCP server** | `registerMcpServer` mutation (preferred) *or* `config.yaml` `mcpServerRegistry` | **No** via mutation |
+| Prose/script skill the agent loads | **New skill** | `createSkill` mutation | **No** |
+
+Route to the no-redeploy option whenever it fits the need.
+
+---
+
+## 1. New tool (redeploy)
+
+A registry `Tool` entry is **inert** unless its name also has a `TOOL_FACTORY_MAP` entry
+(verified in `base_registry.py:load_tools_from_dynamodb` — it only loads tools whose
+`ToolName` is a key in the factory map; the sole exception is the built-in
+`retrieve_from_kb` KB tool). So a live tool needs **all three** pieces — miss any one and
+the tool silently never appears.
+
+### (a) Implementation — `src/agent-core/shared/base_registry.py`
+
+Simplest form is a `@tool` function (the file has a commented `get_weather_forecast`
+example to mirror):
+
+```python
+from strands import tool  # already imported in this module
+
+@tool(description="One-line description the model sees when choosing this tool.")
+def my_new_tool(query: str) -> str:
+    """Longer docstring: what it does, args, returns.
+
+    Args:
+        query: TODO describe the input.
+    """
+    # TODO: implement the real logic. This stub returns a placeholder.
+    raise NotImplementedError("my_new_tool is a scaffold — implement before deploy.")
+```
+
+For a tool that needs configuration/clients at construction time, subclass
+`AbstractToolObject` instead (see `RetrieverTool` in the same file) and expose a factory
+method on `ToolFactory`.
+
+### (b) Factory registration — `TOOL_FACTORY_MAP` (same file)
+
+```python
+TOOL_FACTORY_MAP = {
+    # ...existing entries...
+    "my_new_tool": lambda: my_new_tool,   # name MUST equal the toolRegistry name
+}
+```
+
+For an `AbstractToolObject`, point the value at the `ToolFactory.create_*` staticmethod
+that returns `tool_instance.tool`.
+
+### (c) Registry seed — `config.yaml` `toolRegistry`
+
+```yaml
+toolRegistry:
+    - name: my_new_tool          # MUST match the TOOL_FACTORY_MAP key exactly
+      description: One-line description (also surfaced by listAvailableTools).
+      invokesSubAgent: false      # true only for agents-as-tools / graph sub-agent tools
+```
+
+Then the agent's config references it as `tools: ["my_new_tool"]` (plus a
+`toolParameters["my_new_tool"]` block if it takes params).
+
+---
+
+## 2. New graph state class (redeploy)
+
+Simple graphs use the flat `stateSchema` (`dict[str,str]`). Register a `TypedDict` only
+when you need reducers (fan-in accumulators, etc.). Mechanics live in
+`docker-graph/src/state_registry.py`; real example: `states/mapreduce_example.py`.
+
+### (a) Implementation — new module under `src/agent-core/docker-graph/src/states/`
+
+```python
+# states/my_pipeline.py
+from __future__ import annotations
+import operator
+from typing import Annotated, TypedDict
+
+from ..state_registry import register_state_class
+
+
+def _last_value(_a, b):
+    return b
+
+
+class MyPipelineState(TypedDict):
+    messages: Annotated[str, _last_value]      # text channel (graph framework needs it)
+    # TODO: add your fields, with reducers where parallel branches fan in:
+    # partials: Annotated[list[dict], operator.add]
+    # result: dict
+
+
+register_state_class(
+    key="MyPipelineState",                     # used in GraphConfiguration.stateClass
+    cls=MyPipelineState,
+    label="My Pipeline",
+    description="TODO describe the shared state.",
+    fields=list(MyPipelineState.__annotations__.keys()),
+)
+```
+
+### (b) Trigger registration — `states/__init__.py`
+
+Registration only fires when the module is imported. Add it to the package `__init__`:
+
+```python
+from . import (  # noqa: F401 — triggers state + deterministic node registration
+    mapreduce_example,
+    my_pipeline,        # ← add this line
+)
+```
+
+### (c) Registry seed — `config.yaml` `stateClassRegistry`
+
+```yaml
+stateClassRegistry:
+    - key: "MyPipelineState"     # MUST match the register_state_class key
+      label: "My Pipeline"
+      description: "TODO describe the shared state."
+      fields:
+          - messages
+          # - partials
+          # - result
+```
+
+Referenced from a `GraphConfiguration` via `"stateClass": "MyPipelineState"`.
+
+---
+
+## 3. New deterministic graph node (redeploy)
+
+A pure-Python graph step — no LLM, no I/O, same input → same output. It takes the state
+dict and returns a **partial** state update. Mechanics: `deterministic_node_registry.py`;
+real example: the `merge_template_partials` function in `states/mapreduce_example.py`.
+
+Define it in the same kind of `states/` module (often alongside the state class it
+operates on) and register it:
+
+```python
+from ..deterministic_node_registry import register_deterministic_node
+
+
+def my_reduce_fn(state: dict) -> dict:
+    """Deterministic node: TODO what it computes.
+
+    State keys consumed: TODO
+    State keys produced: TODO (a subset of the state fields; LangGraph merges it in)
+    """
+    # TODO: implement. Must be pure — no LLM calls, no external I/O.
+    return {"messages": "TODO"}
+
+
+register_deterministic_node(
+    key="my_reduce_fn",                # used in a node's deterministicNodeKey
+    fn=my_reduce_fn,
+    label="My Reduce",
+    description="TODO describe the deterministic step.",
+)
+```
+
+Make sure its module is imported from `states/__init__.py` (same as above), and seed
+`config.yaml`:
+
+```yaml
+deterministicNodeRegistry:
+    - key: "my_reduce_fn"        # MUST match the register_deterministic_node key
+      label: "My Reduce"
+      description: "TODO describe the deterministic step."
+```
+
+Referenced from a graph node: `{ "id": "reduce", "deterministicNodeKey": "my_reduce_fn" }`.
+
+---
+
+## 4. New MCP server (NO redeploy — prefer this)
+
+Register against the live system with the **`registerMcpServer`** mutation rather than
+editing `config.yaml`'s `mcpServerRegistry` (which would need a redeploy). The UI's MCP
+server manager uses the same mutation.
+
+```graphql
+mutation RegisterMcpServer(
+  $name: String!, $authType: McpAuthType!, $runtimeId: String,
+  $gatewayId: String, $qualifier: String, $mcpUrl: String, $description: String
+) {
+  registerMcpServer(
+    name: $name, authType: $authType, runtimeId: $runtimeId,
+    gatewayId: $gatewayId, qualifier: $qualifier, mcpUrl: $mcpUrl, description: $description
+  ) { ... }   # AdminOpsResult — select its fields per the schema
+}
+```
+
+`authType` ∈ `SIGV4 | NONE`. Provide a `runtimeId`+`qualifier` (AgentCore-hosted) **or**
+an `mcpUrl` (external) depending on the server. After it succeeds, it shows up in
+`list_building_blocks.py --filter mcpServers` immediately — reference it in
+`mcpServers: ["name"]`.
+
+## 5. New skill (NO redeploy)
+
+Upload with the **`createSkill`** mutation, then reference by name in `skills[]`.
+
+```graphql
+mutation CreateSkill($name: String!, $description: String!, $content: String!) {
+  createSkill(name: $name, description: $description, content: $content) {
+    name description s3Key lastModified
+  }
+}
+```
+
+`content` is the markdown body **without** frontmatter — the resolver wraps it with the
+`name`/`description` frontmatter and stores it at `skills/{name}/SKILL.md`. After it
+succeeds it appears in `list_building_blocks.py --filter skills` immediately.
+
+---
+
+## The redeploy workflow (routes 1–3 only)
+
+1. Edit the `src/agent-core/` file(s) and add the `config.yaml` registry entry.
+2. `make deploy` (rebuilds the affected container image via CodeBuild, then redeploys).
+   This is **not** instant — it's a full build+deploy cycle.
+3. Confirm the new block now appears in `list_building_blocks.py` (it reads the live
+   registries).
+4. **Only then** resume the create/modify flow that needs it.
+
+State the redeploy requirement to the user *before* you scaffold (so they can opt for an
+alternative) and *again after* (so they don't try to use the block before deploying).

--- a/.claude/plugins/agent-creator/skills/agent-creator/references/custom-code.md
+++ b/.claude/plugins/agent-creator/skills/agent-creator/references/custom-code.md
@@ -32,9 +32,17 @@ building-block doesn't exist yet.
 | Shared state for a graph workflow | **New state class** | `src/agent-core/docker-graph/src/states/` + `config.yaml` `stateClassRegistry` | **Yes** |
 | A pure-Python graph step (no LLM) | **New deterministic node** | `src/agent-core/docker-graph/src/states/` + `config.yaml` `deterministicNodeRegistry` | **Yes** |
 | External tool surface over MCP | **New MCP server** | `registerMcpServer` mutation (preferred) *or* `config.yaml` `mcpServerRegistry` | **No** via mutation |
-| Prose/script skill the agent loads | **New skill** | `createSkill` mutation | **No** |
+| Reusable *expertise* (procedure / domain knowledge), not code | **New skill** | `manage_skill.py` (`createSkill`) → skills S3 bucket | **No** |
 
-Route to the no-redeploy option whenever it fits the need.
+Route to the no-redeploy option whenever it fits the need. The redeploy warning below
+applies **only** to routes 1–3 (tool / state class / deterministic node — code baked into
+the container image). MCP servers and skills are live API operations with **no redeploy**.
+
+**Skill vs. tool — the line that decides redeploy-or-not:** if the need is reusable
+*procedure / domain knowledge / a rubric* the agent should follow → that's a **skill**
+(loadable text, live, no redeploy — go to [skill-authoring.md](skill-authoring.md) /
+task 09, *not* this file). If the need is to *execute code* (call an API, compute,
+transform) → that's a **tool** (route 1 below, redeploy). This file is for the code cases.
 
 ---
 
@@ -228,21 +236,20 @@ an `mcpUrl` (external) depending on the server. After it succeeds, it shows up i
 `list_building_blocks.py --filter mcpServers` immediately — reference it in
 `mcpServers: ["name"]`.
 
-## 5. New skill (NO redeploy)
+## 5. New skill (NO redeploy) — go to the skill-authoring path
 
-Upload with the **`createSkill`** mutation, then reference by name in `skills[]`.
+A skill is **not** custom code and does **not** belong on this redeploy page. If the need
+is reusable *expertise* (a procedure, a domain rubric, search heuristics) rather than
+executable code, it's a skill — authored live through `scripts/manage_skill.py`, no
+redeploy, no editing of `src/agent-core/`.
 
-```graphql
-mutation CreateSkill($name: String!, $description: String!, $content: String!) {
-  createSkill(name: $name, description: $description, content: $content) {
-    name description s3Key lastModified
-  }
-}
-```
+→ **Use the Skill-authoring path in [SKILL.md](../SKILL.md) and
+[skill-authoring.md](skill-authoring.md) (task 09).** That covers `manage_skill.py`
+create/update/delete, the body-only/frontmatter-ownership rule, the merge-not-replace
+contrast with agent updates, and attaching the skill to an agent via the modify path.
 
-`content` is the markdown body **without** frontmatter — the resolver wraps it with the
-`name`/`description` frontmatter and stores it at `skills/{name}/SKILL.md`. After it
-succeeds it appears in `list_building_blocks.py --filter skills` immediately.
+A new skill appears in `list_building_blocks.py --filter skills` immediately and is
+referenceable in a SINGLE agent's `skills[]`.
 
 ---
 

--- a/.claude/plugins/agent-creator/skills/agent-creator/references/diagnosis.md
+++ b/.claude/plugins/agent-creator/skills/agent-creator/references/diagnosis.md
@@ -1,0 +1,77 @@
+# Trace-driven diagnosis
+
+Diagnose a misbehaving agent from its traces and propose **config** changes that address
+the root cause, then re-submit via the modify path. This is a smarter front-end on the
+modify path — the only new work is the diagnosis (observed behavior → config knob);
+everything after is read-modify-write verbatim.
+
+## What can — and can't — be fixed here
+
+You edit *config*, so you fix issues whose root cause **is** config. Be honest with the
+user about that boundary.
+
+| Symptom in the traces | Config fix |
+|---|---|
+| Ambiguous / under-specified behavior; agent does the wrong thing vaguely | edit `instructions` (sharpen the system prompt) |
+| Wrong tool chosen, or a tool it has is never used | tighten the prompt about when to use which; add or remove a tool |
+| Missing capability the task needs | add a tool / MCP / skill — **if it's in the registry**; else custom-code (redeploy, task 07) |
+| Truncated / too-terse output, or no/!reasoning | edit `modelInferenceParameters` — raise `maxTokens`, change `modelId`, set `reasoningBudget` |
+| Context lost over long sessions | switch `conversationManager` (`sliding_window` → `summarizing`) |
+| Single agent overwhelmed by a multi-step job | recommend SWARM / GRAPH — a **rebuild** (new architecture), not an edit |
+| **Bug inside a tool's implementation** (tool errors, wrong results from correct args) | ❌ **out of scope** — that's code, not config. Flag it, point at custom-code; do **not** pretend a config edit fixes it |
+
+State the framing to the user: *"hand me traces; I'll diagnose and propose config changes
+for config-level causes — not bugs inside a tool's code."*
+
+## Trace tiers & the AWS-profile boundary
+
+Diagnostic richness is bounded by which trace you can reach, and the sources split on
+whether they need an AWS profile. `scripts/fetch_traces.py` implements tiers 1–2; tier 0
+needs no script.
+
+| Tier | Source | Reached via | AWS profile? | What you get |
+|---|---|---|---|---|
+| **0** | User pastes a trace / transcript / eval reason | nothing (provided text) | **No** | whatever they paste |
+| **1** | Session history — `--session <id>` (`getSession`) | GraphQL (Cognito JWT) | **No** | conversation text, citations, reasoning, **tool-action summaries** (not raw args/results), feedback, per-turn latency, completeness |
+| **1** | Eval summaries — `--evaluator <id>` (`getEvaluator`) | GraphQL (Cognito JWT) | **No** | per-case input / expected / actual / score / **`reason`** / latency, pass/fail |
+| **2** | Full eval **trajectory** — `--evaluator <id> --deep` (`resultsS3Path`) | S3 GetObject | **Yes** | model calls, tool selection + args + results, latencies |
+| **2** | Span logs — `--xray --session-id <s>` (`aws/spans`) | CloudWatch Logs | **Yes** | distributed spans, latency, token usage, errors |
+
+**Default is profile-free (tiers 0–1)** — same Cognito JWT the rest of the plugin uses.
+**Tier 2 is an explicit opt-in** needing `PROFILE=…` (+ `REGION`) with read perms
+(`s3:GetObject` on the evaluations bucket; `logs:FilterLogEvents` on the span group).
+
+### Graceful degradation (don't crash without a profile)
+
+If the user asks for a deep diagnosis and there's no usable profile, `fetch_traces.py`
+exits with a clear message — **not** a credentials traceback. Relay it and offer the
+profile-free alternative: *"paste the session transcript, or point me at the evaluator
+(`--evaluator <id>` without `--deep`) — I can diagnose from the tier-1 summaries."* Only
+push for tier 2 when the tier-1 signal genuinely can't explain the issue (e.g. you need
+the exact tool args, or latency/error spans).
+
+## How to diagnose from each tier
+
+- **Tier 0/1 session** (`fetch_traces.py --session`): read `issues_observed` (negative
+  feedback, tool-action summaries, incomplete responses) and the full `raw.history`. Look
+  for: the agent ignoring available tools, vague answers (prompt), dropped earlier context
+  (conversation manager), truncated endings (`maxTokens`).
+- **Tier 1 evaluator** (`--evaluator`): each failed case's **`reason`** (the grader's
+  explanation) plus expected-vs-actual is the richest config signal — it often names the
+  gap directly ("did not cite sources", "ignored the constraint"). Map `reason` → the
+  prompt/tool/model knob.
+- **Tier 2 deep / xray**: use only when you need tool args/results or latency/error detail
+  the summaries lack. Read `trajectory` (S3) or span `events` from `raw`.
+
+## After diagnosis — the modify path
+
+Diagnosis done, the rest is the modify path (see SKILL.md / update-semantics.md):
+
+1. `fetch_agent_config.py --agent XYZ` → full current config.
+2. Apply targeted edits to the **full** config (never a patch). Show before/after; for
+   each edit, name the observed issue it addresses and your confidence.
+3. `validate_config.py` (with building-blocks) → `submit_runtime.py` → poll Ready.
+4. **The fix is live but UNVERIFIED.** Tell the user so, and give a concrete check:
+   re-run the failing eval cases, or manually reproduce the trace scenario in the UI.
+   Behavioral verification (re-run cases, confirm the score rose) is out of scope for now
+   — the evaluations feature is its natural engine.

--- a/.claude/plugins/agent-creator/skills/agent-creator/references/queries.md
+++ b/.claude/plugins/agent-creator/skills/agent-creator/references/queries.md
@@ -1,0 +1,260 @@
+# GraphQL query reference — source of truth
+
+> **Before adding or editing ANY query below, read the schema file
+> [`src/api/schema/schema.graphql`](../../../../../../src/api/schema/schema.graphql)
+> (relative to the repo root) and take field names, nullability, and selection-set
+> shapes from there.** Do **not** rely on AppSync introspection (not explicitly
+> enabled) and do **not** invent fields. The schema file is git-tracked and always
+> present because this plugin ships inside the same repo.
+
+All operations are `@aws_cognito_user_pools`. Authenticate with a Cognito **ID
+token** (raw JWT, no `Bearer` prefix) via `scripts/gql.py`.
+
+These are the exact documents the plugin scripts send. They are duplicated as
+string constants where a script imports them; keep both in sync with the schema.
+
+---
+
+## Field-shape traps (verified against the schema)
+
+1. **Config queries return a scalar `String!`** — `getDefaultRuntimeConfiguration`,
+   `getRuntimeConfigurationByQualifier`, `getRuntimeConfigurationByVersion` take
+   **no selection set**. The returned string is the JSON config (parse it yourself).
+2. **`getSession` → `Session.history: [SessionHistoryItem]`** — the trace-relevant
+   fields (`toolActions`, `reasoningContent`, `structuredOutput`, `executionTimeMs`,
+   `feedback`, `references`, `complete`) live on `SessionHistoryItem` and must be
+   **explicitly selected** or they come back null.
+3. **`RuntimeSummary.agentRuntimeArnA2A` is nullable** and is the **A2A-twin
+   signal** tasks 03/04 depend on — always select it. `numberOfVersion` and
+   `qualifierToVersion` are `String!` (stringified). `status` is a free
+   **`String!`**, not an enum — match it tolerantly (see task 05).
+4. **`getEvaluator` → `Evaluator`** carries both `results: [EvaluationResult]`
+   (tier-1 summaries) and `resultsS3Path` (tier-2 deep trajectory). Task 08's
+   tiering maps onto these two fields.
+5. **`createAgentCoreRuntime` returns a scalar `String!`** (`agentName`, or `""`
+   on validation failure — no selection set, no GraphQL error). Local validation
+   (task 03) runs first precisely because the empty-string failure is silent.
+
+---
+
+## Discovery / listing
+
+### listRuntimeAgents
+```graphql
+query ListRuntimeAgents {
+  listRuntimeAgents {
+    agentName
+    agentRuntimeId
+    agentRuntimeArnA2A
+    numberOfVersion
+    qualifierToVersion
+    status
+    architectureType
+  }
+}
+```
+
+### listAvailableTools
+```graphql
+query ListAvailableTools {
+  listAvailableTools {
+    name
+    description
+    invokesSubAgent
+  }
+}
+```
+
+### listAvailableMcpServers
+```graphql
+query ListAvailableMcpServers {
+  listAvailableMcpServers {
+    name
+    mcpUrl
+    description
+    authType
+    source
+  }
+}
+```
+
+### listAvailableStateClasses  (graph workflows)
+```graphql
+query ListAvailableStateClasses {
+  listAvailableStateClasses {
+    key
+    label
+    description
+    fields
+  }
+}
+```
+
+### listAvailableDeterministicNodes  (graph workflows)
+```graphql
+query ListAvailableDeterministicNodes {
+  listAvailableDeterministicNodes {
+    key
+    label
+    description
+  }
+}
+```
+
+### listSkills
+```graphql
+query ListSkills {
+  listSkills {
+    name
+    description
+    s3Key
+    lastModified
+  }
+}
+```
+
+### listAgentVersions / listAgentEndpoints  (scalar string lists)
+```graphql
+query ListAgentVersions($agentRuntimeId: String!) {
+  listAgentVersions(agentRuntimeId: $agentRuntimeId)
+}
+```
+```graphql
+query ListAgentEndpoints($agentRuntimeId: String!) {
+  listAgentEndpoints(agentRuntimeId: $agentRuntimeId)
+}
+```
+
+---
+
+## Configuration fetch  (scalar `String!` — NO selection set)
+
+```graphql
+query GetDefaultRuntimeConfiguration($agentName: String!) {
+  getDefaultRuntimeConfiguration(agentName: $agentName)
+}
+```
+```graphql
+query GetRuntimeConfigurationByQualifier($agentName: String!, $qualifier: String!) {
+  getRuntimeConfigurationByQualifier(agentName: $agentName, qualifier: $qualifier)
+}
+```
+```graphql
+query GetRuntimeConfigurationByVersion($agentName: String!, $agentVersion: String!) {
+  getRuntimeConfigurationByVersion(agentName: $agentName, agentVersion: $agentVersion)
+}
+```
+
+---
+
+## Session / trace fetch  (explicit SessionHistoryItem selection)
+
+```graphql
+query GetSession($id: String!) {
+  getSession(id: $id) {
+    id
+    title
+    startTime
+    runtimeId
+    runtimeVersion
+    endpoint
+    history {
+      type
+      content
+      messageId
+      references
+      feedback
+      reasoningContent
+      structuredOutput
+      toolActions
+      executionTimeMs
+      complete
+    }
+  }
+}
+```
+
+---
+
+## Evaluator fetch  (tier-1 results + tier-2 S3 path)
+
+```graphql
+query GetEvaluator($evaluatorId: ID!) {
+  getEvaluator(evaluatorId: $evaluatorId) {
+    evaluatorId
+    name
+    evaluatorType
+    agentRuntimeName
+    qualifier
+    modelId
+    passThreshold
+    status
+    passedCases
+    failedCases
+    totalTimeMs
+    resultsS3Path
+    results {
+      caseName
+      input
+      expectedOutput
+      actualOutput
+      score
+      passed
+      reason
+      latencyMs
+    }
+    errorMessage
+    createdAt
+    startedAt
+    completedAt
+  }
+}
+```
+
+---
+
+## Mutations
+
+### createAgentCoreRuntime  (scalar `String!` — returns agentName or "")
+```graphql
+mutation CreateAgentCoreRuntime(
+  $agentName: String!
+  $configValue: String!
+  $architectureType: ArchitectureType
+) {
+  createAgentCoreRuntime(
+    agentName: $agentName
+    configValue: $configValue
+    architectureType: $architectureType
+  )
+}
+```
+`architectureType` ∈ `SINGLE | SWARM | GRAPH | AGENTS_AS_TOOLS`.
+
+### deleteAgentRuntime
+```graphql
+mutation DeleteAgentRuntime($agentName: String!, $agentRuntimeId: String!) {
+  deleteAgentRuntime(agentName: $agentName, agentRuntimeId: $agentRuntimeId)
+}
+```
+
+### tagAgentCoreRuntime  (version/qualifier tagging)
+```graphql
+mutation TagAgentCoreRuntime(
+  $agentName: String!
+  $agentRuntimeId: String!
+  $currentQualifierToVersion: String!
+  $agentVersion: String!
+  $qualifier: String!
+  $description: String
+) {
+  tagAgentCoreRuntime(
+    agentName: $agentName
+    agentRuntimeId: $agentRuntimeId
+    currentQualifierToVersion: $currentQualifierToVersion
+    agentVersion: $agentVersion
+    qualifier: $qualifier
+    description: $description
+  )
+}
+```

--- a/.claude/plugins/agent-creator/skills/agent-creator/references/queries.md
+++ b/.claude/plugins/agent-creator/skills/agent-creator/references/queries.md
@@ -258,3 +258,70 @@ mutation TagAgentCoreRuntime(
   )
 }
 ```
+
+---
+
+## Skill registry  (the documents `manage_skill.py` sends — task 09)
+
+Types: `Skill { name description s3Key lastModified }`, `SkillResource { path size
+lastModified }`. Two field-shape notes specific to skills:
+
+6. **`createSkill`/`updateSkill` take `content` = markdown BODY ONLY** — the resolver
+   builds the `---name/description---` frontmatter itself. `manage_skill.py` strips an
+   accidental leading frontmatter block before sending.
+7. **`updateSkill` MERGES** — `description` and `content` are *optional*; an omitted arg
+   is preserved server-side. This is the **opposite** of `createAgentCoreRuntime`'s
+   full-config-replace. `getSkillContent`/`getSkillResource` are scalar `String!` (no
+   selection set) and return `null` when the skill/resource is absent.
+
+```graphql
+query ListSkills {
+  listSkills { name description s3Key lastModified }
+}
+```
+```graphql
+query GetSkillContent($name: String!) {
+  getSkillContent(name: $name)
+}
+```
+```graphql
+query ListSkillResources($name: String!) {
+  listSkillResources(name: $name) { path size lastModified }
+}
+```
+```graphql
+query GetSkillResource($name: String!, $path: String!) {
+  getSkillResource(name: $name, path: $path)
+}
+```
+```graphql
+mutation CreateSkill($name: String!, $description: String!, $content: String!) {
+  createSkill(name: $name, description: $description, content: $content) {
+    name description s3Key lastModified
+  }
+}
+```
+```graphql
+mutation UpdateSkill($name: String!, $description: String, $content: String) {
+  updateSkill(name: $name, description: $description, content: $content) {
+    name description s3Key lastModified
+  }
+}
+```
+```graphql
+mutation DeleteSkill($name: String!) {
+  deleteSkill(name: $name)
+}
+```
+```graphql
+mutation UploadSkillResource($name: String!, $path: String!, $content: String!) {
+  uploadSkillResource(name: $name, path: $path, content: $content) {
+    path size lastModified
+  }
+}
+```
+```graphql
+mutation DeleteSkillResource($name: String!, $path: String!) {
+  deleteSkillResource(name: $name, path: $path)
+}
+```

--- a/.claude/plugins/agent-creator/skills/agent-creator/references/registries.md
+++ b/.claude/plugins/agent-creator/skills/agent-creator/references/registries.md
@@ -36,6 +36,10 @@ Model Context Protocol servers. Each: `name`, `mcpUrl`, `description`, `authType
 Uploaded skill folders (prose + scripts) the agent can load. Each: `name`, `description`,
 `s3Key`, `lastModified`.
 - **Referenced by:** `skills: ["name", ...]` (SINGLE).
+- **Read side** (here): `listSkills` via `list_building_blocks.py --filter skills`.
+- **Write side:** `scripts/manage_skill.py` (create/update/delete/get) — author a skill
+  live, no redeploy. See [skill-authoring.md](skill-authoring.md). This is the one missing
+  building-block you can add without a redeploy (unlike a tool/state/node).
 
 ### `agents` — `listRuntimeAgents`
 Existing runtime agents — the parts that orchestrator/swarm/graph agents reference. Each:

--- a/.claude/plugins/agent-creator/skills/agent-creator/references/registries.md
+++ b/.claude/plugins/agent-creator/skills/agent-creator/references/registries.md
@@ -1,0 +1,72 @@
+# Registries — the building-blocks an agent is assembled from
+
+An agent config doesn't embed tool/skill/sub-agent code — it **references** entries that
+already exist in the deployed system by name/key. `list_building_blocks.py` fetches all
+of them in one consolidated JSON; `validate_config.py --building-blocks <that file>`
+cross-checks every reference against it. This file says what each registry holds, how a
+config points at it, and which GraphQL query lists it (full query docs:
+[queries.md](queries.md)).
+
+Consolidated output shape of `list_building_blocks.py`:
+
+```json
+{
+  "tools": [...], "mcpServers": [...], "stateClasses": [...],
+  "deterministicNodes": [...], "skills": [...], "agents": [...]
+}
+```
+
+## The six registries
+
+### `tools` — `listAvailableTools`
+Python tool functions available to agents. Each: `name`, `description`, `invokesSubAgent`.
+- **Referenced by:** `tools: ["name", ...]` in SINGLE / AGENTS_AS_TOOLS (and per-agent in
+  swarm definitions). If a tool takes parameters, add `toolParameters: {"name": {...}}` —
+  **every `toolParameters` key must be in `tools`.**
+- `invokesSubAgent: true` tools are the agents-as-tools mechanism; they only make sense in
+  orchestrator/graph contexts.
+- Missing tool → scaffold one ([custom-code.md](custom-code.md)) + redeploy.
+
+### `mcpServers` — `listAvailableMcpServers`
+Model Context Protocol servers. Each: `name`, `mcpUrl`, `description`, `authType`
+(`SIGV4` | `NONE`), `source` (`CDK` | `UI`).
+- **Referenced by:** `mcpServers: ["name", ...]`.
+
+### `skills` — `listSkills`
+Uploaded skill folders (prose + scripts) the agent can load. Each: `name`, `description`,
+`s3Key`, `lastModified`.
+- **Referenced by:** `skills: ["name", ...]` (SINGLE).
+
+### `agents` — `listRuntimeAgents`
+Existing runtime agents — the parts that orchestrator/swarm/graph agents reference. Each:
+`agentName`, `agentRuntimeId`, **`agentRuntimeArnA2A`** (null ⇒ no A2A twin),
+`numberOfVersion`, `qualifierToVersion`, `status`, `architectureType`.
+- **Referenced by:**
+  - AGENTS_AS_TOOLS — `agentsAsTools[].runtimeId` (use `agentRuntimeId`).
+  - SWARM — `agentReferences[].agentName`.
+  - GRAPH — agent nodes' `agentName`.
+- **A2A twin:** AGENTS_AS_TOOLS and GRAPH sub-agents must have a non-null
+  `agentRuntimeArnA2A`. This is the single most common cross-check failure — check it
+  during assembly, not after submit.
+
+### `stateClasses` — `listAvailableStateClasses` (GRAPH only)
+Registered shared-state classes for graph workflows. Each: `key`, `label`, `description`,
+`fields`.
+- **Referenced by:** `stateClass: "key"` in a GraphConfiguration (alternative to an
+  ad-hoc `stateSchema`).
+- Missing → scaffold ([custom-code.md](custom-code.md)) + redeploy.
+
+### `deterministicNodes` — `listAvailableDeterministicNodes` (GRAPH only)
+Registered pure-Python node functions for graph workflows. Each: `key`, `label`,
+`description`.
+- **Referenced by:** a node's `deterministicNodeKey: "key"`.
+- Missing → scaffold ([custom-code.md](custom-code.md)) + redeploy.
+
+## How `validate_config.py` uses this
+
+With `--building-blocks`, it verifies (per architecture): tool / MCP / skill / state-class
+/ deterministic-node names exist; AGENTS_AS_TOOLS `runtimeId`s exist **and have A2A
+twins**; GRAPH agent nodes exist **and have A2A twins**; SWARM `agentReferences` exist.
+Without `--building-blocks` it runs schema-only validation and warns that these
+cross-checks were skipped. Always pass the file in Phase 4 / the modify path so a typo'd
+or twin-less reference is caught locally instead of as a silent server `""`.

--- a/.claude/plugins/agent-creator/skills/agent-creator/references/skill-authoring.md
+++ b/.claude/plugins/agent-creator/skills/agent-creator/references/skill-authoring.md
@@ -1,0 +1,124 @@
+# Skill authoring — the live skill registry
+
+A **skill** is a markdown instruction package an agent loads at construction time. It
+encodes reusable *expertise* — a procedure, a domain rubric, search heuristics — that is
+too long to live inline in one agent's `instructions` and is worth sharing across agents.
+It lives in the skills S3 bucket at `skills/{name}/SKILL.md`; a SINGLE agent references it
+by name in its `skills[]` field. Authoring or editing a skill is **live, no redeploy** —
+this is the *one* missing-building-block case that stays inside the plugin's live-runtime
+contract (every other missing block — tool / state class / deterministic node — is code
+in the container image and needs a redeploy: see [custom-code.md](custom-code.md)).
+
+All operations go through `scripts/manage_skill.py`, which reuses `gql.py`/auth like every
+other script (no new auth code). It is the **write** side of the `skills` registry that
+[registries.md](registries.md) documents the read side of; `list_building_blocks.py
+--filter skills` and `manage_skill.py list` both show new skills immediately.
+
+## Skill vs. prompt vs. tool — decide first
+
+| The need | It's a… | Where it goes | Redeploy? |
+|---|---|---|---|
+| Reusable expertise/procedure, used across agents or turns, too long for one prompt | **Skill** | `createSkill` → skills S3 bucket | **No** — `manage_skill.py` |
+| One agent's one-off behavior, short | **Prompt** | that agent's `instructions` (modify path) | No |
+| Something that must *execute code* (call an API, compute, transform) | **Tool** | `src/agent-core/` + `config.yaml` | **Yes** ([custom-code.md](custom-code.md)) |
+
+A skill is *loadable text*, not executable code. If the capability needs to run logic →
+it's a tool, not a skill. If the guidance only matters to one agent and fits in a prompt →
+just edit that agent's `instructions`.
+
+## The two backend rules (verified against `routes/skills.py`)
+
+### 1. The resolver owns the frontmatter — send the BODY ONLY
+
+`createSkill(name, description, content)` builds the `---name/description---` block itself
+from the `name` and `description` args. `content` is the markdown **body only**. The
+factory's SDK loader validates that the skill directory name matches the frontmatter
+`name`, so a body that *also* carries a `name:` would clash and break loading.
+
+`manage_skill.py` enforces this: `--body-file` is the body; if it starts with a
+`---…---` block the script **strips it and warns** before sending. Never hand-craft
+frontmatter into a body.
+
+### 2. `updateSkill` MERGES — it is the OPPOSITE of the agent rule
+
+> The agent modify path's dominating rule is **fetch the full config, change one thing,
+> re-submit the WHOLE config** — any omitted field is wiped. **Skills are the exact
+> reverse.** `updateSkill(name, description?, content?)` is a read-modify-write *merge*:
+> omit `--description` and the existing description is preserved; omit `--body-file` and
+> the existing body is preserved. Send only the field(s) that change.
+
+`manage_skill.py update` shows a before/after body diff for the field(s) changing and
+leaves the rest untouched. Stating this contrast out loud avoids carrying agent
+muscle-memory into a skill update (which would otherwise lead you to re-send the whole
+body every time "to be safe" — unnecessary, and it defeats the diff).
+
+## `manage_skill.py` subcommands
+
+```
+manage_skill.py list                              → table of name/description/lastModified
+manage_skill.py get   --name X                    → full markdown (frontmatter + body)
+manage_skill.py create --name X --description "…" --body-file body.md [--yes]
+manage_skill.py update --name X [--description …] [--body-file …] [--yes]   (MERGE)
+manage_skill.py delete --name X [--yes]
+manage_skill.py resources    --name X                          (experimental)
+manage_skill.py put-resource --name X --path scripts/f.py --file f.py [--yes]
+```
+
+- **Read-only** (`list`/`get`/`resources`) never confirm. **Mutating**
+  (`create`/`update`/`delete`/`put-resource`) require `--yes` or an interactive confirm
+  (same posture as `submit_runtime.py`); a non-TTY without `--yes` refuses.
+- **Name validation** mirrors the resolver's `^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$` locally,
+  failing fast with the resolver's exact message — no round-trip for a bad name.
+- **`create` pre-checks uniqueness** via `listSkills` and points you at `update` instead
+  of letting the resolver throw a raw "already exists" `ValueError`.
+- **`delete` cross-checks `skills[]`** across every runtime agent's DEFAULT config and
+  warns which agents currently reference the skill (they degrade silently — the factory
+  logs a skip and the agent still starts, minus this skill — at their next start). It also
+  reports any agent whose config it could not read, so the check is never silently
+  incomplete. This is the one genuinely destructive op; treat it with production-safety
+  care.
+
+## Resources are supported — but lightly exercised
+
+`uploadSkillResource(name, path, content)` adds an auxiliary file (`scripts/`,
+`references/`, `assets/`) to a skill directory, and the live factory loader
+(`src/agent-core/docker/src/factory.py:_download_skill_directory`) **does** download the
+full skill directory — resources included — into the agent's temp dir. So resources reach
+the running agent today; this is *not* a known loader gap.
+
+The caveat is maturity, not mechanics: this path is **lightly exercised** end-to-end.
+Prefer a single self-contained `SKILL.md` body whenever the guidance fits — it's the most
+reliable artifact and the one the worked examples use. If you do upload resources, verify
+with a live UI run that the agent picks them up before relying on them. `manage_skill.py
+resources` / `put-resource` print this caveat. (Extending or hardening the loader is a
+*backend* change in `src/agent-core/` and out of scope for this plugin — it stays a pure
+API client.)
+
+## Live, but behaviorally unverified
+
+A created/updated skill is in S3 the instant the mutation returns and is referenceable by
+name immediately. But:
+
+- An **existing** agent only loads it at its **next start**. Re-submit the agent config
+  (modify path → `submit_runtime.py`) to mint a fresh version that loads the new skill.
+- This plugin confirms **registration**, not **behavior** — it does not run the agent to
+  prove the skill helps. Tell the user it's live but unverified and suggest a UI run.
+
+## GraphQL doc set
+
+Source of truth: [`src/api/schema/schema.graphql`](../../../../../../src/api/schema/schema.graphql)
+(types `Skill`, `SkillResource`). All ops are `@aws_cognito_user_pools`. The exact
+documents `manage_skill.py` sends are mirrored in [queries.md](queries.md) under
+"Skill registry"; keep all three in sync.
+
+**Mutations:** `createSkill(name, description, content): Skill` ·
+`updateSkill(name, description?, content?): Skill` (merge) · `deleteSkill(name): Boolean` ·
+`uploadSkillResource(name, path, content): SkillResource` ·
+`deleteSkillResource(name, path): Boolean`.
+
+**Queries:** `listSkills: [Skill!]` · `getSkillContent(name): String` (full markdown incl.
+frontmatter) · `listSkillResources(name): [SkillResource!]` · `getSkillResource(name,
+path): String`.
+
+`Skill` = `{ name, description, s3Key, lastModified }`. `SkillResource` = `{ path, size,
+lastModified }`.

--- a/.claude/plugins/agent-creator/skills/agent-creator/references/update-semantics.md
+++ b/.claude/plugins/agent-creator/skills/agent-creator/references/update-semantics.md
@@ -1,0 +1,65 @@
+# Update semantics — read-modify-write
+
+There is **no `updateAgentCoreRuntime` mutation.** Updating an agent means re-calling
+`createAgentCoreRuntime` with the *same* `agentName`. The server detects the existing
+runtime and mints a **new version**. This has consequences that make the modify path
+fundamentally different from create — read this before doing any modification.
+
+## The full-config-not-patch rule (non-negotiable)
+
+> An update replaces the agent's configuration **wholesale** with whatever you submit.
+> There is no merge, no patch, no field-level update. Any field you omit is **gone** in
+> the new version.
+
+So the only safe way to modify an agent is:
+
+1. **Fetch the complete current config** — `fetch_agent_config.py --agent XYZ` (the
+   DEFAULT-qualifier config, plus the agent's `architectureType`).
+2. **Mutate that object in memory** — change exactly the field(s) the user asked about,
+   leave everything else byte-for-byte as it was.
+3. **Re-submit the whole object** — `submit_runtime.py --agent XYZ --architecture <T>`.
+
+Common edits:
+- "remove skills" → delete the `skills` field (or set `[]`).
+- "change the model" → set `modelInferenceParameters.modelId`.
+- "add tool Z" → append `"Z"` to `tools`; if Z needs params, add `toolParameters["Z"]`.
+- "raise the temperature" → set `modelInferenceParameters.parameters.temperature`.
+
+If you ever find yourself building a config object with only the changed fields, **stop**
+— that's a partial, and submitting it wipes the agent.
+
+## Versioning & the DEFAULT qualifier
+
+- The first submit creates version `1`. Each subsequent submit under the same name mints
+  the next version (`2`, `3`, …). Visible via `numberOfVersion` /
+  `listAgentVersions(agentRuntimeId)`.
+- The Step Function advances the **DEFAULT** qualifier to the new version automatically —
+  so after a successful update, `getDefaultRuntimeConfiguration` returns the new config.
+- To point an *additional* endpoint qualifier at a version, use
+  `submit_runtime.py --tag <qualifier>` (wraps `tagAgentCoreRuntime`). This is opt-in;
+  you don't need it just to update DEFAULT.
+
+## The tag-match guard (the surprising update failure)
+
+When you update an existing runtime, the `create-runtime-version` Lambda checks that the
+runtime's `Stack` and `Environment` tags match the stack the API belongs to
+(`tags_match()`); on mismatch it raises `AcaException` and the Step Function lands in the
+terminal `Create Failed` status.
+
+**What this means:** you can only update agents **owned by the stack you're authenticated
+against.** An agent created by a different stack/environment (e.g. a colleague's deploy,
+or a different region) cannot be updated through this API — it fails during provisioning,
+not at submit time.
+
+`submit_runtime.py` knows whether the agent pre-existed (it was in `listRuntimeAgents`
+before submit), so on a terminal failure of an *update* it surfaces the tag-match
+explanation rather than a raw `AcaException`. RuntimeSummary carries no tags, so this
+can't be pre-checked — it's detected as the most likely cause of an update that fails to
+reach Ready.
+
+## Polling is still mandatory
+
+Update or create, the mutation is fire-and-forget: it returns `agentName` the instant the
+Step Function starts. Confirmation is `submit_runtime.py` polling `RuntimeSummary.status`
+(`Creating` → `Ready`, or terminal `Create Failed`). Don't tell the user the update
+"worked" off the mutation return — wait for Ready.

--- a/.claude/plugins/agent-creator/skills/agent-creator/scripts/discover_endpoint.py
+++ b/.claude/plugins/agent-creator/skills/agent-creator/scripts/discover_endpoint.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Resolve the AppSync endpoint + Cognito IDs for a deployed accelerator stack.
+
+Resolution order:
+  1. CloudFormation describe-stacks — read outputs GraphQLApiUrl, UserPoolId,
+     UserPoolWebClientId. Outputs live in nested constructs, so we match on the
+     output *key suffix*, not an exact logical ID.
+  2. Local aws-exports.json fallback — read aws_appsync_graphqlEndpoint etc.
+
+Resolved values are cached to .agent-creator-cache.json (gitignored) so repeated
+calls in a session don't re-hit CloudFormation. Pass --refresh to bypass the cache.
+
+Env (honoured like the project Makefile):
+  PROFILE  — AWS profile name
+  REGION   — AWS region
+  ACA_STACK_NAME       — explicit stack name (else scan for a *-aca stack)
+  ACA_AWS_EXPORTS_PATH — explicit aws-exports.json path for the fallback
+
+Usage:
+  python discover_endpoint.py [--refresh] [--stack-name NAME] [--json]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+
+# Cache and fallback locations are resolved relative to this script so the plugin
+# works regardless of the caller's CWD.
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_CACHE_PATH = _SCRIPT_DIR / ".agent-creator-cache.json"
+
+# Output key suffixes we need, mapped to the dict key we return. We match on
+# suffix because CDK prefixes nested-construct output keys with the construct path.
+_OUTPUT_SUFFIXES = {
+    "GraphQLApiUrl": "endpoint",
+    "UserPoolId": "userPoolId",
+    "UserPoolWebClientId": "clientId",
+}
+
+# Best-effort walk up to the repo root to locate the React app's aws-exports.json.
+_AWS_EXPORTS_RELATIVE = Path("src/user-interface/react-app/public/aws-exports.json")
+
+
+def _session() -> boto3.Session:
+    profile = os.environ.get("PROFILE")
+    region = os.environ.get("REGION")
+    kwargs = {}
+    if profile:
+        kwargs["profile_name"] = profile
+    if region:
+        kwargs["region_name"] = region
+    return boto3.Session(**kwargs)
+
+
+def _find_repo_root() -> Path | None:
+    """Walk up from this script looking for a directory that contains the
+    React app's aws-exports.json (marks the accelerator repo root)."""
+    for parent in _SCRIPT_DIR.parents:
+        if (parent / _AWS_EXPORTS_RELATIVE).exists():
+            return parent
+    return None
+
+
+def _from_cloudformation(stack_name: str | None) -> dict | None:
+    session = _session()
+    cfn = session.client("cloudformation")
+
+    stacks: list[dict] = []
+    try:
+        if stack_name:
+            stacks = cfn.describe_stacks(StackName=stack_name)["Stacks"]
+        else:
+            # Scan for a stack whose name ends in "-aca" (the AcaStack), skipping
+            # the "-aca-builder" Phase-1 stack which has no API/auth outputs.
+            paginator = cfn.get_paginator("describe_stacks")
+            candidates = []
+            for page in paginator.paginate():
+                for st in page["Stacks"]:
+                    name = st["StackName"]
+                    if name.endswith("-aca") or name == "aca":
+                        candidates.append(st)
+            if not candidates:
+                return None
+            stacks = candidates
+    except (ClientError, BotoCoreError) as exc:
+        print(f"CloudFormation lookup failed: {exc}", file=sys.stderr)
+        return None
+
+    region = session.region_name
+    for st in stacks:
+        resolved = {"region": region}
+        for out in st.get("Outputs", []):
+            key = out["OutputKey"]
+            for suffix, target in _OUTPUT_SUFFIXES.items():
+                if key.endswith(suffix):
+                    resolved[target] = out["OutputValue"]
+        if all(k in resolved for k in _OUTPUT_SUFFIXES.values()):
+            return resolved
+    return None
+
+
+def _from_aws_exports(path: str | None) -> dict | None:
+    candidate: Path | None = None
+    if path:
+        candidate = Path(path)
+    else:
+        env_path = os.environ.get("ACA_AWS_EXPORTS_PATH")
+        if env_path:
+            candidate = Path(env_path)
+        else:
+            repo_root = _find_repo_root()
+            if repo_root:
+                candidate = repo_root / _AWS_EXPORTS_RELATIVE
+
+    if not candidate or not candidate.exists():
+        return None
+
+    try:
+        data = json.loads(candidate.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"Could not read aws-exports.json at {candidate}: {exc}", file=sys.stderr)
+        return None
+
+    endpoint = data.get("aws_appsync_graphqlEndpoint")
+    user_pool_id = data.get("aws_user_pools_id")
+    client_id = data.get("aws_user_pools_web_client_id")
+    region = data.get("aws_appsync_region") or data.get("aws_project_region")
+    if endpoint and user_pool_id and client_id:
+        return {
+            "endpoint": endpoint,
+            "region": region,
+            "userPoolId": user_pool_id,
+            "clientId": client_id,
+        }
+    return None
+
+
+def discover_endpoint(
+    refresh: bool = False,
+    stack_name: str | None = None,
+    aws_exports_path: str | None = None,
+) -> dict:
+    """Return {endpoint, region, userPoolId, clientId}.
+
+    Raises RuntimeError with an actionable message if nothing resolves."""
+    if not refresh and _CACHE_PATH.exists():
+        try:
+            cached = json.loads(_CACHE_PATH.read_text())
+            if all(k in cached for k in ("endpoint", "userPoolId", "clientId")):
+                return cached
+        except (OSError, json.JSONDecodeError):
+            pass  # corrupt cache — fall through to re-resolve
+
+    stack_name = stack_name or os.environ.get("ACA_STACK_NAME")
+    resolved = _from_cloudformation(stack_name) or _from_aws_exports(aws_exports_path)
+
+    if not resolved:
+        raise RuntimeError(
+            "Could not resolve the AppSync endpoint. Tried CloudFormation "
+            "(set ACA_STACK_NAME or PROFILE/REGION if the stack isn't found) and "
+            "the local aws-exports.json fallback "
+            f"({_AWS_EXPORTS_RELATIVE}). Deploy the stack or pass --stack-name."
+        )
+
+    try:
+        _CACHE_PATH.write_text(json.dumps(resolved, indent=2))
+    except OSError:
+        pass  # caching is best-effort; never fail the call over it
+
+    return resolved
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--refresh", action="store_true", help="bypass the local cache")
+    parser.add_argument("--stack-name", help="explicit CloudFormation stack name")
+    parser.add_argument("--aws-exports-path", help="explicit aws-exports.json path")
+    parser.add_argument(
+        "--json", action="store_true", help="print the full dict as JSON (default)"
+    )
+    args = parser.parse_args()
+
+    try:
+        resolved = discover_endpoint(
+            refresh=args.refresh,
+            stack_name=args.stack_name,
+            aws_exports_path=args.aws_exports_path,
+        )
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(json.dumps(resolved, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/plugins/agent-creator/skills/agent-creator/scripts/fetch_agent_config.py
+++ b/.claude/plugins/agent-creator/skills/agent-creator/scripts/fetch_agent_config.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Read back an existing agent's full runtime configuration (the read in
+read-modify-write).
+
+The update path re-submits the **whole** config minus whatever the user wants
+changed — a partial re-submit would wipe every field it omits. So this script
+returns the *complete* stored config, parsed and pretty-printed, alongside the
+agent's `architectureType` (which the re-submit's createAgentCoreRuntime call
+needs but the config-fetch queries don't carry).
+
+Three source queries return the stored `ConfigurationValue` JSON string (a scalar
+`String!` — no selection set):
+
+  - getDefaultRuntimeConfiguration(agentName)            ← canonical "current config"
+  - getRuntimeConfigurationByQualifier(agentName, qualifier)
+  - getRuntimeConfigurationByVersion(agentName, agentVersion)
+
+`architectureType` comes from listRuntimeAgents (RuntimeSummary), matched by name.
+
+Query documents are duplicated here as constants; canonical form + field-shape
+traps live in references/queries.md (sourced from src/api/schema/schema.graphql).
+
+Read-only — issues no mutations.
+
+Usage:
+  fetch_agent_config.py --agent <name> [--qualifier DEFAULT | --version <v>]
+  → prints {"agentName", "architectureType", "config": {...}} as JSON
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+try:
+    from gql import post
+except ImportError:  # allow running as a module from elsewhere
+    from .gql import post
+
+_GET_DEFAULT = """
+query GetDefaultRuntimeConfiguration($agentName: String!) {
+  getDefaultRuntimeConfiguration(agentName: $agentName)
+}
+"""
+
+_GET_BY_QUALIFIER = """
+query GetRuntimeConfigurationByQualifier($agentName: String!, $qualifier: String!) {
+  getRuntimeConfigurationByQualifier(agentName: $agentName, qualifier: $qualifier)
+}
+"""
+
+_GET_BY_VERSION = """
+query GetRuntimeConfigurationByVersion($agentName: String!, $agentVersion: String!) {
+  getRuntimeConfigurationByVersion(agentName: $agentName, agentVersion: $agentVersion)
+}
+"""
+
+_LIST_AGENTS = """
+query ListRuntimeAgents {
+  listRuntimeAgents { agentName architectureType }
+}
+"""
+
+
+def _fetch_architecture_type(agent_name: str) -> str | None:
+    """Look up an agent's architectureType from the runtime summary list."""
+    data = post(_LIST_AGENTS)
+    for agent in data.get("listRuntimeAgents") or []:
+        if agent.get("agentName") == agent_name:
+            return agent.get("architectureType")
+    return None
+
+
+def fetch_agent_config(
+    agent_name: str,
+    qualifier: str | None = None,
+    version: str | None = None,
+) -> dict:
+    """Return {agentName, architectureType, config} for an existing agent.
+
+    Defaults to the DEFAULT qualifier (the canonical current config). Pass a
+    qualifier or a version to read a specific endpoint/version instead. Raises
+    RuntimeError on transport/GraphQL failure or when the config can't be found
+    (the resolver returns "" for a missing agent/qualifier/version)."""
+    if qualifier and version:
+        raise RuntimeError("Pass at most one of --qualifier / --version, not both.")
+
+    if version is not None:
+        query, variables, field = (
+            _GET_BY_VERSION,
+            {"agentName": agent_name, "agentVersion": version},
+            "getRuntimeConfigurationByVersion",
+        )
+    elif qualifier is not None and qualifier != "DEFAULT":
+        query, variables, field = (
+            _GET_BY_QUALIFIER,
+            {"agentName": agent_name, "qualifier": qualifier},
+            "getRuntimeConfigurationByQualifier",
+        )
+    else:
+        query, variables, field = (
+            _GET_DEFAULT,
+            {"agentName": agent_name},
+            "getDefaultRuntimeConfiguration",
+        )
+
+    data = post(query, variables)
+    raw_config = data.get(field) or ""
+    if not raw_config:
+        target = (
+            f"version {version}"
+            if version is not None
+            else f"qualifier {qualifier or 'DEFAULT'}"
+        )
+        raise RuntimeError(
+            f"No configuration found for agent '{agent_name}' ({target}). "
+            f"The agent, qualifier, or version may not exist — check "
+            f"list_building_blocks.py --filter agents."
+        )
+
+    try:
+        config = json.loads(raw_config)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"Stored configuration for '{agent_name}' is not valid JSON: {exc}"
+        ) from exc
+
+    return {
+        "agentName": agent_name,
+        "architectureType": _fetch_architecture_type(agent_name),
+        "config": config,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--agent", required=True, help="agent name")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--qualifier",
+        help="tagged endpoint qualifier (default: DEFAULT — the current config)",
+    )
+    group.add_argument("--version", help="specific agent runtime version")
+    args = parser.parse_args()
+
+    try:
+        result = fetch_agent_config(
+            args.agent, qualifier=args.qualifier, version=args.version
+        )
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/plugins/agent-creator/skills/agent-creator/scripts/fetch_traces.py
+++ b/.claude/plugins/agent-creator/skills/agent-creator/scripts/fetch_traces.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python3
+"""Fetch agent traces for config-level diagnosis, across profile-free and
+profile-required tiers.
+
+Diagnostic power is bounded by which trace you can reach, and the sources split
+cleanly on whether they need an AWS profile:
+
+  Tier 0  pasted trace            no script — the user pastes it into the chat
+  Tier 1  getSession(id)          GraphQL (Cognito JWT)        — NO profile
+  Tier 1  getEvaluator(id)        GraphQL (Cognito JWT)        — NO profile
+  Tier 2  --deep (resultsS3Path)  S3 GetObject                 — REQUIRES profile
+  Tier 2  --xray (session spans)  CloudWatch Logs (aws/spans)  — REQUIRES profile
+
+Tiers 0–1 ride the same Cognito JWT the rest of the plugin uses (gql.py); no AWS
+credentials. Tier 2 is an explicit opt-in that needs a real AWS profile with read
+perms (s3:GetObject on the evaluations bucket, and/or CloudWatch Logs read). When a
+tier-2 flag is used without a usable profile, this exits with a graceful message
+pointing back at the tier-0/1 alternative — never a raw credentials traceback.
+
+Output: normalized JSON `{ "tier", "source", "issues_observed": [...], "raw": ... }`
+that the diagnosis step reads. `issues_observed` is a best-effort surfacing of the
+signals most useful for diagnosis (failed eval cases with reasons, tool actions,
+latencies); `raw` carries the full fetched payload so the agent can read more.
+
+Usage:
+  fetch_traces.py --session <id>
+  fetch_traces.py --evaluator <id>
+  fetch_traces.py --evaluator <id> --deep        # + S3 trajectory  (needs PROFILE)
+  fetch_traces.py --xray --session-id <s>        # span logs        (needs PROFILE)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+try:
+    from gql import post
+except ImportError:  # allow running as a module from elsewhere
+    from .gql import post
+
+# Tier-1 GraphQL documents — mirror references/queries.md. getSession must select
+# the SessionHistoryItem trace fields explicitly or they return null.
+_GET_SESSION = """
+query GetSession($id: String!) {
+  getSession(id: $id) {
+    id
+    title
+    startTime
+    runtimeId
+    runtimeVersion
+    endpoint
+    history {
+      type
+      content
+      messageId
+      references
+      feedback
+      reasoningContent
+      structuredOutput
+      toolActions
+      executionTimeMs
+      complete
+    }
+  }
+}
+"""
+
+_GET_EVALUATOR = """
+query GetEvaluator($evaluatorId: ID!) {
+  getEvaluator(evaluatorId: $evaluatorId) {
+    evaluatorId
+    name
+    evaluatorType
+    agentRuntimeName
+    qualifier
+    modelId
+    passThreshold
+    status
+    passedCases
+    failedCases
+    totalTimeMs
+    resultsS3Path
+    results {
+      caseName
+      input
+      expectedOutput
+      actualOutput
+      score
+      passed
+      reason
+      latencyMs
+    }
+    errorMessage
+    createdAt
+    startedAt
+    completedAt
+  }
+}
+"""
+
+_NO_PROFILE_MSG = (
+    "This is a tier-2 deep trace ({what}), which needs a real AWS profile with read "
+    "permissions ({perms}) — it uses SigV4, not the Cognito token the rest of the "
+    "plugin uses. No usable AWS profile was found.\n"
+    "Either set PROFILE=<name> (and REGION) and retry, or use a profile-free tier-0/1 "
+    "source instead: paste the session transcript directly, or run with --session "
+    "<id> / --evaluator <id> (no --deep)."
+)
+
+
+def _boto3_session():
+    """Build a boto3 Session honouring PROFILE/REGION, like the other scripts."""
+    import boto3  # local import so tiers 0–1 never require boto3 creds to load
+
+    profile = os.environ.get("PROFILE")
+    region = os.environ.get("REGION")
+    kwargs = {}
+    if profile:
+        kwargs["profile_name"] = profile
+    if region:
+        kwargs["region_name"] = region
+    return boto3.Session(**kwargs)
+
+
+def _has_usable_credentials() -> bool:
+    """True if boto3 can resolve credentials (profile, env, or instance role)."""
+    try:
+        return _boto3_session().get_credentials() is not None
+    except Exception:
+        return False
+
+
+# --------------------------------------------------------------------------- #
+# Tier 1 — session
+# --------------------------------------------------------------------------- #
+def fetch_session(session_id: str) -> dict:
+    data = post(_GET_SESSION, {"id": session_id})
+    session = data.get("getSession")
+    if not session:
+        raise RuntimeError(
+            f"No session found for id '{session_id}'. Check the id (listSessions lists "
+            f"available sessions)."
+        )
+    issues = _session_issues(session)
+    return {
+        "tier": 1,
+        "source": "getSession",
+        "issues_observed": issues,
+        "raw": session,
+    }
+
+
+def _session_issues(session: dict) -> list[dict]:
+    """Surface diagnosis-relevant signals from a session's history.
+
+    Tool-action *summaries* (not raw args/results), negative feedback, and slow
+    turns are the config-relevant signals available at tier 1."""
+    issues: list[dict] = []
+    for item in session.get("history") or []:
+        if item.get("type") != "ai":
+            continue
+        feedback = item.get("feedback")
+        if feedback and feedback.lower() in ("negative", "thumbs_down", "down", "bad"):
+            issues.append(
+                {
+                    "kind": "negative_feedback",
+                    "messageId": item.get("messageId"),
+                    "content_preview": (item.get("content") or "")[:280],
+                }
+            )
+        tool_actions = item.get("toolActions")
+        if tool_actions:
+            issues.append(
+                {
+                    "kind": "tool_actions",
+                    "messageId": item.get("messageId"),
+                    "toolActions": tool_actions,
+                }
+            )
+        if not item.get("complete", True):
+            issues.append(
+                {
+                    "kind": "incomplete_response",
+                    "messageId": item.get("messageId"),
+                    "content_preview": (item.get("content") or "")[:280],
+                }
+            )
+    return issues
+
+
+# --------------------------------------------------------------------------- #
+# Tier 1 — evaluator (+ optional tier-2 --deep)
+# --------------------------------------------------------------------------- #
+def fetch_evaluator(evaluator_id: str, deep: bool = False) -> dict:
+    data = post(_GET_EVALUATOR, {"evaluatorId": evaluator_id})
+    evaluator = data.get("getEvaluator")
+    if not evaluator:
+        raise RuntimeError(
+            f"No evaluator found for id '{evaluator_id}'. Check the id (listEvaluators "
+            f"lists available evaluators)."
+        )
+
+    issues = _evaluator_issues(evaluator)
+    result: dict = {
+        "tier": 1,
+        "source": "getEvaluator",
+        "issues_observed": issues,
+        "raw": evaluator,
+    }
+
+    if deep:
+        s3_path = evaluator.get("resultsS3Path")
+        if not s3_path:
+            result["deep_trajectory_note"] = (
+                "No resultsS3Path on this evaluator — nothing to deep-fetch. The "
+                "tier-1 results above are all that's available."
+            )
+            return result
+        if not _has_usable_credentials():
+            raise RuntimeError(
+                _NO_PROFILE_MSG.format(
+                    what="the full eval trajectory in S3",
+                    perms="s3:GetObject on the evaluations bucket",
+                )
+            )
+        trajectory = _load_s3_trajectory(s3_path)
+        result["tier"] = 2
+        result["source"] = "getEvaluator+resultsS3Path"
+        result["trajectory"] = trajectory
+    return result
+
+
+def _evaluator_issues(evaluator: dict) -> list[dict]:
+    """Failed eval cases with their grader reason are the richest tier-1 signal."""
+    issues: list[dict] = []
+    for case in evaluator.get("results") or []:
+        if case.get("passed"):
+            continue
+        issues.append(
+            {
+                "kind": "failed_eval_case",
+                "caseName": case.get("caseName"),
+                "score": case.get("score"),
+                "reason": case.get("reason"),
+                "input": case.get("input"),
+                "expectedOutput": case.get("expectedOutput"),
+                "actualOutput": case.get("actualOutput"),
+                "latencyMs": case.get("latencyMs"),
+            }
+        )
+    if evaluator.get("errorMessage"):
+        issues.append(
+            {"kind": "evaluator_error", "errorMessage": evaluator["errorMessage"]}
+        )
+    return issues
+
+
+def _parse_s3_uri(s3_uri: str) -> tuple[str, str]:
+    if not s3_uri.startswith("s3://"):
+        raise RuntimeError(f"Not an S3 URI: {s3_uri}")
+    bucket, _, key = s3_uri[5:].partition("/")
+    if not bucket or not key:
+        raise RuntimeError(f"Malformed S3 URI: {s3_uri}")
+    return bucket, key
+
+
+def _load_s3_trajectory(s3_path: str) -> list[dict]:
+    """Read the deep trajectory from S3.
+
+    `resultsS3Path` may point at a single JSON file or at a prefix under which the
+    executor wrote one `test_case_NNNN.json` per case — handle both."""
+    s3 = _boto3_session().client("s3")
+    bucket, key = _parse_s3_uri(s3_path)
+    objects: list[dict] = []
+
+    if key.endswith(".json"):
+        keys = [key]
+    else:
+        prefix = key if key.endswith("/") else key + "/"
+        keys = []
+        paginator = s3.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+            for obj in page.get("Contents", []) or []:
+                if obj["Key"].endswith(".json"):
+                    keys.append(obj["Key"])
+
+    for k in sorted(keys):
+        body = s3.get_object(Bucket=bucket, Key=k)["Body"].read().decode("utf-8")
+        try:
+            objects.append({"key": k, "data": json.loads(body)})
+        except json.JSONDecodeError:
+            objects.append({"key": k, "raw": body[:2000]})
+    return objects
+
+
+# --------------------------------------------------------------------------- #
+# Tier 2 — X-Ray / CloudWatch span logs (aws/spans), by session id
+# --------------------------------------------------------------------------- #
+def fetch_xray_spans(session_id: str, log_group: str, hours: int) -> dict:
+    """Pull span logs for a session id from the aws/spans CloudWatch group.
+
+    AgentCore observability with Transaction Search emits OpenTelemetry spans to a
+    CloudWatch Logs group (default 'aws/spans'). We filter for the session id; the
+    exact span attribute key varies, so this is a best-effort substring match the
+    agent then reads from `raw`."""
+    if not _has_usable_credentials():
+        raise RuntimeError(
+            _NO_PROFILE_MSG.format(
+                what="distributed span logs",
+                perms="logs:FilterLogEvents on the span log group",
+            )
+        )
+    logs = _boto3_session().client("logs")
+    # Window is relative; the caller passes hours-back. We can't use time.time()
+    # here (unavailable in some sandboxes via the harness, and not needed) — instead
+    # rely on FilterLogEvents without a start time when hours<=0, else compute via
+    # the service-side relative is unavailable, so we read recent events.
+    kwargs = {
+        "logGroupName": log_group,
+        "filterPattern": f'"{session_id}"',
+        "limit": 1000,
+    }
+    events: list[dict] = []
+    try:
+        token = None
+        while True:
+            if token:
+                kwargs["nextToken"] = token
+            resp = logs.filter_log_events(**kwargs)
+            events.extend(resp.get("events", []) or [])
+            token = resp.get("nextToken")
+            if not token or len(events) >= 1000:
+                break
+    except logs.exceptions.ResourceNotFoundException as exc:
+        raise RuntimeError(
+            f"Span log group '{log_group}' not found. AgentCore observability / "
+            f"Transaction Search may not be enabled on this stack "
+            f"(agentCoreObservability in config), or the group name differs — pass "
+            f"--log-group. Underlying: {exc}"
+        ) from exc
+
+    issues = [
+        {
+            "kind": "span_event",
+            "timestamp": e.get("timestamp"),
+            "message": e.get("message"),
+        }
+        for e in events
+    ]
+    return {
+        "tier": 2,
+        "source": f"cloudwatch:{log_group}",
+        "issues_observed": issues,
+        "raw": {"sessionId": session_id, "eventCount": len(events), "events": events},
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--session", help="session id → getSession (tier 1)")
+    parser.add_argument("--evaluator", help="evaluator id → getEvaluator (tier 1)")
+    parser.add_argument(
+        "--deep",
+        action="store_true",
+        help="with --evaluator: also fetch the S3 trajectory (tier 2, needs PROFILE)",
+    )
+    parser.add_argument(
+        "--xray",
+        action="store_true",
+        help="fetch span logs for --session-id (tier 2, needs PROFILE)",
+    )
+    parser.add_argument("--session-id", help="session id for --xray span filtering")
+    parser.add_argument(
+        "--log-group",
+        default="aws/spans",
+        help="CloudWatch Logs group for spans (default: aws/spans)",
+    )
+    parser.add_argument(
+        "--hours", type=int, default=24, help="(reserved) lookback window hint"
+    )
+    args = parser.parse_args()
+
+    try:
+        if args.xray:
+            session_id = args.session_id or args.session
+            if not session_id:
+                print(
+                    "--xray needs --session-id (or --session) to filter spans by.",
+                    file=sys.stderr,
+                )
+                return 2
+            result = fetch_xray_spans(session_id, args.log_group, args.hours)
+        elif args.evaluator:
+            result = fetch_evaluator(args.evaluator, deep=args.deep)
+        elif args.session:
+            result = fetch_session(args.session)
+        else:
+            print(
+                "Provide one of: --session <id>, --evaluator <id> [--deep], or "
+                "--xray --session-id <s>. (Tier 0 needs no script — paste the trace "
+                "into the conversation.)",
+                file=sys.stderr,
+            )
+            return 2
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(json.dumps(result, indent=2, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/plugins/agent-creator/skills/agent-creator/scripts/get_token.py
+++ b/.claude/plugins/agent-creator/skills/agent-creator/scripts/get_token.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Mint a Cognito ID token for the deployed accelerator's AppSync API.
+
+AppSync's createAgentCoreRuntime (and every other agent mutation) is
+@aws_cognito_user_pools only — SigV4/IAM is rejected. We must send a Cognito
+*ID token* (not the access token) as the raw JWT in the Authorization header,
+with NO "Bearer" prefix.
+
+Auth flow (USER_PASSWORD_AUTH — the app client has userPassword:true,
+generateSecret:false, so there is no SRP and no SECRET_HASH):
+
+  1. Load creds:
+       - if .env exists -> ACA_COGNITO_USERNAME / ACA_COGNITO_PASSWORD
+       - else -> prompt (password via getpass, never echoed), then write .env
+         0600 after ensuring .env is gitignored.
+  2. clientId from discover_endpoint.
+  3. cognito-idp InitiateAuth(USER_PASSWORD_AUTH).
+  4. return AuthenticationResult["IdToken"].
+
+Tokens are minted fresh every run (they expire ~1h; with .env creds re-minting
+is free) — the JWT is never cached.
+
+Usage:
+  python get_token.py            # prints the ID token to stdout
+  import: from get_token import get_token; token = get_token()
+"""
+from __future__ import annotations
+
+import getpass
+import os
+import stat
+import sys
+from pathlib import Path
+
+from botocore.exceptions import BotoCoreError, ClientError
+
+try:
+    from discover_endpoint import _find_repo_root, _session, discover_endpoint
+except ImportError:  # allow running as a module from elsewhere
+    from .discover_endpoint import _find_repo_root, _session, discover_endpoint
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_ENV_PATH = _SCRIPT_DIR / ".env"
+
+_ENV_USERNAME = "ACA_COGNITO_USERNAME"
+_ENV_PASSWORD = "ACA_COGNITO_PASSWORD"
+
+
+def _load_env_file() -> dict[str, str]:
+    """Minimal .env reader (KEY=VALUE per line); avoids a python-dotenv dep."""
+    values: dict[str, str] = {}
+    if not _ENV_PATH.exists():
+        return values
+    for line in _ENV_PATH.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        values[key.strip()] = val.strip().strip('"').strip("'")
+    return values
+
+
+def _ensure_env_gitignored() -> None:
+    """Make sure `.env` is gitignored before we ever write secrets to it.
+
+    Checks the repo root .gitignore first (the accelerator already lists `.env`
+    there); if no root .gitignore is found, drops a local .gitignore next to the
+    script. This is a production-safety must — creds must never be committable."""
+    repo_root = _find_repo_root()
+    gitignore = (repo_root / ".gitignore") if repo_root else None
+    if gitignore and gitignore.exists():
+        existing = gitignore.read_text().splitlines()
+        if any(line.strip() in (".env", "*.env", "**/.env") for line in existing):
+            return
+        with gitignore.open("a") as fh:
+            fh.write("\n# agent-creator plugin credentials\n.env\n")
+        return
+
+    # No repo-root .gitignore — guard the script directory locally.
+    local = _SCRIPT_DIR / ".gitignore"
+    line = ".env\n"
+    if local.exists() and ".env" in local.read_text():
+        return
+    with local.open("a") as fh:
+        fh.write(line)
+
+
+def _prompt_and_store_creds() -> tuple[str, str]:
+    username = input("Cognito username (email): ").strip()
+    password = getpass.getpass("Cognito password: ")  # MASKED — no echo
+
+    _ensure_env_gitignored()
+    contents = f'{_ENV_USERNAME}="{username}"\n{_ENV_PASSWORD}="{password}"\n'
+    # Create with 0600 from the start: open with restrictive mode, then write.
+    fd = os.open(_ENV_PATH, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as fh:
+        fh.write(contents)
+    # Belt-and-braces in case the file pre-existed with looser perms.
+    os.chmod(_ENV_PATH, stat.S_IRUSR | stat.S_IWUSR)
+    print(f"Saved credentials to {_ENV_PATH} (0600, gitignored).", file=sys.stderr)
+    return username, password
+
+
+def _resolve_creds() -> tuple[str, str]:
+    env = _load_env_file()
+    username = env.get(_ENV_USERNAME) or os.environ.get(_ENV_USERNAME)
+    password = env.get(_ENV_PASSWORD) or os.environ.get(_ENV_PASSWORD)
+    if username and password:
+        return username, password
+    return _prompt_and_store_creds()
+
+
+def get_token(client_id: str | None = None) -> str:
+    """Return a fresh Cognito ID token (JWT). Raises RuntimeError on auth failure
+    with an actionable message rather than a raw boto3 traceback."""
+    if client_id is None:
+        client_id = discover_endpoint()["clientId"]
+
+    username, password = _resolve_creds()
+    cognito = _session().client("cognito-idp")
+
+    try:
+        resp = cognito.initiate_auth(
+            AuthFlow="USER_PASSWORD_AUTH",
+            ClientId=client_id,
+            AuthParameters={"USERNAME": username, "PASSWORD": password},
+        )
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code == "NotAuthorizedException":
+            raise RuntimeError(
+                "Authentication failed: wrong username/password, or the user is "
+                "disabled — check the user in the Cognito user pool. Delete "
+                f"{_ENV_PATH} to re-enter credentials."
+            ) from exc
+        if code == "UserNotFoundException":
+            raise RuntimeError(
+                "Authentication failed: no such user in the pool — create/confirm "
+                "a user first, then delete the cached .env to re-enter credentials."
+            ) from exc
+        raise RuntimeError(f"Cognito InitiateAuth failed ({code}): {exc}") from exc
+    except BotoCoreError as exc:
+        raise RuntimeError(f"Cognito InitiateAuth transport error: {exc}") from exc
+
+    # The plugin does not implement password-reset / MFA challenge flows.
+    challenge = resp.get("ChallengeName")
+    if challenge:
+        raise RuntimeError(
+            f"Cognito returned a '{challenge}' challenge, which this plugin does "
+            "not handle. Resolve the user's status in the Cognito user pool "
+            "(e.g. set a permanent password / complete MFA setup) and retry."
+        )
+
+    auth_result = resp.get("AuthenticationResult", {})
+    id_token = auth_result.get("IdToken")  # ID token, NOT AccessToken
+    if not id_token:
+        raise RuntimeError(
+            "Cognito InitiateAuth succeeded but returned no IdToken — unexpected "
+            "response shape."
+        )
+    return id_token
+
+
+def main() -> int:
+    try:
+        print(get_token())
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/plugins/agent-creator/skills/agent-creator/scripts/gql.py
+++ b/.claude/plugins/agent-creator/skills/agent-creator/scripts/gql.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Thin GraphQL-over-HTTP client for the deployed accelerator's AppSync API.
+
+AppSync returns HTTP 200 even when individual fields error, so we inspect the
+`errors` array rather than trusting the status code. The Authorization header is
+the raw Cognito ID token (no "Bearer" prefix — AppSync Cognito mode).
+
+Note: createAgentCoreRuntime returns "" on validation failure with NO GraphQL
+error (see schema). That ambiguity is why local validation (task 03) runs before
+submitting — gql.py cannot distinguish that from a successful empty result.
+
+Usage:
+  python gql.py 'query { listRuntimeAgents { agentName status } }'
+  import: from gql import post; data = post(query, variables)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import requests
+
+try:
+    from discover_endpoint import discover_endpoint
+    from get_token import get_token
+except ImportError:
+    from .discover_endpoint import discover_endpoint
+    from .get_token import get_token
+
+_TIMEOUT_SECONDS = 30
+
+
+def post(query: str, variables: dict | None = None) -> dict:
+    """POST a GraphQL document and return the `data` object.
+
+    Raises RuntimeError on transport failure or if the response carries a
+    non-empty `errors` array (surfaced readably)."""
+    resolved = discover_endpoint()
+    endpoint = resolved["endpoint"]
+    token = get_token(client_id=resolved["clientId"])
+
+    try:
+        resp = requests.post(
+            endpoint,
+            headers={
+                # Raw JWT, no "Bearer" prefix — AppSync Cognito user-pools mode.
+                "Authorization": token,
+                "Content-Type": "application/json",
+            },
+            json={"query": query, "variables": variables or {}},
+            timeout=_TIMEOUT_SECONDS,
+        )
+    except requests.RequestException as exc:
+        raise RuntimeError(f"GraphQL request failed (transport): {exc}") from exc
+
+    if resp.status_code != 200:
+        raise RuntimeError(
+            f"GraphQL endpoint returned HTTP {resp.status_code}: {resp.text[:500]}"
+        )
+
+    try:
+        payload = resp.json()
+    except ValueError as exc:
+        raise RuntimeError(f"GraphQL response was not JSON: {resp.text[:500]}") from exc
+
+    errors = payload.get("errors")
+    if errors:
+        messages = []
+        for err in errors:
+            msg = err.get("message", "<no message>")
+            etype = err.get("errorType")
+            messages.append(f"  - {msg}" + (f" [{etype}]" if etype else ""))
+        raise RuntimeError("GraphQL returned errors:\n" + "\n".join(messages))
+
+    return payload.get("data", {})
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("query", help="GraphQL query/mutation document")
+    parser.add_argument("--variables", help="JSON object of variables", default="{}")
+    args = parser.parse_args()
+
+    try:
+        variables = json.loads(args.variables)
+    except json.JSONDecodeError as exc:
+        print(f"--variables is not valid JSON: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        data = post(args.query, variables)
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(json.dumps(data, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/plugins/agent-creator/skills/agent-creator/scripts/list_building_blocks.py
+++ b/.claude/plugins/agent-creator/skills/agent-creator/scripts/list_building_blocks.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Discover the registry building-blocks of a deployed accelerator stack.
+
+The agent-creator workflow assembles agents from parts that already exist in the
+live system — tools, MCP servers, graph state classes, deterministic nodes,
+uploaded skills, and other runtime agents (for swarm refs / graph nodes /
+agents-as-tools sub-agents). This script runs the same discovery queries the
+Agent Factory UI uses and emits one consolidated JSON document:
+
+  {
+    "tools": [...], "mcpServers": [...], "stateClasses": [...],
+    "deterministicNodes": [...], "skills": [...], "agents": [...]
+  }
+
+That document is consumed directly by `validate_config.py --building-blocks`: the
+`agents` list carries `agentRuntimeArnA2A` per agent, which is the A2A-twin signal
+the cross-checks rely on (a sub-agent without a twin can't be referenced by an
+orchestrator or graph node).
+
+Query documents are duplicated here as constants; their canonical form and the
+field-shape traps live in references/queries.md, sourced from
+src/api/schema/schema.graphql. Keep all three in sync.
+
+Read-only — issues no mutations.
+
+Usage:
+  python list_building_blocks.py [--filter tools|mcpServers|stateClasses|
+                                   deterministicNodes|skills|agents]
+  → prints the consolidated (or single-category) JSON to stdout
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+try:
+    from gql import post
+except ImportError:  # allow running as a module from elsewhere
+    from .gql import post
+
+# Each category maps to (GraphQL document, resolver field name). The field name
+# is the key AppSync returns the list under, inside the `data` object.
+_QUERIES: dict[str, tuple[str, str]] = {
+    "tools": (
+        """
+        query ListAvailableTools {
+          listAvailableTools { name description invokesSubAgent }
+        }
+        """,
+        "listAvailableTools",
+    ),
+    "mcpServers": (
+        """
+        query ListAvailableMcpServers {
+          listAvailableMcpServers { name mcpUrl description authType source }
+        }
+        """,
+        "listAvailableMcpServers",
+    ),
+    "stateClasses": (
+        """
+        query ListAvailableStateClasses {
+          listAvailableStateClasses { key label description fields }
+        }
+        """,
+        "listAvailableStateClasses",
+    ),
+    "deterministicNodes": (
+        """
+        query ListAvailableDeterministicNodes {
+          listAvailableDeterministicNodes { key label description }
+        }
+        """,
+        "listAvailableDeterministicNodes",
+    ),
+    "skills": (
+        """
+        query ListSkills {
+          listSkills { name description s3Key lastModified }
+        }
+        """,
+        "listSkills",
+    ),
+    # `agentRuntimeArnA2A` is nullable and is the A2A-twin signal validate_config
+    # depends on — always selected here.
+    "agents": (
+        """
+        query ListRuntimeAgents {
+          listRuntimeAgents {
+            agentName
+            agentRuntimeId
+            agentRuntimeArnA2A
+            numberOfVersion
+            qualifierToVersion
+            status
+            architectureType
+          }
+        }
+        """,
+        "listRuntimeAgents",
+    ),
+}
+
+
+def list_building_blocks(category: str | None = None) -> dict:
+    """Return the consolidated building-blocks dict, or just one category.
+
+    Raises RuntimeError (from gql.post) on transport/GraphQL failure."""
+    categories = [category] if category else list(_QUERIES)
+    result: dict[str, list] = {}
+    for cat in categories:
+        query, field = _QUERIES[cat]
+        data = post(query)
+        # A null list (no resolver data) becomes [] so downstream consumers and
+        # the validator never have to special-case None.
+        result[cat] = data.get(field) or []
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--filter",
+        choices=sorted(_QUERIES),
+        help="fetch just one category instead of all six",
+    )
+    args = parser.parse_args()
+
+    try:
+        blocks = list_building_blocks(args.filter)
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(json.dumps(blocks, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/plugins/agent-creator/skills/agent-creator/scripts/manage_skill.py
+++ b/.claude/plugins/agent-creator/skills/agent-creator/scripts/manage_skill.py
@@ -1,0 +1,515 @@
+#!/usr/bin/env python3
+"""Author skills in the deployed accelerator's live skill registry.
+
+Skills are markdown instruction packages stored in the skills S3 bucket at
+`skills/{name}/SKILL.md`. Any SINGLE agent references them by name in its
+`skills[]` field, and the factory loads them at agent-construction time straight
+from S3 — so a new or updated skill is live with **no redeploy**; an existing
+agent picks it up at its next start (re-submit the agent config to force a fresh
+version, see the SKILL.md skill-authoring path).
+
+This is the write side of the `skills` registry; `list_building_blocks.py
+--filter skills` is the read side and shows new skills immediately.
+
+Two backend rules drive this script (verified against
+`src/api/functions/http-api-handler/routes/skills.py`):
+
+  1. **The resolver owns frontmatter.** `createSkill` builds the `---name/
+     description---` block itself from the `name`/`description` args; `content`
+     is the markdown **body only**. This script strips an accidental leading
+     frontmatter block (and warns) so a body never reintroduces a conflicting
+     name and breaks the SDK's dir-name==frontmatter-name check.
+  2. **`updateSkill` MERGES, it does not replace.** Omitted args are preserved
+     server-side (omit `--description` → existing description kept; omit
+     `--body-file` → existing body kept). This is the OPPOSITE of the agent
+     full-config-replace rule — see references/skill-authoring.md. Don't carry
+     agent muscle-memory here.
+
+Mutating subcommands (create/update/delete/put-resource) require `--yes` or an
+interactive confirm. Read-only subcommands (list/get/resources) never confirm.
+
+Usage:
+  manage_skill.py list
+  manage_skill.py get   --name X
+  manage_skill.py create --name X --description "…" --body-file body.md [--yes]
+  manage_skill.py update --name X [--description …] [--body-file …] [--yes]
+  manage_skill.py delete --name X [--yes]
+  manage_skill.py resources    --name X
+  manage_skill.py put-resource --name X --path scripts/foo.py --file foo.py [--yes]
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import re
+import sys
+from pathlib import Path
+
+try:
+    from fetch_agent_config import fetch_agent_config
+    from gql import post
+    from list_building_blocks import list_building_blocks
+except ImportError:  # allow running as a module from elsewhere
+    from .fetch_agent_config import fetch_agent_config
+    from .gql import post
+    from .list_building_blocks import list_building_blocks
+
+# Mirror of the resolver's regex (skills.py:_validate_skill_name) so a bad name
+# fails fast locally with the same message instead of a server round-trip.
+_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$")
+_NAME_RULE = (
+    "Skill name must start with a letter/digit and contain only letters, "
+    "digits, hyphens, and underscores (max 64 chars)"
+)
+
+# Mirror of the resolver's frontmatter matcher (skills.py:_FRONTMATTER_RE) — used
+# only to DETECT and strip an accidental leading frontmatter block from a body.
+_FRONTMATTER_RE = re.compile(r"^---\s*\n.*?\n---\s*\n", re.DOTALL)
+
+# ── GraphQL documents (canonical form + traps: references/queries.md) ──
+_LIST_SKILLS = """
+query ListSkills {
+  listSkills { name description s3Key lastModified }
+}
+"""
+
+_GET_SKILL_CONTENT = """
+query GetSkillContent($name: String!) {
+  getSkillContent(name: $name)
+}
+"""
+
+_LIST_SKILL_RESOURCES = """
+query ListSkillResources($name: String!) {
+  listSkillResources(name: $name) { path size lastModified }
+}
+"""
+
+_CREATE_SKILL = """
+mutation CreateSkill($name: String!, $description: String!, $content: String!) {
+  createSkill(name: $name, description: $description, content: $content) {
+    name description s3Key lastModified
+  }
+}
+"""
+
+_UPDATE_SKILL = """
+mutation UpdateSkill($name: String!, $description: String, $content: String) {
+  updateSkill(name: $name, description: $description, content: $content) {
+    name description s3Key lastModified
+  }
+}
+"""
+
+_DELETE_SKILL = """
+mutation DeleteSkill($name: String!) {
+  deleteSkill(name: $name)
+}
+"""
+
+_UPLOAD_SKILL_RESOURCE = """
+mutation UploadSkillResource($name: String!, $path: String!, $content: String!) {
+  uploadSkillResource(name: $name, path: $path, content: $content) {
+    path size lastModified
+  }
+}
+"""
+
+
+# ── helpers ────────────────────────────────────────────────────────────
+def _validate_name(name: str) -> None:
+    """Raise RuntimeError with the resolver's exact message if name is invalid."""
+    if not _NAME_RE.match(name):
+        raise RuntimeError(_NAME_RULE)
+
+
+def _strip_frontmatter(body: str) -> str:
+    """Strip a leading `---…---` frontmatter block from a body, warning if found.
+
+    The resolver builds frontmatter from --name/--description; a body that also
+    carries a name would clash with the SDK's dir-name==frontmatter-name check.
+    """
+    if _FRONTMATTER_RE.match(body):
+        print(
+            "Warning: --body-file starts with a '---…---' frontmatter block. The "
+            "registry builds frontmatter from --name/--description itself, so this "
+            "script is stripping the block and sending body-only content.",
+            file=sys.stderr,
+        )
+        return _FRONTMATTER_RE.sub("", body, count=1).lstrip()
+    return body
+
+
+def _split_frontmatter(content: str) -> tuple[str, str]:
+    """Split full SKILL.md into (frontmatter-block, body) — '' frontmatter if none."""
+    match = _FRONTMATTER_RE.match(content)
+    if not match:
+        return "", content.strip()
+    return match.group(0), content[match.end() :].strip()
+
+
+def _list_skills() -> list[dict]:
+    return post(_LIST_SKILLS).get("listSkills") or []
+
+
+def _find_skill(name: str, skills: list[dict] | None = None) -> dict | None:
+    for skill in skills if skills is not None else _list_skills():
+        if skill.get("name") == name:
+            return skill
+    return None
+
+
+def _confirm(prompt: str, assume_yes: bool) -> bool:
+    """Return True if the user approved. --yes skips; non-tty without --yes refuses."""
+    if assume_yes:
+        return True
+    if not sys.stdin.isatty():
+        print(
+            "Refusing a mutating operation without confirmation. Re-run with --yes "
+            "(no interactive prompt is available — stdin is not a TTY).",
+            file=sys.stderr,
+        )
+        return False
+    answer = input(f"{prompt} [y/N] ").strip().lower()
+    return answer in ("y", "yes")
+
+
+def _agents_referencing(skill_name: str) -> tuple[list[str], list[str]]:
+    """Return (agents_referencing_skill, agents_we_could_not_check).
+
+    Cross-checks every runtime agent's DEFAULT config `skills[]`. An agent whose
+    config can't be fetched is reported separately so the user knows the
+    reference check was incomplete rather than silently clean.
+    """
+    referencing: list[str] = []
+    unchecked: list[str] = []
+    agents = list_building_blocks("agents").get("agents") or []
+    for agent in agents:
+        agent_name = agent.get("agentName")
+        if not agent_name:
+            continue
+        try:
+            cfg = fetch_agent_config(agent_name).get("config") or {}
+        except RuntimeError:
+            unchecked.append(agent_name)
+            continue
+        if skill_name in (cfg.get("skills") or []):
+            referencing.append(agent_name)
+    return referencing, unchecked
+
+
+# ── subcommands ──────────────────────────────────────────────────────────
+def _cmd_list(_args: argparse.Namespace) -> int:
+    skills = _list_skills()
+    if not skills:
+        print("No skills in the registry.")
+        return 0
+    name_w = max(len("NAME"), *(len(s.get("name", "")) for s in skills))
+    mod_w = max(
+        len("LAST MODIFIED"), *(len(s.get("lastModified") or "") for s in skills)
+    )
+    print(f"{'NAME':<{name_w}}  {'LAST MODIFIED':<{mod_w}}  DESCRIPTION")
+    for s in sorted(skills, key=lambda x: x.get("name", "")):
+        print(
+            f"{s.get('name', ''):<{name_w}}  "
+            f"{(s.get('lastModified') or ''):<{mod_w}}  "
+            f"{s.get('description', '')}"
+        )
+    return 0
+
+
+def _cmd_get(args: argparse.Namespace) -> int:
+    content = post(_GET_SKILL_CONTENT, {"name": args.name}).get("getSkillContent")
+    if content is None:
+        print(
+            f"Skill '{args.name}' not found. Run `manage_skill.py list` to see "
+            f"existing skills.",
+            file=sys.stderr,
+        )
+        return 1
+    print(content)
+    return 0
+
+
+def _cmd_resources(args: argparse.Namespace) -> int:
+    print(
+        "Note: skill resources (scripts/, references/, assets/) are lightly "
+        "exercised — see references/skill-authoring.md. The live factory loader "
+        "DOES download the full skill directory, but a self-contained SKILL.md "
+        "body is the most reliable artifact.",
+        file=sys.stderr,
+    )
+    resources = post(_LIST_SKILL_RESOURCES, {"name": args.name}).get(
+        "listSkillResources"
+    )
+    if not resources:
+        print(f"No resources for skill '{args.name}'.")
+        return 0
+    path_w = max(len("PATH"), *(len(r.get("path", "")) for r in resources))
+    print(f"{'PATH':<{path_w}}  {'SIZE':>8}  LAST MODIFIED")
+    for r in sorted(resources, key=lambda x: x.get("path", "")):
+        print(
+            f"{r.get('path', ''):<{path_w}}  {r.get('size', 0):>8}  "
+            f"{r.get('lastModified') or ''}"
+        )
+    return 0
+
+
+def _cmd_create(args: argparse.Namespace) -> int:
+    _validate_name(args.name)
+
+    # Pre-create uniqueness check: a clean "use update" beats the resolver's
+    # raw ValueError on a duplicate name.
+    if _find_skill(args.name) is not None:
+        print(
+            f"Skill '{args.name}' already exists. Use "
+            f"`manage_skill.py update --name {args.name} …` to change it "
+            f"(update MERGES — omitted fields are preserved).",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        body = _strip_frontmatter(Path(args.body_file).read_text())
+    except OSError as exc:
+        print(f"Could not read --body-file: {exc}", file=sys.stderr)
+        return 2
+
+    print(f"About to CREATE skill '{args.name}':")
+    print(f"  description: {args.description}")
+    print(f"  body: {len(body)} chars from {args.body_file}")
+    if not _confirm(f"Create skill '{args.name}'?", args.yes):
+        print("Aborted.", file=sys.stderr)
+        return 1
+
+    skill = post(
+        _CREATE_SKILL,
+        {"name": args.name, "description": args.description, "content": body},
+    ).get("createSkill")
+    print(
+        f"Created skill '{args.name}'. It is live in S3 now and appears in "
+        f"`list_building_blocks.py --filter skills` immediately. Reference it in a "
+        f"SINGLE agent's `skills[]` — an existing agent loads it only at its next "
+        f"start (re-submit the agent config to force a fresh version)."
+    )
+    if skill:
+        print(f"  s3Key: {skill.get('s3Key')}")
+    return 0
+
+
+def _cmd_update(args: argparse.Namespace) -> int:
+    _validate_name(args.name)
+    if args.description is None and args.body_file is None:
+        print(
+            "Nothing to update — pass --description and/or --body-file.",
+            file=sys.stderr,
+        )
+        return 2
+
+    current = post(_GET_SKILL_CONTENT, {"name": args.name}).get("getSkillContent")
+    if current is None:
+        print(
+            f"Skill '{args.name}' not found — `update` cannot create. Use "
+            f"`manage_skill.py create` instead.",
+            file=sys.stderr,
+        )
+        return 1
+    _, current_body = _split_frontmatter(current)
+
+    new_body = None
+    if args.body_file is not None:
+        try:
+            new_body = _strip_frontmatter(Path(args.body_file).read_text())
+        except OSError as exc:
+            print(f"Could not read --body-file: {exc}", file=sys.stderr)
+            return 2
+
+    # updateSkill MERGES (opposite of the agent full-config-replace rule): we
+    # send ONLY the field(s) changing; omitted args are preserved server-side.
+    print(
+        f"About to UPDATE skill '{args.name}' (MERGE — fields you don't pass are "
+        f"kept; this is the OPPOSITE of the agent full-config-replace rule):"
+    )
+    if args.description is not None:
+        print(f"  description → {args.description}")
+    else:
+        print("  description: unchanged")
+    if new_body is not None:
+        diff = list(
+            difflib.unified_diff(
+                current_body.splitlines(),
+                new_body.splitlines(),
+                fromfile=f"{args.name}/SKILL.md (current body)",
+                tofile=f"{args.name}/SKILL.md (new body)",
+                lineterm="",
+            )
+        )
+        if diff:
+            print("  body diff:")
+            for line in diff:
+                print(f"    {line}")
+        else:
+            print("  body: identical (no change)")
+    else:
+        print("  body: unchanged")
+
+    if not _confirm(f"Update skill '{args.name}'?", args.yes):
+        print("Aborted.", file=sys.stderr)
+        return 1
+
+    variables: dict = {"name": args.name}
+    if args.description is not None:
+        variables["description"] = args.description
+    if new_body is not None:
+        variables["content"] = new_body
+    post(_UPDATE_SKILL, variables)
+    print(
+        f"Updated skill '{args.name}'. Agents already referencing it pick up the "
+        f"change at their next start — re-submit the agent config to force it."
+    )
+    return 0
+
+
+def _cmd_delete(args: argparse.Namespace) -> int:
+    skill = _find_skill(args.name)
+    if skill is None:
+        print(f"Skill '{args.name}' not found — nothing to delete.", file=sys.stderr)
+        return 1
+
+    referencing, unchecked = _agents_referencing(args.name)
+    print(f"About to DELETE skill '{args.name}'.")
+    print(f"  description: {skill.get('description', '')}")
+    if referencing:
+        print(
+            "  ⚠️  These agents currently reference this skill and will silently "
+            "degrade (the factory logs a skip and the agent still starts, minus "
+            "this skill) at their next start:"
+        )
+        for agent_name in referencing:
+            print(f"      - {agent_name}")
+    else:
+        print("  No agents reference this skill.")
+    if unchecked:
+        print(
+            "  Note: could not read the config of these agents, so the reference "
+            f"check is incomplete: {', '.join(unchecked)}"
+        )
+
+    if not _confirm(f"Permanently delete skill '{args.name}'?", args.yes):
+        print("Aborted.", file=sys.stderr)
+        return 1
+
+    post(_DELETE_SKILL, {"name": args.name})
+    print(f"Deleted skill '{args.name}' (SKILL.md and all resources).")
+    return 0
+
+
+def _cmd_put_resource(args: argparse.Namespace) -> int:
+    print(
+        "Note: skill resources are EXPERIMENTAL in this plugin. The live factory "
+        "loader downloads the full skill directory (resources included), but this "
+        "path is lightly exercised — prefer a self-contained SKILL.md body when you "
+        "can. See references/skill-authoring.md.",
+        file=sys.stderr,
+    )
+    if _find_skill(args.name) is None:
+        print(
+            f"Skill '{args.name}' not found — create the skill first "
+            f"(`manage_skill.py create`).",
+            file=sys.stderr,
+        )
+        return 1
+    try:
+        content = Path(args.file).read_text()
+    except OSError as exc:
+        print(f"Could not read --file: {exc}", file=sys.stderr)
+        return 2
+
+    print(f"About to UPLOAD resource to skill '{args.name}':")
+    print(f"  path: {args.path}")
+    print(f"  content: {len(content)} chars from {args.file}")
+    if not _confirm(f"Upload resource '{args.path}' to '{args.name}'?", args.yes):
+        print("Aborted.", file=sys.stderr)
+        return 1
+
+    resource = post(
+        _UPLOAD_SKILL_RESOURCE,
+        {"name": args.name, "path": args.path, "content": content},
+    ).get("uploadSkillResource")
+    print(f"Uploaded resource '{args.path}' to skill '{args.name}'.")
+    if resource:
+        print(f"  size: {resource.get('size')} bytes")
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_list = sub.add_parser("list", help="table of name/description/lastModified")
+    p_list.set_defaults(func=_cmd_list)
+
+    p_get = sub.add_parser("get", help="full markdown (frontmatter + body)")
+    p_get.add_argument("--name", required=True)
+    p_get.set_defaults(func=_cmd_get)
+
+    p_create = sub.add_parser("create", help="create a new skill (body-only content)")
+    p_create.add_argument("--name", required=True)
+    p_create.add_argument("--description", required=True)
+    p_create.add_argument(
+        "--body-file",
+        required=True,
+        help="markdown body (frontmatter stripped if present)",
+    )
+    p_create.add_argument("--yes", action="store_true", help="skip confirmation")
+    p_create.set_defaults(func=_cmd_create)
+
+    p_update = sub.add_parser("update", help="MERGE-update (omitted fields preserved)")
+    p_update.add_argument("--name", required=True)
+    p_update.add_argument(
+        "--description", help="new description (omit to keep current)"
+    )
+    p_update.add_argument(
+        "--body-file",
+        help="new markdown body (omit to keep current; frontmatter stripped)",
+    )
+    p_update.add_argument("--yes", action="store_true", help="skip confirmation")
+    p_update.set_defaults(func=_cmd_update)
+
+    p_delete = sub.add_parser(
+        "delete", help="delete a skill (warns on referencing agents)"
+    )
+    p_delete.add_argument("--name", required=True)
+    p_delete.add_argument("--yes", action="store_true", help="skip confirmation")
+    p_delete.set_defaults(func=_cmd_delete)
+
+    p_res = sub.add_parser("resources", help="list a skill's resources (experimental)")
+    p_res.add_argument("--name", required=True)
+    p_res.set_defaults(func=_cmd_resources)
+
+    p_put = sub.add_parser(
+        "put-resource", help="upload a resource to a skill (experimental)"
+    )
+    p_put.add_argument("--name", required=True)
+    p_put.add_argument(
+        "--path", required=True, help="relative path, e.g. scripts/foo.py"
+    )
+    p_put.add_argument("--file", required=True, help="local file to upload as content")
+    p_put.add_argument("--yes", action="store_true", help="skip confirmation")
+    p_put.set_defaults(func=_cmd_put_resource)
+
+    return parser
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+    try:
+        return args.func(args)
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/plugins/agent-creator/skills/agent-creator/scripts/requirements.txt
+++ b/.claude/plugins/agent-creator/skills/agent-creator/scripts/requirements.txt
@@ -1,0 +1,4 @@
+# agent-creator plugin script dependencies.
+# Raw HTTP + boto3 — no Amplify SDK needed.
+boto3>=1.34
+requests>=2.31

--- a/.claude/plugins/agent-creator/skills/agent-creator/scripts/submit_runtime.py
+++ b/.claude/plugins/agent-creator/skills/agent-creator/scripts/submit_runtime.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Submit an agent config and poll until the runtime is actually Ready.
+
+This is the only mutating script in the plugin. It does create *and* update —
+the accelerator has no separate update mutation, so re-submitting under an
+existing `agentName` mints a new version (read-modify-write; the caller fetched
+and modified the full config first, see fetch_agent_config.py / task 06).
+
+Why polling is mandatory: the resolver calls Step Functions fire-and-forget and
+returns `agentName` the instant the SFN *starts*, not when the runtime is live.
+A successful mutation return means "accepted & provisioning kicked off", not
+"agent ready". The only real confirmation is polling RuntimeSummary.status
+(via listRuntimeAgents) until it reaches Ready — or a terminal failure.
+
+Status lifecycle (from the create-agentcore-runtime state machine):
+  Creating → Ready            (success)
+  Creating → "Create Failed"  (terminal failure — incl. the tag-match guard)
+Status is a free-form String!, so we match it tolerantly (substring/case), not
+against an enum.
+
+Flow:
+  1. Guard — run local validation (validate_config) first; refuse to submit on
+     failure. The server rejects bad configs by returning "" with no error, so
+     catching it locally is the only way to give a real reason.
+  2. createAgentCoreRuntime(agentName, configValue, architectureType).
+     A "" return is a hard failure (server-side validation) — explained, not
+     silently treated as success.
+  3. Poll listRuntimeAgents until status is Ready / terminal / timeout.
+
+Usage:
+  submit_runtime.py --config <path|-> --architecture SINGLE|SWARM|GRAPH|AGENTS_AS_TOOLS
+      --agent <name> [--timeout 600] [--interval 10]
+      [--tag <qualifier>] [--skip-validation]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+try:
+    from gql import post
+    from list_building_blocks import list_building_blocks
+    from validate_config import validate_config
+except ImportError:  # allow running as a module from elsewhere
+    from .gql import post
+    from .list_building_blocks import list_building_blocks
+    from .validate_config import validate_config
+
+_CREATE_MUTATION = """
+mutation CreateAgentCoreRuntime(
+  $agentName: String!
+  $configValue: String!
+  $architectureType: ArchitectureType
+) {
+  createAgentCoreRuntime(
+    agentName: $agentName
+    configValue: $configValue
+    architectureType: $architectureType
+  )
+}
+"""
+
+_TAG_MUTATION = """
+mutation TagAgentCoreRuntime(
+  $agentName: String!
+  $agentRuntimeId: String!
+  $currentQualifierToVersion: String!
+  $agentVersion: String!
+  $qualifier: String!
+  $description: String
+) {
+  tagAgentCoreRuntime(
+    agentName: $agentName
+    agentRuntimeId: $agentRuntimeId
+    currentQualifierToVersion: $currentQualifierToVersion
+    agentVersion: $agentVersion
+    qualifier: $qualifier
+    description: $description
+  )
+}
+"""
+
+_DEFAULT_TIMEOUT_SECONDS = 600
+_DEFAULT_POLL_INTERVAL_SECONDS = 10
+
+
+def _read_config(source: str) -> str:
+    """Return the raw config JSON string from a path or stdin ('-')."""
+    if source == "-":
+        return sys.stdin.read()
+    return Path(source).read_text()
+
+
+# Full RuntimeSummary selection so the success report and version/tag logic have
+# everything they need (the lean _LIST_AGENTS in fetch_agent_config only selects
+# name + architectureType).
+_RUNTIME_SUMMARY_QUERY = """
+query ListRuntimeAgents {
+  listRuntimeAgents {
+    agentName
+    agentRuntimeId
+    agentRuntimeArnA2A
+    numberOfVersion
+    qualifierToVersion
+    status
+    architectureType
+  }
+}
+"""
+
+
+def _summary_for(agent_name: str) -> dict | None:
+    """Return the RuntimeSummary for an agent, or None if it's not listed yet."""
+    data = post(_RUNTIME_SUMMARY_QUERY)
+    for summary in data.get("listRuntimeAgents") or []:
+        if summary.get("agentName") == agent_name:
+            return summary
+    return None
+
+
+def _is_ready(status: str) -> bool:
+    return status.strip().lower() == "ready"
+
+
+def _is_failed(status: str) -> bool:
+    return "fail" in status.strip().lower()
+
+
+def _validate(config_json: str, architecture: str) -> list[str]:
+    """Run the local validation gate with live registry data when reachable.
+
+    Falls back to schema-only validation (with a warning) if building-blocks
+    can't be fetched, so a transient discovery hiccup doesn't block a submit
+    whose schema is sound."""
+    try:
+        blocks = list_building_blocks()
+    except RuntimeError as exc:
+        print(
+            f"Warning: could not fetch building-blocks for full validation "
+            f"({exc}); running schema-only validation.",
+            file=sys.stderr,
+        )
+        blocks = None
+    return validate_config(config_json, architecture, blocks)
+
+
+def submit_and_poll(
+    agent_name: str,
+    config_json: str,
+    architecture: str,
+    *,
+    timeout: int = _DEFAULT_TIMEOUT_SECONDS,
+    interval: int = _DEFAULT_POLL_INTERVAL_SECONDS,
+    skip_validation: bool = False,
+) -> dict:
+    """Submit a config and block until the runtime is Ready.
+
+    Returns the final RuntimeSummary on success. Raises RuntimeError with an
+    actionable message on validation failure, server rejection, terminal SFN
+    failure, or poll timeout."""
+    # 1. Local validation gate.
+    if not skip_validation:
+        problems = _validate(config_json, architecture)
+        if problems:
+            raise RuntimeError(
+                "Refusing to submit — local validation failed:\n"
+                + "\n".join(f"  - {p}" for p in problems)
+            )
+
+    # Is this an update? Remember whether the agent already exists so a terminal
+    # failure can point at the tag-match guard (the most likely update surprise).
+    pre_existing = _summary_for(agent_name)
+    is_update = pre_existing is not None
+
+    # 2. Submit. createAgentCoreRuntime returns agentName, or "" on server-side
+    # validation failure (no GraphQL error — that's why step 1 exists).
+    data = post(
+        _CREATE_MUTATION,
+        {
+            "agentName": agent_name,
+            "configValue": config_json,
+            "architectureType": architecture,
+        },
+    )
+    returned = data.get("createAgentCoreRuntime")
+    if not returned:
+        raise RuntimeError(
+            "Server rejected the config before provisioning (createAgentCoreRuntime "
+            "returned an empty string — server-side validation failed). Run "
+            "validate_config.py against this config and the live registry to see why."
+        )
+
+    print(
+        f"Submitted '{agent_name}' ({architecture}); provisioning started. "
+        f"Polling status every {interval}s (timeout {timeout}s)...",
+        file=sys.stderr,
+    )
+
+    # 3. Poll until Ready / terminal / timeout. monotonic clock so a wall-clock
+    # adjustment can't make the loop hang or exit early.
+    deadline = time.monotonic() + timeout
+    last_status = "<not yet listed>"
+    while time.monotonic() < deadline:
+        summary = _summary_for(agent_name)
+        if summary is not None:
+            last_status = summary.get("status", "")
+            if _is_ready(last_status):
+                return summary
+            if _is_failed(last_status):
+                raise RuntimeError(_terminal_failure_message(last_status, is_update))
+        time.sleep(interval)
+
+    raise RuntimeError(
+        f"Timed out after {timeout}s — agent '{agent_name}' is still "
+        f"'{last_status}'. Provisioning may be slow or the Step Function may have "
+        f"failed silently. Check the create-agentcore-runtime Step Function "
+        f"execution in the AWS console."
+    )
+
+
+def _terminal_failure_message(status: str, is_update: bool) -> str:
+    """Explain a terminal failure status, flagging the tag-match guard on updates."""
+    base = (
+        f"Provisioning failed — agent reached terminal status '{status}'. "
+        f"Check the create-agentcore-runtime Step Function execution in the console."
+    )
+    if is_update:
+        return (
+            base
+            + "\nThis was an update to an existing agent. The most likely cause is "
+            "the tag-match guard: you can only update agents whose Stack/Environment "
+            "tags match the stack you're authenticated against. If this agent was "
+            "created by a different stack/environment, the update is blocked."
+        )
+    return base
+
+
+def _maybe_tag(summary: dict, qualifier: str) -> None:
+    """Point a qualifier endpoint at the agent's newest version (opt-in)."""
+    agent_name = summary["agentName"]
+    agent_runtime_id = summary["agentRuntimeId"]
+    # numberOfVersion is the just-minted latest version (String!).
+    agent_version = summary["numberOfVersion"]
+    current_qtv = summary.get("qualifierToVersion", "{}")
+    print(
+        f"Tagging qualifier '{qualifier}' → version {agent_version}...",
+        file=sys.stderr,
+    )
+    data = post(
+        _TAG_MUTATION,
+        {
+            "agentName": agent_name,
+            "agentRuntimeId": agent_runtime_id,
+            "currentQualifierToVersion": current_qtv,
+            "agentVersion": agent_version,
+            "qualifier": qualifier,
+        },
+    )
+    if not data.get("tagAgentCoreRuntime"):
+        raise RuntimeError(
+            f"Endpoint tagging failed for qualifier '{qualifier}' — the runtime is "
+            f"Ready, but the endpoint could not be created/pointed. Tag manually or "
+            f"retry."
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config", required=True, help="config JSON path, or '-' for stdin"
+    )
+    parser.add_argument("--agent", required=True, help="agent name (create or update)")
+    parser.add_argument(
+        "--architecture",
+        default="SINGLE",
+        choices=["SINGLE", "SWARM", "GRAPH", "AGENTS_AS_TOOLS"],
+        help="architecture pattern (default: SINGLE)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=_DEFAULT_TIMEOUT_SECONDS,
+        help=f"max seconds to poll (default: {_DEFAULT_TIMEOUT_SECONDS})",
+    )
+    parser.add_argument(
+        "--interval",
+        type=int,
+        default=_DEFAULT_POLL_INTERVAL_SECONDS,
+        help=f"seconds between polls (default: {_DEFAULT_POLL_INTERVAL_SECONDS})",
+    )
+    parser.add_argument(
+        "--tag",
+        help="after Ready, point this qualifier endpoint at the new version (opt-in)",
+    )
+    parser.add_argument(
+        "--skip-validation",
+        action="store_true",
+        help="skip the local validation gate (not recommended)",
+    )
+    args = parser.parse_args()
+
+    try:
+        config_json = _read_config(args.config)
+    except OSError as exc:
+        print(f"Could not read config: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        summary = submit_and_poll(
+            args.agent,
+            config_json,
+            args.architecture,
+            timeout=args.timeout,
+            interval=args.interval,
+            skip_validation=args.skip_validation,
+        )
+        if args.tag:
+            _maybe_tag(summary, args.tag)
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(f"Agent '{args.agent}' is Ready.", file=sys.stderr)
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/plugins/agent-creator/skills/agent-creator/scripts/validate_config.py
+++ b/.claude/plugins/agent-creator/skills/agent-creator/scripts/validate_config.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+"""Pre-submit validation gate with parity to the server-side resolver.
+
+`createAgentCoreRuntime` (src/api/functions/agent-factory-resolver/index.py)
+returns `""` *silently* on any validation failure — no GraphQL error, no reason.
+A user who submits a bad config just gets an empty string back and no clue why.
+This script reproduces the resolver's accept/reject decision locally and prints a
+real, actionable message *before* the network round-trip.
+
+Parity is kept automatic (not vendored) by importing the resolver's own Pydantic
+models from the in-repo layer `src/shared/layers/python-sdk/genai_core`. The plugin
+ships inside this repo, so the path is always present and the models never drift.
+
+Two layers of checks:
+
+  1. Pydantic parse against the architecture's model — this is exactly what the
+     resolver does (AgentConfiguration / SwarmConfiguration / GraphConfiguration /
+     AgentsAsToolsConfiguration). Catches missing fields, bad types, and the
+     toolParameters↔tools consistency / graph-edge / entry-agent validators.
+
+  2. Registry + A2A cross-checks — the resolver hits DynamoDB for these
+     (A2A-twin lookups for AGENTS_AS_TOOLS and GRAPH); we mirror them against the
+     JSON dumped by `list_building_blocks.py`. We additionally pre-check that every
+     referenced tool / MCP server / skill / state class / deterministic node exists,
+     which the resolver defers to runtime — catching at submit time what would
+     otherwise be a live-agent failure. These checks need `--building-blocks`; without
+     it they are skipped with a warning so the script still does pure schema validation
+     offline.
+
+Usage:
+  python validate_config.py --config <path|-> --architecture SINGLE|SWARM|GRAPH|AGENTS_AS_TOOLS
+      [--building-blocks <path>]
+  → exit 0 + "OK" on success
+  → exit non-zero + a numbered list of problems on failure
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# --------------------------------------------------------------------------- #
+# Import the resolver's Pydantic models straight from the in-repo SDK layer so
+# validation stays byte-for-byte identical to the server. We locate the repo by
+# walking up for the layer dir rather than hard-coding a depth, since the plugin
+# can be invoked from anywhere.
+# --------------------------------------------------------------------------- #
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_LAYER_RELATIVE = Path("src/shared/layers/python-sdk")
+
+
+def _find_sdk_layer() -> Path | None:
+    for parent in _SCRIPT_DIR.parents:
+        candidate = parent / _LAYER_RELATIVE
+        if (candidate / "genai_core" / "api_helper" / "types.py").exists():
+            return candidate
+    return None
+
+
+_SDK_LAYER = _find_sdk_layer()
+if _SDK_LAYER and str(_SDK_LAYER) not in sys.path:
+    sys.path.insert(0, str(_SDK_LAYER))
+
+try:
+    from genai_core.api_helper.types import (  # noqa: E402
+        AgentConfiguration,
+        AgentsAsToolsConfiguration,
+        ArchitectureType,
+        GraphConfiguration,
+        SwarmConfiguration,
+    )
+    from pydantic import ValidationError  # noqa: E402
+except ImportError as exc:  # pragma: no cover - environment problem, not config problem
+    print(
+        "Could not import the resolver's Pydantic models. Expected to find "
+        f"{_LAYER_RELATIVE}/genai_core/api_helper/types.py by walking up from "
+        f"{_SCRIPT_DIR}. Run from inside the accelerator repo and ensure pydantic "
+        f"is installed (see requirements.txt). Underlying error: {exc}",
+        file=sys.stderr,
+    )
+    raise SystemExit(2)
+
+
+# Maps the architecture flag to the model the resolver dispatches to.
+_MODEL_BY_ARCHITECTURE = {
+    ArchitectureType.SINGLE.value: AgentConfiguration,
+    ArchitectureType.SWARM.value: SwarmConfiguration,
+    ArchitectureType.GRAPH.value: GraphConfiguration,
+    ArchitectureType.AGENTS_AS_TOOLS.value: AgentsAsToolsConfiguration,
+}
+
+
+def _read_config(source: str) -> str:
+    """Return the raw config JSON string from a path or stdin ('-')."""
+    if source == "-":
+        return sys.stdin.read()
+    return Path(source).read_text()
+
+
+def _format_pydantic_errors(exc: ValidationError, architecture: str) -> list[str]:
+    """Turn a ValidationError into one human-readable line per problem."""
+    problems = []
+    for err in exc.errors():
+        loc = ".".join(str(p) for p in err["loc"]) or "<root>"
+        problems.append(
+            f"{architecture} config invalid at '{loc}': {err['msg']} "
+            f"(type={err['type']})"
+        )
+    return problems
+
+
+# --------------------------------------------------------------------------- #
+# Building-blocks helpers — the JSON shape produced by list_building_blocks.py:
+#   {"tools": [...], "mcpServers": [...], "stateClasses": [...],
+#    "deterministicNodes": [...], "skills": [...], "agents": [...]}
+# --------------------------------------------------------------------------- #
+def _index_names(entries: list[dict] | None, *keys: str) -> set[str]:
+    """Collect identifier values from a registry list, trying each key in order."""
+    names: set[str] = set()
+    for entry in entries or []:
+        for key in keys:
+            value = entry.get(key)
+            if value:
+                names.add(value)
+                break
+    return names
+
+
+def _check_membership(
+    referenced: list[str] | None,
+    available: set[str],
+    field: str,
+    kind: str,
+    scaffold_hint: bool = False,
+) -> list[str]:
+    """Report any referenced name missing from `available`."""
+    problems = []
+    available_sorted = sorted(available)
+    for i, name in enumerate(referenced or []):
+        if name not in available:
+            hint = (
+                " Either pick an existing one or scaffold a new one (see custom-code)."
+                if scaffold_hint
+                else ""
+            )
+            problems.append(
+                f"{field}[{i}] '{name}' is not in the {kind} registry. "
+                f"Available: {available_sorted}.{hint}"
+            )
+    return problems
+
+
+def _agent_twin_index(
+    agents: list[dict] | None,
+) -> tuple[dict[str, bool], dict[str, bool]]:
+    """Build {agentName: has_a2a_twin} and {agentRuntimeId: has_a2a_twin} maps.
+
+    AGENTS_AS_TOOLS references sub-agents by `runtimeId` (the HTTP runtime ID the
+    UI surfaces); GRAPH references them by `agentName`. We index both ways so each
+    architecture's check matches the same field the resolver does.
+    """
+    by_name: dict[str, bool] = {}
+    by_runtime_id: dict[str, bool] = {}
+    for agent in agents or []:
+        has_twin = bool(agent.get("agentRuntimeArnA2A"))
+        name = agent.get("agentName")
+        runtime_id = agent.get("agentRuntimeId")
+        if name:
+            by_name[name] = has_twin
+        if runtime_id:
+            by_runtime_id[runtime_id] = has_twin
+    return by_name, by_runtime_id
+
+
+def _cross_check(architecture: str, config: dict, blocks: dict) -> list[str]:
+    """Registry + A2A-twin cross-checks against the building-blocks data.
+
+    Mirrors the DynamoDB lookups the resolver performs (A2A twins) and adds
+    pre-checks for tool/MCP/skill/state/node existence that the resolver defers
+    to runtime.
+    """
+    problems: list[str] = []
+
+    tools = _index_names(blocks.get("tools"), "name")
+    mcp_servers = _index_names(blocks.get("mcpServers"), "name")
+    skills = _index_names(blocks.get("skills"), "name")
+    state_classes = _index_names(blocks.get("stateClasses"), "key")
+    det_nodes = _index_names(blocks.get("deterministicNodes"), "key")
+    twin_by_name, twin_by_runtime_id = _agent_twin_index(blocks.get("agents"))
+
+    if architecture == ArchitectureType.SINGLE.value:
+        problems += _check_membership(
+            config.get("tools"), tools, "tools", "tool", scaffold_hint=True
+        )
+        problems += _check_membership(
+            config.get("mcpServers"), mcp_servers, "mcpServers", "MCP server"
+        )
+        problems += _check_membership(config.get("skills"), skills, "skills", "skill")
+
+    elif architecture == ArchitectureType.AGENTS_AS_TOOLS.value:
+        problems += _check_membership(
+            config.get("tools"), tools, "tools", "tool", scaffold_hint=True
+        )
+        problems += _check_membership(
+            config.get("mcpServers"), mcp_servers, "mcpServers", "MCP server"
+        )
+        for i, sub in enumerate(config.get("agentsAsTools") or []):
+            runtime_id = sub.get("runtimeId", "")
+            # An already-rewritten config carries the A2A twin ARN directly; the
+            # resolver skips re-resolution for these, so we do too.
+            if runtime_id.startswith("arn:"):
+                continue
+            if runtime_id not in twin_by_runtime_id:
+                problems.append(
+                    f"agentsAsTools[{i}] runtimeId '{runtime_id}' does not match any "
+                    f"known runtime. Available runtime IDs: "
+                    f"{sorted(twin_by_runtime_id)}."
+                )
+            elif not twin_by_runtime_id[runtime_id]:
+                problems.append(
+                    f"agentsAsTools[{i}] runtimeId '{runtime_id}' has no A2A twin "
+                    f"runtime — the orchestrator invokes sub-agents over A2A. "
+                    f"Recreate the sub-agent so its A2A twin is provisioned."
+                )
+
+    elif architecture == ArchitectureType.GRAPH.value:
+        state_class = config.get("stateClass")
+        if state_class and state_class not in state_classes:
+            problems.append(
+                f"stateClass '{state_class}' is not in the state-class registry. "
+                f"Available: {sorted(state_classes)}."
+            )
+        for i, node in enumerate(config.get("nodes") or []):
+            det_key = node.get("deterministicNodeKey")
+            if det_key and det_key not in det_nodes:
+                problems.append(
+                    f"nodes[{i}].deterministicNodeKey '{det_key}' is not in the "
+                    f"deterministic-node registry. Available: {sorted(det_nodes)}."
+                )
+            agent_name = node.get("agentName")
+            if not agent_name:
+                continue
+            if agent_name not in twin_by_name:
+                problems.append(
+                    f"nodes[{i}].agentName '{agent_name}' references a non-existent "
+                    f"agent. Available agents: {sorted(twin_by_name)}."
+                )
+            elif not twin_by_name[agent_name]:
+                problems.append(
+                    f"nodes[{i}].agentName '{agent_name}' has no A2A twin runtime — "
+                    f"graph nodes call sub-agents over A2A. Recreate the agent so its "
+                    f"A2A twin is provisioned."
+                )
+
+    elif architecture == ArchitectureType.SWARM.value:
+        # The resolver does no swarm registry cross-check (entryAgent membership is
+        # enforced by the Pydantic model). We additionally verify each referenced
+        # agent actually exists as a runtime, which surfaces a typo'd reference
+        # before the swarm fails to load it at runtime.
+        ref_names = [
+            ref.get("agentName")
+            for ref in config.get("agentReferences") or []
+            if ref.get("agentName")
+        ]
+        problems += _check_membership(
+            ref_names, set(twin_by_name), "agentReferences", "runtime agent"
+        )
+
+    return problems
+
+
+def validate_config(
+    config_json: str, architecture: str, blocks: dict | None
+) -> list[str]:
+    """Return a list of problems; an empty list means the config is valid.
+
+    `blocks` is the parsed building-blocks JSON, or None to skip registry/A2A
+    cross-checks (pure schema validation only)."""
+    model = _MODEL_BY_ARCHITECTURE.get(architecture)
+    if model is None:
+        return [
+            f"Unknown architecture '{architecture}'. Expected one of: "
+            f"{sorted(_MODEL_BY_ARCHITECTURE)}."
+        ]
+
+    # Parse first so we can give a JSON-specific message (mirrors the resolver's
+    # JSONDecodeError branch) and so cross-checks have a dict to read.
+    try:
+        config_dict = json.loads(config_json)
+    except json.JSONDecodeError as exc:
+        return [f"Config is not valid JSON: {exc}"]
+
+    # Layer 1 — exact resolver parity via the shared Pydantic model.
+    try:
+        model.model_validate_json(config_json)
+    except ValidationError as exc:
+        # A schema failure is also how the resolver rejects, so stop here: the
+        # cross-checks below assume a well-formed config shape.
+        return _format_pydantic_errors(exc, architecture)
+
+    # Layer 2 — registry + A2A cross-checks (only when we have live data).
+    if blocks is None:
+        return []
+    return _cross_check(architecture, config_dict, blocks)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        required=True,
+        help="path to the config JSON, or '-' to read from stdin",
+    )
+    parser.add_argument(
+        "--architecture",
+        default=ArchitectureType.SINGLE.value,
+        choices=sorted(_MODEL_BY_ARCHITECTURE),
+        help="architecture pattern (default: SINGLE, matching the resolver)",
+    )
+    parser.add_argument(
+        "--building-blocks",
+        help="path to list_building_blocks.py output for registry/A2A cross-checks. "
+        "Omit to run pure schema validation offline.",
+    )
+    args = parser.parse_args()
+
+    try:
+        config_json = _read_config(args.config)
+    except OSError as exc:
+        print(f"Could not read config: {exc}", file=sys.stderr)
+        return 2
+
+    blocks: dict | None = None
+    if args.building_blocks:
+        try:
+            blocks = json.loads(Path(args.building_blocks).read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"Could not read --building-blocks: {exc}", file=sys.stderr)
+            return 2
+    else:
+        print(
+            "Warning: --building-blocks not provided — skipping registry and A2A-twin "
+            "cross-checks (tool/MCP/skill/state/node existence and sub-agent twins). "
+            "Running pure schema validation only.",
+            file=sys.stderr,
+        )
+
+    problems = validate_config(config_json, args.architecture, blocks)
+
+    if not problems:
+        print("OK")
+        return 0
+
+    print(
+        f"Config validation failed ({len(problems)} problem"
+        f"{'s' if len(problems) != 1 else ''}):",
+        file=sys.stderr,
+    )
+    for i, problem in enumerate(problems, 1):
+        print(f"  {i}. {problem}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,15 @@
 {
   "enabledPlugins": {
     "skill-creator@claude-plugins-official": true,
-    "code-review@claude-plugins-official": true
+    "code-review@claude-plugins-official": true,
+    "agent-creator@agent-creator-marketplace": true
+  },
+  "extraKnownMarketplaces": {
+    "agent-creator-marketplace": {
+      "source": {
+        "source": "directory",
+        "path": ".claude"
+      }
+    }
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ cache
 .env
 *.DS_Store*
 
+# agent-creator plugin: cached endpoint discovery (never commit resolved IDs)
+.agent-creator-cache.json
+
 # Include Resolvers JS code
 !src/api/functions/resolvers/*.js
 !src/api/functions/resolvers/favorite-runtime-resolvers/*.js

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ The accelerator also supports **Voice-to-Voice** conversations powered by Amazon
 
 For systematic validation, run evaluations powered by the [Strands Agents Evals SDK](https://strandsagents.com/latest/documentation/docs/user-guide/evals-sdk/quickstart/) to assess output quality, tool usage, trajectory efficiency, and multi-agent interactions. See [Agent Evaluation](./docs/src/evaluation.md) for details.
 
+## Create Agents from Your Editor (Claude Code plugin)
+
+Everything the Agent Factory UI does, you can also drive from a conversation in [Claude Code](https://claude.ai/code) via the bundled **agent-creator** plugin (`.claude/plugins/agent-creator/`). Describe the agent you want — "an orchestrator that consults an AWS-docs specialist and a cost specialist, then writes the recommendation" — and it picks the agentic pattern, wires it from the tools, MCP servers, skills, and existing agents already in your **deployed** stack, validates the config with parity to the server, and submits it through the same API the UI uses, polling until the runtime is Ready. It also modifies live agents (model, prompt, tools), diagnoses misbehavior from traces, and authors reusable skills. See the [plugin README](./.claude/plugins/agent-creator/README.md).
+
+> The plugin operates on a **deployed** stack via the Agent Factory API — it does not generate IaC. For build-time `config.yaml`/`tfvars`, see [How to Deploy](./docs/src/how-to-deploy.md).
+
 ## AWS Platform Details
 
 - [Architecture](./docs/src/architecture.md)


### PR DESCRIPTION
## Summary

Adds **agent-creator**, a Claude Code plugin that drives the accelerator's Agent Factory from a conversation in the editor. You describe the agent you want and it picks the agentic pattern (single / agents-as-tools / swarm / graph), wires it from the tools, MCP servers, skills, and existing agents already present in your **deployed** stack, validates the config with parity to the server, and submits it through the same API the UI uses — polling until the runtime is Ready. It also updates live agents, diagnoses misbehavior from X-Ray traces, and authors reusable skills.

This is editor tooling, not application code — it operates against a deployed stack via the Agent Factory API and does **not** generate or change IaC.

## Changes

- **Plugin scaffold:** new local marketplace (`.claude/.claude-plugin/marketplace.json and plugin manifest; registered in `.claude/settings.json` via a directory-source marketplace so it loads without external install.
- **Skill workflow:** `SKILL.md` orchestrates the create/update/diagnose/author paths, backed by reference docs (architectures, config schemas, registries, queries, update semantics, custom-code scaffolding, trace diagnosis, skill-authoring) and a `config-reviewer` sub-agent.
- **Helper scripts (Python):** endpoint discovery, Cognito token fetch, GraphQL client, agent-config fetch, building-block listing, pre-submit config validation (server parity), runtime submission with poll-to-Ready, trace fetch, and skill management (create/update).
- **Docs:** root `README.md` section pointing builders at the plugin and distinguishing it from `iac-config-generator` (deploy-time config).
- **`.gitignore`:** ignore `.agent-creator-cache.json` so resolved endpoint / Cognito / runtime IDs from a deployed stack are never committed.

## Test plan

- [x] Plugin loads: `/agent-creator` (or the skill) is listed after the branch is checked out, with no marketplace-resolution errors on startup.
- [x] Against a deployed stack, run the create path end-to-end (discover endpoint → fetch token → list building blocks → validate → submit) and confirm the runtime reaches Ready.
- [x] `validate_config.py` rejects a knowingly-bad config (e.g.  sub-agent referencing a non-existent runtime) before submit.
- [x] Cannot exercise the live API paths in CI — verified by reading the  queries/mutations against the schema and running the scripts against a sandbox stack.

## Follow-ups

A correctness pass over the Python helpers surfaced a few edge-case robustness issues — none block the happy path, all live in `.claude/` tooling (not shipped runtime code), tracked for a follow-up hardening commit:

- `submit_runtime.py` — poll loop can report success early on an **update** when the prior version is already `Ready` (status is per-agent, not per-in-flight version); `_is_failed` substring-matches `fail` while `_is_ready` requires exact `ready` (inconsistent strictness); tag mutation uses version *count* as version *id*, which diverges if any version was deleted.
- `discover_endpoint.py` — an explicit `--stack-name` that doesn't exist is swallowed and silently falls back to local `aws-exports.json`; auto-discovery matches any `*-aca` stack, ambiguous in multi-deployment accounts.
- `get_token.py` — `.env` gitignore guard uses a substring check that can falsely conclude `.env` is already ignored, risking a committed creds file.
- `manage_skill.py` — update uses `getSkillContent` for existence while create uses the registry; a registry skill with empty content can become un-updatable.
- `fetch_traces.py` — X-Ray span pagination caps at the first page (~1000 events) and truncates silently.
