### PR TITLE
🐛 (agent-creator): fix endpoint discovery profile/region & CDK-hashed outputs

### DIFF
--- a/.claude/plugins/agent-creator/README.md
+++ b/.claude/plugins/agent-creator/README.md
@@ -1,30 +1,19 @@
 # agent-creator
 
-A Claude Code plugin that creates and modifies **live AgentCore runtime agents** in a
-**deployed** instance of this accelerator — the same agents you'd otherwise build by
-clicking through the Agent Factory UI, driven instead from a conversation in your editor.
+A Claude Code plugin that creates and modifies **live AgentCore runtime agents** in a **deployed** instance of this accelerator — the same agents you'd otherwise build by clicking through the Agent Factory UI, driven instead from a conversation in your editor.
 
-You describe what you want ("an orchestrator that consults an AWS-docs specialist and a
-cost specialist, then writes the recommendation"); the plugin picks the right agentic
-pattern, wires it from the building-blocks already in your running system (tools, MCP
-servers, skills, existing agents), validates the config with parity to the server, and
-submits it through the same GraphQL mutation the UI uses — polling until the runtime is
-**Ready**.
+You describe what you want ("an orchestrator that consults an AWS-docs specialist and a cost specialist, then writes the recommendation"); the plugin picks the right agentic pattern, wires it from the building-blocks already in your running system (tools, MCP servers, skills, existing agents), validates the config with parity to the server, and submits it through the same GraphQL mutation the UI uses — polling until the runtime is **Ready**.
 
-> **This plugin talks to a *deployed* stack over the Agent Factory API.** It does **not**
-> generate IaC. For build-time, baked-into-the-stack config (`config.yaml` / `tfvars`),
-> use the `iac-config-generator` skill instead.
+> **This plugin talks to a *deployed* stack over the Agent Factory API.** It does **not** generate IaC. For build-time, baked-into-the-stack config (`config.yaml` / `tfvars`), use the `iac-config-generator` skill instead.
 
 ## When to use it
 
 Invoke it (via `/agent-creator:agent-creator`, or just describe the task) when you want to:
 
 - **Create** a new runtime agent — single, or a multi-agent orchestrator / swarm / graph.
-- **Modify** a live agent — change its model or system prompt, add/remove tools, MCP
-  servers, or skills.
+- **Modify** a live agent — change its model or system prompt, add/remove tools, MCP servers, or skills.
 - **Diagnose** a misbehaving agent from traces / eval output, and apply the config-level fix.
-- **Author a skill** — a reusable, loadable instruction package an agent picks up at start,
-  live with no redeploy.
+- **Author a skill** — a reusable, loadable instruction package an agent picks up at start, live with no redeploy.
 
 ## The four paths
 
@@ -37,89 +26,86 @@ Invoke it (via `/agent-creator:agent-creator`, or just describe the task) when y
 
 ## Architecture patterns it can build
 
-The plugin classifies your request into one of four patterns (it decides — you don't have
-to name it):
+The plugin classifies your request into one of four patterns (it decides — you don't have to name it):
 
 - **Single** — one agent, one job (tools + MCP + skills, optional structured output).
-- **Agents as Tools** — a coordinator that delegates to specialist sub-agents it chooses at
-  runtime.
-- **Swarm** — peer agents that hand control to each other collaboratively, with emergent
-  order.
+- **Agents as Tools** — a coordinator that delegates to specialist sub-agents it chooses at runtime.
+- **Swarm** — peer agents that hand control to each other collaboratively, with emergent order.
 - **Graph** — a fixed, author-defined workflow of nodes and edges with shared state.
 
-Multi-agent patterns reference sub-agents that must already exist (and, for Agents-as-Tools
-and Graph, have an **A2A twin**), so the plugin builds bottom-up: specialists first, the
-coordinator last.
+Multi-agent patterns reference sub-agents that must already exist (and, for Agents-as-Tools and Graph, have an **A2A twin**), so the plugin builds bottom-up: specialists first, the coordinator last.
 
 ## What makes it safe to iterate
 
-The server's config validation is strict and **silent** — a bad config is rejected by
-returning an empty string with no reason. The plugin's local validator (`validate_config.py`)
-has **parity with the server**, so problems are caught locally with an explanation instead
-of as a silent server reject. And because there is no partial-update mutation, every
-modification is a **full-config replacement** that mints a new version — which is why the
-modify path always re-submits the whole config, never a patch.
+The server's config validation is strict and **silent** — a bad config is rejected by returning an empty string with no reason. The plugin's local validator (`validate_config.py`) has **parity with the server**, so problems are caught locally with an explanation instead of as a silent server reject. And because there is no partial-update mutation, every modification is a **full-config replacement** that mints a new version — which is why the modify path always re-submits the whole config, never a patch.
 
-> Every submit is validated and polled to Ready, but **not behaviorally tested** — static
-> validation only. After a create or modify, run the agent in the UI to confirm it actually
-> behaves as intended.
+> Every submit is validated and polled to Ready, but **not behaviorally tested** — static validation only. After a create or modify, run the agent in the UI to confirm it actually behaves as intended.
 
 ## How it's invoked
 
-The plugin's scripts share Cognito auth and endpoint discovery against your deployed stack;
-the first call prompts once for credentials and caches them in a gitignored `.env`. The
-skill (`skills/agent-creator/SKILL.md`) drives the whole flow — you interact in natural
-language and confirm before anything is submitted.
+The plugin's scripts share Cognito auth and endpoint discovery against your deployed stack; the first call prompts once for credentials and caches them in a gitignored `.env`. The skill (`skills/agent-creator/SKILL.md`) drives the whole flow — you interact in natural language and confirm before anything is submitted.
+
+### Pointing it at the right stack (profile & region)
+
+Endpoint discovery (`scripts/discover_endpoint.py`) resolves the AppSync GraphQL URL, Cognito user pool, and client ID in three tiers:
+
+1. **Cache** — `scripts/.agent-creator-cache.json` (gitignored). Returned as-is if present **and** the settings that selected it (`PROFILE` / `REGION` / `ACA_STACK_NAME` / `ACA_AWS_EXPORTS_PATH`) are unchanged. The cache is stamped with those settings, so changing your `.env` (e.g. switching profile) **auto-invalidates** it — discovery re-resolves without you needing `--refresh`. Pass `--refresh` to force a re-resolve regardless.
+2. **CloudFormation** — `describe-stacks` on the AWS session, matching the `GraphQLApiUrl` / `UserPoolId` / `UserPoolWebClientId` output **suffixes**. With no `ACA_STACK_NAME` it scans for a stack whose name ends in `-aca`.
+3. **`aws-exports.json` fallback** — `src/user-interface/react-app/public/aws-exports.json` if CloudFormation finds nothing.
+
+`PROFILE`, `REGION`, `ACA_STACK_NAME`, and `ACA_AWS_EXPORTS_PATH` are read from the **process environment first, then from `.env`** as a fallback (a real environment variable always wins). So to target a non-default profile, you can either export them, or just add them to `.env` alongside the Cognito creds. **In most cases `PROFILE` alone is enough** — the region comes from that profile's `~/.aws/config` entry (and a profile's region beats an `AWS_REGION` set in your shell), so you rarely need `REGION`:
+
+```ini
+ACA_COGNITO_USERNAME="you@example.com"
+ACA_COGNITO_PASSWORD="…"
+PROFILE="your-aws-profile"
+```
+
+Only set `REGION` in the two cases where the profile can't supply it: your profile has **no** `region` configured, or you want to **override** it (same credentials, a stack in a different region):
+
+```ini
+REGION="eu-west-1"
+```
+
+Then refresh the cache so the new target is resolved:
+
+```bash
+python3 .claude/plugins/agent-creator/skills/agent-creator/scripts/discover_endpoint.py --refresh
+```
+
+**Gotcha — silent fallback to a stale `aws-exports.json`.** Changing your `PROFILE`/`REGION`/stack settings now auto-invalidates the cache, but it can't fix the case where discovery resolves *nothing* from CloudFormation (wrong profile/region, or the stack genuinely isn't found) and falls back to whatever `aws-exports.json` is on disk — which may be a leftover from a previous deployment with the **old** endpoint. The auto-invalidation re-runs discovery, but discovery itself still lands on the stale file. The tell-tale and fix:
+
+- **Tell-tale:** the resolved `region` should match your target (on the CloudFormation path it comes from the AWS session). If it shows an old region, you're on the `aws-exports.json` fallback, not CloudFormation.
+- **Fix:** make sure `PROFILE` (and `REGION` if the profile doesn't pin one) point at the deployment you want, and that a `-aca` stack actually exists there — or set `ACA_STACK_NAME` explicitly. Failing that, update `src/user-interface/react-app/public/aws-exports.json` to the current deployment.
+
+> Note: auto-invalidation keys off the **settings**, not the deployed stack. If the *same* settings now point at a **redeployed** stack (you tore down and recreated it with a new endpoint), nothing in the settings changed — use `--refresh` to pick up the new values.
 
 ## Sample prompts
 
-You don't name the architecture — the plugin infers it from the shape of what you describe.
-The four prompts below each steer it toward a different pattern; use them as starting points.
+You don't name the architecture — the plugin infers it from the shape of what you describe. The four prompts below each steer it toward a different pattern; use them as starting points.
 
 **Single — one agent, one job:**
 
-> "Create an agent that answers AWS questions from the official docs — it should search the
-> documentation, cite a URL for every claim, and say so when the docs don't cover something."
+> "Create an agent that answers AWS questions from the official docs — it should search the documentation, cite a URL for every claim, and say so when the docs don't cover something."
 
 **Agents as Tools — a coordinator that decides who to consult at runtime:**
 
-> "Build something that, given a workload description, recommends an AWS architecture. One
-> part digs through the AWS docs to pick services and cite best practices; another reasons
-> about cost and sizing. Add a layer on top that decides which to consult, then writes up
-> the final recommendation."
+> "Build something that, given a workload description, recommends an AWS architecture. One part digs through the AWS docs to pick services and cite best practices; another reasons about cost and sizing. Add a layer on top that decides which to consult, then writes up the final recommendation."
 
 **Graph — a fixed pipeline, same steps every time:**
 
-> "I want a fixed pipeline for AWS workload reviews. For every workload, always run a
-> docs/architecture specialist and a cost specialist in parallel, then merge their two
-> outputs into one combined recommendation. The steps never change."
+> "I want a fixed pipeline for AWS workload reviews. For every workload, always run a docs/architecture specialist and a cost specialist in parallel, then merge their two outputs into one combined recommendation. The steps never change."
 
 **Swarm — peers that hand off collaboratively, no fixed order:**
 
-> "Create a swarm debate agent to help decide when serverless or managed is better suited to
-> a given architecture."
+> "Create a swarm debate agent to help decide when serverless or managed is better suited to a given architecture."
 
-This is the prompt behind the worked example below. The plugin builds three SINGLE persona
-agents bottom-up — a `serverless_advocate` and a `managed_advocate` (each grounded in the
-`aws-knowledge` MCP server, arguing in good faith and conceding honest weaknesses) and a
-neutral `debate_moderator` — then assembles a `serverless_vs_managed_debate` SWARM with the
-moderator as the entry agent. The moderator frames the workload (asking for any missing
-decision-critical facts), the advocates hand the problem back and forth until each has
-rebutted the other's strongest point, and the moderator writes the final verdict — including
-the losing side's best argument and the conditions under which the recommendation would flip.
+This is the prompt behind the worked example below. The plugin builds three SINGLE persona agents bottom-up — a `serverless_advocate` and a `managed_advocate` (each grounded in the `aws-knowledge` MCP server, arguing in good faith and conceding honest weaknesses) and a neutral `debate_moderator` — then assembles a `serverless_vs_managed_debate` SWARM with the moderator as the entry agent. The moderator frames the workload (asking for any missing decision-critical facts), the advocates hand the problem back and forth until each has rebutted the other's strongest point, and the moderator writes the final verdict — including the losing side's best argument and the conditions under which the recommendation would flip.
 
 A workload prompt to run the finished swarm against in the UI:
 
-> "We're building the backend for a B2B SaaS document-processing API — customers upload PDFs,
-> we extract and transform text, store structured JSON. Traffic is spiky and low-volume today
-> (~5,000 docs/day in business hours, near-zero overnight) but could grow 10–20x. Each doc is
-> CPU-bound and takes 8–40s; results are persisted and queried; p95 under ~2 min is fine. We're
-> a 3-person team with limited ops experience, tight budget now but predictability matters at
-> scale. Serverless or provisioned/managed? Debate it and give me a verdict."
+> "We're building the backend for a B2B SaaS document-processing API — customers upload PDFs, we extract and transform text, store structured JSON. Traffic is spiky and low-volume today (~5,000 docs/day in business hours, near-zero overnight) but could grow 10–20x. Each doc is CPU-bound and takes 8–40s; results are persisted and queried; p95 under ~2 min is fine. We're a 3-person team with limited ops experience, tight budget now but predictability matters at scale. Serverless or provisioned/managed? Debate it and give me a verdict."
 
-Modify, diagnose, and skill-authoring requests are just as conversational — e.g. "remove the
-skills from `pubmed_study_ideator`", "it keeps picking the wrong tool, here are the traces:
-…", or "create a skill that teaches the agent PubMed search craft."
+Modify, diagnose, and skill-authoring requests are just as conversational — e.g. "remove the skills from `pubmed_study_ideator`", "it keeps picking the wrong tool, here are the traces: …", or "create a skill that teaches the agent PubMed search craft."
 
-After a build, the plugin can suggest behavioral prompts to run the new agent against in the
-UI — confirming it actually routes, merges, or hands off as intended before you rely on it.
+After a build, the plugin can suggest behavioral prompts to run the new agent against in the UI — confirming it actually routes, merges, or hands off as intended before you rely on it.

--- a/.claude/plugins/agent-creator/skills/agent-creator/scripts/discover_endpoint.py
+++ b/.claude/plugins/agent-creator/skills/agent-creator/scripts/discover_endpoint.py
@@ -10,7 +10,10 @@ Resolution order:
 Resolved values are cached to .agent-creator-cache.json (gitignored) so repeated
 calls in a session don't re-hit CloudFormation. Pass --refresh to bypass the cache.
 
-Env (honoured like the project Makefile):
+Settings (honoured like the project Makefile) are read from the process
+environment first, then from the sibling `.env` file as a fallback — so you can
+either `export PROFILE=…` or drop `PROFILE="…"` in `.env` alongside the Cognito
+creds. A real environment variable always wins over `.env`.
   PROFILE  — AWS profile name
   REGION   — AWS region
   ACA_STACK_NAME       — explicit stack name (else scan for a *-aca stack)
@@ -24,6 +27,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -34,22 +38,65 @@ from botocore.exceptions import BotoCoreError, ClientError
 # works regardless of the caller's CWD.
 _SCRIPT_DIR = Path(__file__).resolve().parent
 _CACHE_PATH = _SCRIPT_DIR / ".agent-creator-cache.json"
+_ENV_PATH = _SCRIPT_DIR / ".env"
 
-# Output key suffixes we need, mapped to the dict key we return. We match on
-# suffix because CDK prefixes nested-construct output keys with the construct path.
+# Output key suffixes we need, mapped to the dict key we return. CDK wraps the
+# logical name on BOTH sides: it prefixes the nested-construct path
+# (e.g. "ChatbotApiGraphQLApiUrl") and appends an 8-hex-char uniqueness hash
+# (e.g. "...GraphQLApiUrl1ED912E9"). So we strip the trailing hash, then match on
+# suffix — a plain endswith() would miss every hashed key.
 _OUTPUT_SUFFIXES = {
     "GraphQLApiUrl": "endpoint",
     "UserPoolId": "userPoolId",
     "UserPoolWebClientId": "clientId",
 }
 
+# CDK appends an 8-char uppercase-hex hash to CfnOutput logical IDs.
+_CDK_HASH_SUFFIX = re.compile(r"[0-9A-F]{8}$")
+
 # Best-effort walk up to the repo root to locate the React app's aws-exports.json.
 _AWS_EXPORTS_RELATIVE = Path("src/user-interface/react-app/public/aws-exports.json")
 
 
+def load_env_file() -> dict[str, str]:
+    """Minimal .env reader (KEY=VALUE per line); avoids a python-dotenv dep.
+
+    Shared by get_token.py for the Cognito creds and by _setting() below for
+    PROFILE/REGION — one parser so the two never drift."""
+    values: dict[str, str] = {}
+    if not _ENV_PATH.exists():
+        return values
+    for line in _ENV_PATH.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        values[key.strip()] = val.strip().strip('"').strip("'")
+    return values
+
+
+def _setting(name: str) -> str | None:
+    """Resolve a setting from the real environment first, then the .env file.
+
+    A genuine environment variable always wins so callers can override .env
+    ad hoc (e.g. `REGION=eu-west-1 python discover_endpoint.py`)."""
+    return os.environ.get(name) or load_env_file().get(name)
+
+
+# The settings that determine WHICH stack we resolve. The cache is stamped with
+# these so it self-invalidates when you switch profile/region/stack — otherwise a
+# valid-but-stale cache would mask a changed .env (the #1 footgun of this script).
+_FINGERPRINT_KEYS = ("PROFILE", "REGION", "ACA_STACK_NAME", "ACA_AWS_EXPORTS_PATH")
+_FINGERPRINT_FIELD = "_settings"
+
+
+def _settings_fingerprint() -> dict[str, str | None]:
+    return {k: _setting(k) for k in _FINGERPRINT_KEYS}
+
+
 def _session() -> boto3.Session:
-    profile = os.environ.get("PROFILE")
-    region = os.environ.get("REGION")
+    profile = _setting("PROFILE")
+    region = _setting("REGION")
     kwargs = {}
     if profile:
         kwargs["profile_name"] = profile
@@ -96,7 +143,8 @@ def _from_cloudformation(stack_name: str | None) -> dict | None:
     for st in stacks:
         resolved = {"region": region}
         for out in st.get("Outputs", []):
-            key = out["OutputKey"]
+            # Drop CDK's trailing uniqueness hash so the suffix match can land.
+            key = _CDK_HASH_SUFFIX.sub("", out["OutputKey"])
             for suffix, target in _OUTPUT_SUFFIXES.items():
                 if key.endswith(suffix):
                     resolved[target] = out["OutputValue"]
@@ -110,7 +158,7 @@ def _from_aws_exports(path: str | None) -> dict | None:
     if path:
         candidate = Path(path)
     else:
-        env_path = os.environ.get("ACA_AWS_EXPORTS_PATH")
+        env_path = _setting("ACA_AWS_EXPORTS_PATH")
         if env_path:
             candidate = Path(env_path)
         else:
@@ -149,15 +197,22 @@ def discover_endpoint(
     """Return {endpoint, region, userPoolId, clientId}.
 
     Raises RuntimeError with an actionable message if nothing resolves."""
+    fingerprint = _settings_fingerprint()
     if not refresh and _CACHE_PATH.exists():
         try:
             cached = json.loads(_CACHE_PATH.read_text())
-            if all(k in cached for k in ("endpoint", "userPoolId", "clientId")):
-                return cached
+            has_values = all(
+                k in cached for k in ("endpoint", "userPoolId", "clientId")
+            )
+            # Honour the cache only if it was produced under the SAME settings.
+            # A mismatch (you switched profile/region/stack) means it's stale, so
+            # we fall through and re-resolve instead of returning the old stack.
+            if has_values and cached.get(_FINGERPRINT_FIELD) == fingerprint:
+                return {k: v for k, v in cached.items() if k != _FINGERPRINT_FIELD}
         except (OSError, json.JSONDecodeError):
             pass  # corrupt cache — fall through to re-resolve
 
-    stack_name = stack_name or os.environ.get("ACA_STACK_NAME")
+    stack_name = stack_name or _setting("ACA_STACK_NAME")
     resolved = _from_cloudformation(stack_name) or _from_aws_exports(aws_exports_path)
 
     if not resolved:
@@ -169,7 +224,11 @@ def discover_endpoint(
         )
 
     try:
-        _CACHE_PATH.write_text(json.dumps(resolved, indent=2))
+        # Stamp the settings alongside the values so the next read can detect a
+        # changed .env and self-invalidate.
+        _CACHE_PATH.write_text(
+            json.dumps({**resolved, _FINGERPRINT_FIELD: fingerprint}, indent=2)
+        )
     except OSError:
         pass  # caching is best-effort; never fail the call over it
 

--- a/.claude/plugins/agent-creator/skills/agent-creator/scripts/get_token.py
+++ b/.claude/plugins/agent-creator/skills/agent-creator/scripts/get_token.py
@@ -35,29 +35,25 @@ from pathlib import Path
 from botocore.exceptions import BotoCoreError, ClientError
 
 try:
-    from discover_endpoint import _find_repo_root, _session, discover_endpoint
+    from discover_endpoint import (
+        _find_repo_root,
+        _session,
+        discover_endpoint,
+        load_env_file,
+    )
 except ImportError:  # allow running as a module from elsewhere
-    from .discover_endpoint import _find_repo_root, _session, discover_endpoint
+    from .discover_endpoint import (
+        _find_repo_root,
+        _session,
+        discover_endpoint,
+        load_env_file,
+    )
 
 _SCRIPT_DIR = Path(__file__).resolve().parent
 _ENV_PATH = _SCRIPT_DIR / ".env"
 
 _ENV_USERNAME = "ACA_COGNITO_USERNAME"
 _ENV_PASSWORD = "ACA_COGNITO_PASSWORD"  # pragma: allowlist secret # nosec B105 - env var name, not a credential
-
-
-def _load_env_file() -> dict[str, str]:
-    """Minimal .env reader (KEY=VALUE per line); avoids a python-dotenv dep."""
-    values: dict[str, str] = {}
-    if not _ENV_PATH.exists():
-        return values
-    for line in _ENV_PATH.read_text().splitlines():
-        line = line.strip()
-        if not line or line.startswith("#") or "=" not in line:
-            continue
-        key, _, val = line.partition("=")
-        values[key.strip()] = val.strip().strip('"').strip("'")
-    return values
 
 
 def _ensure_env_gitignored() -> None:
@@ -102,7 +98,7 @@ def _prompt_and_store_creds() -> tuple[str, str]:
 
 
 def _resolve_creds() -> tuple[str, str]:
-    env = _load_env_file()
+    env = load_env_file()
     username = env.get(_ENV_USERNAME) or os.environ.get(_ENV_USERNAME)
     password = env.get(_ENV_PASSWORD) or os.environ.get(_ENV_PASSWORD)
     if username and password:

--- a/src/user-interface/react-app/src/components/chatbot/chat-input-panel.tsx
+++ b/src/user-interface/react-app/src/components/chatbot/chat-input-panel.tsx
@@ -87,6 +87,9 @@ const ChatInputPanel = forwardRef<ChatInputPanelHandle, ChatInputPanelProps>(fun
         value: "",
     });
     const [readyState, setReadyState] = useState<ReadyState>(ReadyState.UNINSTANTIATED);
+    // Bumped by the manual Reconnect button to force the connect effect to re-run
+    // and re-establish a dropped WebSocket without reloading the page.
+    const [reconnectNonce, setReconnectNonce] = useState(0);
 
     // Use lifted state from props
     const {
@@ -388,7 +391,7 @@ const ChatInputPanel = forwardRef<ChatInputPanelHandle, ChatInputPanelProps>(fun
                 wsConnectionRef.current = null;
             }
         };
-    }, [props.session.id, agentRuntimeId, qualifier, appContext]);
+    }, [props.session.id, agentRuntimeId, qualifier, appContext, reconnectNonce]);
 
     // Send heartbeat when a new session is initialized (no messages yet)
     useEffect(() => {
@@ -550,6 +553,18 @@ const ChatInputPanel = forwardRef<ChatInputPanelHandle, ChatInputPanelProps>(fun
     };
 
     const wsReady = readyState === ReadyState.OPEN;
+    const wsDisconnected =
+        readyState === ReadyState.CLOSED || readyState === ReadyState.CLOSING;
+
+    // Tear down any lingering socket and re-run the connect effect so a dropped
+    // connection can be re-established in place (no full page reload needed).
+    const reconnect = () => {
+        if (wsConnectionRef.current) {
+            wsConnectionRef.current.close();
+            wsConnectionRef.current = null;
+        }
+        setReconnectNonce((n) => n + 1);
+    };
 
     return (
         <SpaceBetween direction="vertical" size="l">
@@ -649,15 +664,32 @@ const ChatInputPanel = forwardRef<ChatInputPanelHandle, ChatInputPanelProps>(fun
                                     />
                                 </FormField>
                             </div>
-                            <Button
-                                iconName="refresh"
-                                variant="icon"
-                                onClick={refreshAgents}
-                                disabled={agentsLoading}
-                            />
-                            <StatusIndicator type={connectionStatus().type}>
-                                {connectionStatus().label}
-                            </StatusIndicator>
+                            {/* Match the Select input height (32px) so these
+                                unlabeled controls center on the boxes rather than
+                                bottom-hugging the taller labeled FormField columns. */}
+                            <div
+                                style={{
+                                    display: "flex",
+                                    alignItems: "center",
+                                    gap: "8px",
+                                    height: "32px",
+                                }}
+                            >
+                                <Button
+                                    iconName="refresh"
+                                    variant="icon"
+                                    onClick={refreshAgents}
+                                    disabled={agentsLoading}
+                                />
+                                <StatusIndicator type={connectionStatus().type}>
+                                    {connectionStatus().label}
+                                </StatusIndicator>
+                                {wsDisconnected && agentRuntimeId && qualifier && (
+                                    <Button iconName="refresh" onClick={reconnect}>
+                                        Reconnect
+                                    </Button>
+                                )}
+                            </div>
                         </>
                     )}
                 </SpaceBetween>


### PR DESCRIPTION
CloudFormation resolution never matched because CDK appends an 8-hex hash to CfnOutput keys, so discovery silently fell back to a stale aws-exports.json. Strip the hash before suffix-matching, and read PROFILE/REGION (etc.) from .env as well as the environment so a profile actually targets its region. Stamp the cache with its resolving settings so it auto-invalidates when .env changes, instead of returning the old stack until a manual --refresh.