### PR TITLE
🐛 Fix blank RuntimeVersion column and add filtering to Session History

### DIFF
--- a/src/agent-core/docker-agents-as-tools/app.py
+++ b/src/agent-core/docker-agents-as-tools/app.py
@@ -248,6 +248,7 @@ async def text_chat(websocket: WebSocket):
                                         "agentRuntimeId",
                                         os.environ.get("agentName", ""),
                                     ),
+                                    runtime_version=message.get("runtimeVersion"),
                                     endpoint_name=message.get("qualifier", "DEFAULT"),
                                 )
                             except Exception as hist_err:

--- a/src/agent-core/docker-graph/app.py
+++ b/src/agent-core/docker-graph/app.py
@@ -382,6 +382,7 @@ async def graph_text_chat(websocket: WebSocket):
                             runtime_id=message.get(
                                 "agentRuntimeId", os.environ.get("agentName", "")
                             ),
+                            runtime_version=message.get("runtimeVersion"),
                             endpoint_name=message.get("qualifier", "DEFAULT"),
                         )
                     except Exception as hist_err:

--- a/src/agent-core/docker-swarm/app.py
+++ b/src/agent-core/docker-swarm/app.py
@@ -281,6 +281,7 @@ async def swarm_text_chat(websocket: WebSocket):
                             runtime_id=message.get(
                                 "agentRuntimeId", os.environ.get("agentName", "")
                             ),
+                            runtime_version=message.get("runtimeVersion"),
                             endpoint_name=message.get("qualifier", "DEFAULT"),
                         )
                     except Exception as hist_err:

--- a/src/agent-core/docker/app.py
+++ b/src/agent-core/docker/app.py
@@ -595,6 +595,7 @@ async def text_chat(websocket: WebSocket):
                                         "agentRuntimeId",
                                         os.environ.get("agentName", ""),
                                     ),
+                                    runtime_version=message.get("runtimeVersion"),
                                     endpoint_name=message.get("qualifier", "DEFAULT"),
                                 )
                             except Exception as hist_err:

--- a/src/agent-core/shared/bidi_ws_adapter.py
+++ b/src/agent-core/shared/bidi_ws_adapter.py
@@ -91,6 +91,7 @@ class WebSocketBidiInput:
         turns = data.get("turns", [])
         runtime_id = data.get("agentRuntimeId", "")
         qualifier = data.get("qualifier", "DEFAULT")
+        runtime_version = data.get("runtimeVersion")
 
         if not session_id or not turns:
             logger.warning("voice_save: missing sessionId or turns — skipping")
@@ -119,6 +120,7 @@ class WebSocketBidiInput:
                             user_message=user_text.strip(),
                             ai_response=assistant_text.strip(),
                             runtime_id=runtime_id,
+                            runtime_version=runtime_version,
                             endpoint_name=qualifier,
                         )
                     except Exception as e:
@@ -149,6 +151,7 @@ class WebSocketBidiInput:
                     user_message=user_text.strip() if user_text else "(voice session)",
                     ai_response=assistant_text.strip() if assistant_text else "",
                     runtime_id=runtime_id,
+                    runtime_version=runtime_version,
                     endpoint_name=qualifier,
                 )
             except Exception as e:

--- a/src/user-interface/react-app/src/common/hooks/useVoiceAgent.ts
+++ b/src/user-interface/react-app/src/common/hooks/useVoiceAgent.ts
@@ -67,6 +67,8 @@ export interface UseVoiceAgentOptions {
     qualifier: string;
     sessionId: string;
     config: ConnectOptions["config"];
+    /** Concrete runtime version for the selected endpoint — persisted to session history. */
+    runtimeVersion?: string;
 }
 
 export interface UseVoiceAgentReturn {
@@ -491,6 +493,7 @@ export function useVoiceAgent(options: UseVoiceAgentOptions): UseVoiceAgentRetur
                     sessionId: options.sessionId,
                     agentRuntimeId: options.agentRuntimeId,
                     qualifier: options.qualifier,
+                    runtimeVersion: options.runtimeVersion ?? "",
                     turns: finalTurns,
                 });
             }
@@ -500,7 +503,7 @@ export function useVoiceAgent(options: UseVoiceAgentOptions): UseVoiceAgentRetur
         }
         connectionRef.current = null;
         setIsConnected(false);
-    }, [options.sessionId, options.agentRuntimeId, options.qualifier]);
+    }, [options.sessionId, options.agentRuntimeId, options.qualifier, options.runtimeVersion]);
 
     // Cleanup on unmount — fully disconnect
     useEffect(() => {

--- a/src/user-interface/react-app/src/components/chatbot/VoiceConversationView.tsx
+++ b/src/user-interface/react-app/src/components/chatbot/VoiceConversationView.tsx
@@ -18,7 +18,7 @@ import { useVoiceAgent, VoiceConversationTurn } from "../../common/hooks/useVoic
 import { getDefaultRuntimeConfiguration as getDefaultRuntimeConfigurationQuery } from "../../graphql/queries";
 import { ConnectOptions } from "../../websocket-presigned";
 import { AgentOption, EndpointOption } from "./types";
-import { maskSensitiveInfo } from "./utils";
+import { maskSensitiveInfo, resolveRuntimeVersion } from "./utils";
 import MarkdownContent from "./side-view/markdown-content";
 
 export interface VoiceConversationViewProps {
@@ -68,13 +68,17 @@ export default function VoiceConversationView({
             accountId: appContext?.aws_account_id || "",
             qualifier,
             sessionId,
+            runtimeVersion: resolveRuntimeVersion(
+                availableAgents.find((a) => a.value === agentRuntimeId)?.qualifierToVersion,
+                qualifier,
+            ),
             config: {
                 aws_project_region: appContext?.aws_project_region || "",
                 aws_user_pools_id: appContext?.aws_user_pools_id || "",
                 aws_cognito_identity_pool_id: appContext?.aws_cognito_identity_pool_id || "",
             } as ConnectOptions["config"],
         }),
-        [agentRuntimeId, qualifier, sessionId, appContext],
+        [agentRuntimeId, qualifier, sessionId, appContext, availableAgents],
     );
 
     const { isRecording, isConnected, conversationTurns, activeSpeaker, startVoice, stopVoice, disconnectVoice: _disconnectVoice, error } =

--- a/src/user-interface/react-app/src/components/chatbot/chat-input-panel.tsx
+++ b/src/user-interface/react-app/src/components/chatbot/chat-input-panel.tsx
@@ -30,7 +30,7 @@ import {
     LLMToken,
     ToolActionItem,
 } from "./types";
-import { appendToolAction, markToolComplete, updateMessageHistoryRef } from "./utils";
+import { appendToolAction, markToolComplete, resolveRuntimeVersion, updateMessageHistoryRef } from "./utils";
 
 export interface ChatInputPanelProps {
     running: boolean;
@@ -483,6 +483,11 @@ const ChatInputPanel = forwardRef<ChatInputPanelHandle, ChatInputPanelProps>(fun
                 console.warn("Could not fetch user attributes for userId");
             }
 
+            // Resolve the concrete runtime version for the selected endpoint so
+            // the container can persist it to session history (Sessions table).
+            const selectedAgent = availableAgents.find((a) => a.value === agentRuntimeId);
+            const runtimeVersion = resolveRuntimeVersion(selectedAgent?.qualifierToVersion, qualifier);
+
             wsConnectionRef.current.send({
                 type: "text_input",
                 text: value,
@@ -491,6 +496,7 @@ const ChatInputPanel = forwardRef<ChatInputPanelHandle, ChatInputPanelProps>(fun
                 messageId: message_id,
                 agentRuntimeId: agentRuntimeId,
                 qualifier: qualifier,
+                runtimeVersion: runtimeVersion,
             });
         } catch (err) {
             console.log(Utils.getErrorMessage(err));

--- a/src/user-interface/react-app/src/components/chatbot/chat.tsx
+++ b/src/user-interface/react-app/src/components/chatbot/chat.tsx
@@ -175,6 +175,7 @@ export default function Chat(props: { sessionId?: string }) {
                         iconName: getStatusIcon(agent.status),
                         disabled: agent.status.toLowerCase() !== "ready",
                         architectureType: agent.architectureType || undefined,
+                        qualifierToVersion: agent.qualifierToVersion || undefined,
                     };
                 }) || [];
 

--- a/src/user-interface/react-app/src/components/chatbot/sessions.tsx
+++ b/src/user-interface/react-app/src/components/chatbot/sessions.tsx
@@ -15,6 +15,7 @@ import {
     Input,
     Modal,
     Pagination,
+    PropertyFilter,
     SpaceBetween,
     Table,
     TableProps,
@@ -40,11 +41,43 @@ export interface SessionsProps {
     readonly toolsOpen: boolean;
 }
 
+// The "AgentName" column is derived from runtimeId (the agent name is the
+// prefix before the first "-"). Surface it as a real field so it can be
+// filtered/sorted like the other columns.
+type SessionRow = Session & { agentName: string };
+
+const FILTERING_PROPERTIES = [
+    {
+        key: "title",
+        propertyLabel: "Title",
+        groupValuesLabel: "Title values",
+        operators: [":", "!:", "=", "!="],
+    },
+    {
+        key: "agentName",
+        propertyLabel: "AgentName",
+        groupValuesLabel: "AgentName values",
+        operators: [":", "!:", "=", "!="],
+    },
+    {
+        key: "runtimeVersion",
+        propertyLabel: "RuntimeVersion",
+        groupValuesLabel: "RuntimeVersion values",
+        operators: [":", "!:", "=", "!="],
+    },
+    {
+        key: "endpoint",
+        propertyLabel: "Endpoint",
+        groupValuesLabel: "Endpoint values",
+        operators: [":", "!:", "=", "!="],
+    },
+];
+
 export default function Sessions(props: SessionsProps) {
     const appContext = useContext(AppContext);
-    const [sessions, setSessions] = useState<Session[]>([]);
+    const [sessions, setSessions] = useState<SessionRow[]>([]);
     const [isLoading, setIsLoading] = useState(true);
-    const [selectedItems, setSelectedItems] = useState<Session[]>([]);
+    const [selectedItems, setSelectedItems] = useState<SessionRow[]>([]);
     const [preferences, setPreferences] = useState({ pageSize: 20 });
     const [showModalDelete, setShowModalDelete] = useState(false);
     const [deleteAllSessions, setDeleteAllSessions] = useState(false);
@@ -56,27 +89,36 @@ export default function Sessions(props: SessionsProps) {
 
     const { t } = useTranslation("ACA");
 
-    const { items, collectionProps, paginationProps } = useCollection(sessions, {
-        filtering: {
-            empty: (
-                <Box margin={{ vertical: "xs" }} textAlign="center" color="inherit">
-                    <SpaceBetween size="m">
-                        <b>{t("CHATBOT.SESSIONS.EMPTY_MSG")}</b>
-                    </SpaceBetween>
-                </Box>
-            ),
-        },
-        pagination: { pageSize: preferences.pageSize },
-        sorting: {
-            defaultState: {
-                sortingColumn: {
-                    sortingField: "startTime",
-                },
-                isDescending: true,
+    const { items, collectionProps, paginationProps, propertyFilterProps, filteredItemsCount } =
+        useCollection(sessions, {
+            propertyFiltering: {
+                filteringProperties: FILTERING_PROPERTIES,
+                empty: (
+                    <Box margin={{ vertical: "xs" }} textAlign="center" color="inherit">
+                        <SpaceBetween size="m">
+                            <b>{t("CHATBOT.SESSIONS.EMPTY_MSG")}</b>
+                        </SpaceBetween>
+                    </Box>
+                ),
+                noMatch: (
+                    <Box margin={{ vertical: "xs" }} textAlign="center" color="inherit">
+                        <SpaceBetween size="m">
+                            <b>{t("CHATBOT.SESSIONS.EMPTY_MSG")}</b>
+                        </SpaceBetween>
+                    </Box>
+                ),
             },
-        },
-        selection: {},
-    });
+            pagination: { pageSize: preferences.pageSize },
+            sorting: {
+                defaultState: {
+                    sortingColumn: {
+                        sortingField: "startTime",
+                    },
+                    isDescending: true,
+                },
+            },
+            selection: {},
+        });
 
     const listSessions = useCallback(async () => {
         if (!appContext) return;
@@ -87,7 +129,12 @@ export default function Sessions(props: SessionsProps) {
             const result = await apiClient.graphql({
                 query: listSessionQuery,
             });
-            setSessions(result.data!.listSessions);
+            setSessions(
+                result.data!.listSessions.map((s) => ({
+                    ...s,
+                    agentName: s.runtimeId.split("-")[0],
+                })),
+            );
         } catch (error) {
             console.log(Utils.getErrorMessage(error));
             setGlobalError(Utils.getErrorMessage(error));
@@ -260,6 +307,14 @@ export default function Sessions(props: SessionsProps) {
                     itemSelectionLabel: (e, item) => item.title!,
                 }}
                 pagination={<Pagination {...paginationProps} />}
+                filter={
+                    <PropertyFilter
+                        {...propertyFilterProps}
+                        countText={`${filteredItemsCount} matches`}
+                        filteringPlaceholder="Filter sessions by property"
+                        filteringAriaLabel="Filter sessions"
+                    />
+                }
                 loadingText="Loading history"
                 loading={isLoading}
                 resizableColumns
@@ -382,22 +437,25 @@ export default function Sessions(props: SessionsProps) {
                         {
                             id: "agentName",
                             header: "AgentName",
+                            sortingField: "agentName",
                             width: 200,
-                            cell: (e) => e.runtimeId.split("-")[0],
+                            cell: (e) => e.agentName,
                         },
                         {
                             id: "runtimeVersion",
                             header: "RuntimeVersion",
+                            sortingField: "runtimeVersion",
                             width: 200,
                             cell: (e) => e.runtimeVersion,
                         },
                         {
                             id: "endpoint",
                             header: "Endpoint",
+                            sortingField: "endpoint",
                             width: 200,
                             cell: (e) => e.endpoint,
                         },
-                    ] as TableProps.ColumnDefinition<Session>[]
+                    ] as TableProps.ColumnDefinition<SessionRow>[]
                 }
             />
             {renameSessionModal}

--- a/src/user-interface/react-app/src/components/chatbot/types.ts
+++ b/src/user-interface/react-app/src/components/chatbot/types.ts
@@ -146,6 +146,9 @@ export interface AgentOption {
     iconName?: IconProps.Name;
     disabled?: boolean;
     architectureType?: string;
+    // JSON string mapping each endpoint (qualifier) to its numeric runtime
+    // version. Used to persist the served version into session history.
+    qualifierToVersion?: string;
 }
 
 export interface EndpointOption {

--- a/src/user-interface/react-app/src/components/chatbot/utils.tsx
+++ b/src/user-interface/react-app/src/components/chatbot/utils.tsx
@@ -18,6 +18,28 @@ import {
 const TOOL_NAME_ACRONYMS = new Set(["aws", "s3", "api", "a2a"]);
 
 /**
+ * Resolve the concrete runtime version for a selected endpoint (qualifier).
+ *
+ * `listRuntimeAgents` returns `qualifierToVersion` as a JSON string mapping each
+ * endpoint name to its numeric AgentCore version. The container persists this
+ * value to session history so the Sessions table can show which version served
+ * a conversation. Returns "" when the map is missing/unparseable or the
+ * qualifier has no entry, matching the read-side fallback.
+ */
+export function resolveRuntimeVersion(
+    qualifierToVersion: string | null | undefined,
+    qualifier: string,
+): string {
+    if (!qualifierToVersion) return "";
+    try {
+        const version = (JSON.parse(qualifierToVersion) as Record<string, number | string>)[qualifier];
+        return version === undefined || version === null ? "" : String(version);
+    } catch {
+        return "";
+    }
+}
+
+/**
  * Turn a raw tool name into a human-friendly label.
  *
  * Tool names arrive as identifiers (e.g. `search_documentation`) and MCP tools


### PR DESCRIPTION
## Summary

The RuntimeVersion column in the Session History table was always blank. The DynamoDB write only sets `RuntimeVersion` when `save_conversation_exchange(..., runtime_version=...)` receives a value, but no caller ever passed it — so the read-side `.get("RuntimeVersion", "")` fallback always returned empty. This PR sources the version on the frontend (the browser already fetches `qualifierToVersion` per agent) and threads it through to the container write. It also adds a Cloudscape PropertyFilter to the Session History table, mirroring the existing AgentCore Runtime Manager.

## Changes
- Agent containers (src/agent-core/): pass runtime_version into save_conversation_exchange at all 4 text-chat call sites + both voice-save sites in shared/bidi_ws_adapter.py.
- Frontend version sourcing: new resolveRuntimeVersion() helper; AgentOption carries qualifierToVersion (populated from listRuntimeAgents); resolved version added to the text and voice_save payloads.
- Session History filter (sessions.tsx): switched useCollection to propertyFiltering + PropertyFilter over Title/AgentName/RuntimeVersion/ Endpoint; AgentName surfaced as a real `agentName` field (SessionRow) so it is filterable and sortable.

## Why frontend-driven sourcing

Single agents never receive the agentsSummaryTableName env var, so a backend-only fix would leave the common single-agent case blank and need IAM/env changes. The browser resolves the version uniformly across all 4 architectures with no infra change.

## Test plan
- [x] tsc --noEmit passes; ASH PASSED with 0 actionable findings on PR files
- [x] Deploy to sandbox (make deploy rebuilds agent images), start text chat, confirm RuntimeVersion populates
- [ ] Repeat for voice + swarm/graph/agents-as-tools
- [x] Use the property filter + column sorting on the Sessions page

## Notes / scope
- Version written only on session creation (first exchange), matching RuntimeId/Endpoint — pre-existing sessions stay blank (expected).
- Frontend/runtime-only; no iac-cdk/ or iac-terraform/ touched — no Terraform mirror needed.