### PR TITLE
✨ (agent-core): surface reasoning from all intermediate model calls

### DIFF
--- a/src/agent-core/docker-agents-as-tools/app.py
+++ b/src/agent-core/docker-agents-as-tools/app.py
@@ -598,8 +598,13 @@ def _build_final_response(
         "messageId": message_id,
     }
 
-    # Reasoning content
-    reasoning_content = _extract_reasoning_content(agent_result)
+    # Prefer accumulated reasoning (captures ALL model calls); fall back to
+    # final-only extraction.
+    reasoning_content = (
+        callbacks.accumulated_reasoning
+        if callbacks and callbacks.accumulated_reasoning
+        else _extract_reasoning_content(agent_result)
+    )
     if reasoning_content:
         logger.info(
             "Model reasoning process",

--- a/src/agent-core/docker-agents-as-tools/src/factory.py
+++ b/src/agent-core/docker-agents-as-tools/src/factory.py
@@ -16,6 +16,7 @@ from shared.mcp_client import MCPClientManager
 from shared.sigv4_auth import SigV4HTTPXAuth
 from strands import Agent
 from strands.hooks.events import (
+    AfterModelCallEvent,
     AfterToolCallEvent,
     BeforeToolCallEvent,
 )
@@ -83,6 +84,7 @@ def create_orchestrator(
 
     agent.hooks.add_callback(BeforeToolCallEvent, callbacks.log_tool_entries)
     agent.hooks.add_callback(AfterToolCallEvent, callbacks.log_tool_results)
+    agent.hooks.add_callback(AfterModelCallEvent, callbacks.accumulate_reasoning)
 
     if configuration.tools and any(
         [t.startswith(RETRIEVE_FROM_KB_PREFIX) for t in configuration.tools]

--- a/src/agent-core/docker/app.py
+++ b/src/agent-core/docker/app.py
@@ -480,8 +480,13 @@ async def text_chat(websocket: WebSocket):
                                 },
                             )
 
-                            # Extract reasoning content
-                            reasoning_content = _extract_reasoning(raw_result)
+                            # Prefer accumulated reasoning (captures ALL model
+                            # calls); fall back to final-only extraction.
+                            reasoning_content = (
+                                callbacks.accumulated_reasoning
+                                if callbacks and callbacks.accumulated_reasoning
+                                else _extract_reasoning(raw_result)
+                            )
 
                             final_data: dict = {
                                 "type": "final_response",

--- a/src/agent-core/docker/src/factory.py
+++ b/src/agent-core/docker/src/factory.py
@@ -15,6 +15,7 @@ from shared.base_factory import BaseAgentFactory
 from shared.mcp_client import MCPClientManager
 from strands import Agent, AgentSkills
 from strands.hooks.events import (
+    AfterModelCallEvent,
     AfterToolCallEvent,
     BeforeToolCallEvent,
 )
@@ -258,6 +259,7 @@ def create_agent(
 
     agent.hooks.add_callback(BeforeToolCallEvent, callbacks.log_tool_entries)
     agent.hooks.add_callback(AfterToolCallEvent, callbacks.log_tool_results)
+    agent.hooks.add_callback(AfterModelCallEvent, callbacks.accumulate_reasoning)
 
     if any([t.startswith(RETRIEVE_FROM_KB_PREFIX) for t in configuration.tools]):
         logger.info(

--- a/src/agent-core/shared/base_callbacks.py
+++ b/src/agent-core/shared/base_callbacks.py
@@ -11,6 +11,8 @@ import asyncio
 import json
 from typing import TYPE_CHECKING
 
+from strands.hooks.events import AfterModelCallEvent
+
 from .base_constants import RETRIEVE_FROM_KB_PREFIX
 from .kb_types import Citation, RetrievedReference
 
@@ -150,6 +152,7 @@ class BaseAgentCallbacks:
         self._metadata = dict()
         self._logger = logger
         self._nb_tool_invocations = 0
+        self._reasoning_chunks: list[str] = []
         self._session_id = session_id
         self._user_id = user_id
         self._websocket = None  # Optional WebSocket for direct tool action delivery
@@ -186,6 +189,31 @@ class BaseAgentCallbacks:
         """Reset metadata and tool invocation counter."""
         self._metadata = dict()
         self._nb_tool_invocations = 0
+        self._reasoning_chunks = []
+
+    @property
+    def accumulated_reasoning(self) -> str:
+        """Reasoning text accumulated from all model calls in this turn."""
+        return "\n".join(self._reasoning_chunks) if self._reasoning_chunks else ""
+
+    def accumulate_reasoning(self, event: AfterModelCallEvent) -> None:
+        """Accumulate reasoning content from each model call.
+
+        Registered as an AfterModelCallEvent hook so it fires after every model
+        inference — not just the final one — capturing the full chain of thought
+        across tool-use loops.
+        """
+        if event.stop_response is None:
+            return
+        for block in event.stop_response.message.get("content", []):
+            if not isinstance(block, dict) or "reasoningContent" not in block:
+                continue
+            r_content = block["reasoningContent"]
+            if not isinstance(r_content, dict) or "reasoningText" not in r_content:
+                continue
+            r_text = r_content["reasoningText"]
+            if isinstance(r_text, dict) and r_text.get("text"):
+                self._reasoning_chunks.append(r_text["text"])
 
     def _extract_tool_parameters(self, event, specs) -> list[dict]:
         """Extract and format tool parameters from event.


### PR DESCRIPTION
Previously only the final model call's reasoning reached the UI. Register an AfterModelCallEvent hook on the docker and agents-as-tools agents to accumulate reasoning text across every model inference in a turn, so the full chain of thought (including tool-selection rationale) is shown. Falls back to final-only extraction when the hook captures nothing.