### PR TITLE
📝 docs: reframe as agentic harness + accuracy/navigation pass

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ This is a **3-stack-equivalent CDK app** (`iac-cdk/bin/aca.ts`):
 Two CDK aspects run in `aca.ts`: `LambdaNodejsRuntimeUpgrader` (forces all `nodejs*` Lambdas to `nodejs24.x`, including framework-managed ones), then `AwsSolutionsChecks` (cdk-nag). Order matters — runtime upgrade must happen before nag validation.
 
 ### Runtime data plane
-The browser talks to AgentCore **directly over WebSocket** (`wss://bedrock-agentcore.<region>.amazonaws.com/runtimes/<ARN>/ws`) using a SigV4-signed presigned URL. AppSync/Lambda are **not** in the chat data path — they are only used for CRUD (sessions, agent config, evaluations) and a *side-channel* for AI-rephrased tool-action descriptions (SNS → `agentTools` topic → Agent Tools Handler Lambda → `chatMessages` topic → Outgoing Message Handler → AppSync subscription → browser).
+The browser talks to AgentCore **directly over WebSocket** (`wss://bedrock-agentcore.<region>.amazonaws.com/runtimes/<ARN>/ws`) using a SigV4-signed presigned URL. AppSync/Lambda are **not** in the chat data path — chat tokens *and* tool-step updates ("Using X…", arguments, success/error status) stream to the browser over that same WebSocket. AppSync is used for CRUD (sessions, agent config, evaluations) and for runtime/evaluation status notifications (e.g. `notify-runtime-update` → `publishRuntimeUpdate` → subscription → browser). Note: tool-step descriptions are no longer AI-rephrased and routed through SNS — the old `agentTools` topic and Agent Tools Handler Lambda have been removed.
 
 FastAPI inside the AgentCore container exposes:
 - `/ws` — text + voice (`voice_init` flips into Nova Sonic BidiAgent mode)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,10 +102,12 @@ Contributions should align with the following principles:
 
 For complete development environment setup, project structure, IDE configuration, and local development instructions, see the **[Development Guide](./docs/src/development-guide.md)**.
 
+> **Note:** This is the toolchain for *contributing* — building containers, layers, and linting Lambdas locally. Just *deploying* the accelerator needs far less (Node.js + AWS CLI + `zip`); Docker/Finch/Python are not required because builds run on AWS CodeBuild. See [How to Deploy](./docs/src/how-to-deploy.md#pre-requisites).
+
 In summary, you will need:
 
 - **Node.js** (version 20 recommended)
-- **Docker** or **Finch** (for container builds)
+- **Docker** or **Finch** (for local container builds)
 - **AWS CLI** (configured with appropriate credentials)
 - **Python 3.11+** (for Lambda development and linting)
 - **Git**
@@ -166,7 +168,7 @@ For detailed information on code quality tools, frontend testing, CDK synthesis,
 
 - **Infrastructure (CDK)**: Modifications to `iac-cdk/lib/` directory constructs
 - **Lambda Functions**: Python handlers in `src/*/functions/`
-- **Frontend (React)**: Components in `lib/user-interface/react-app/src/`
+- **Frontend (React)**: Components in `src/user-interface/react-app/src/`
 - **Agent Runtime**: Docker container and Python code in `src/agent-core/docker/`
 
 ### Documentation Contributions

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Agentic Chatbot Accelerator
 
-The Agentic Chatbot Accelerator is a full-stack solution for building, deploying, and iterating on agentic chatbots. It implements an iterative agent development lifecycle:
+> A full-stack agentic harness on AWS — spin up multi-agent chatbots, voice-to-voice AI, RAG, and an Agent Factory on Bedrock AgentCore. From idea to deployed agent, fast.
+
+The Agentic Chatbot Accelerator is a **full-stack agentic harness on AWS** — everything you need to build, deploy, run, and iterate on multi-agent chatbots in one place. Instead of standing up a single agent in isolation, it wraps your agents in the complete lifecycle: an Agent Factory to design and configure them, a managed runtime to deploy them, a chat interface (text and voice) to exercise them, and evaluation, observability, and feedback tooling to measure and improve them.
+
+It implements an iterative agent development lifecycle:
 
 <p align="center">
   <img src="./docs/imgs/agent-lifecycle.png" alt="Agent Development Lifecycle" />
@@ -12,7 +16,7 @@ The Agentic Chatbot Accelerator is a full-stack solution for building, deploying
 4. **Deploy Agent** – Managed runtime environment for your agents
 5. **Experiment & Gather Feedback** – Agent behavior testing, human feedback collection, and iterative refinement
 
-The accelerator provides a web-based interface, agent factory, knowledge base management, and observability tooling to support this full cycle. The current implementation deploys on AWS using CDK or Terraform, leveraging Amazon Bedrock AgentCore.
+As a harness, it closes the loop end to end: a web-based interface and Agent Factory to author agents, four agentic patterns (single, agents-as-tools, swarm, graph), an MCP server registry and knowledge base management to extend them, a managed runtime to host them, and evaluation, experiments, and observability tooling to measure and refine them. The current implementation deploys on AWS using CDK or Terraform, leveraging Amazon Bedrock AgentCore.
 
 ## How to Get Started
 
@@ -61,11 +65,15 @@ Everything the Agent Factory UI does, you can also drive from a conversation in 
 
 > The plugin operates on a **deployed** stack via the Agent Factory API — it does not generate IaC. For build-time `config.yaml`/`tfvars`, see [How to Deploy](./docs/src/how-to-deploy.md).
 
-## AWS Platform Details
+## Documentation
 
-- [Architecture](./docs/src/architecture.md)
-- [API Reference](./docs/src/api.md)
-- [Observability & Insights](./docs/src/observability-insights.md)
+📚 **[Full documentation index](./docs/src/index.md)** — the complete map of guides, grouped by lifecycle stage.
+
+Frequently referenced:
+
+- [How to Deploy](./docs/src/how-to-deploy.md) · [Development Guide](./docs/src/development-guide.md) · [Troubleshooting](./docs/src/troubleshooting.md)
+- [Architecture](./docs/src/architecture.md) · [API Reference](./docs/src/api.md) · [Observability & Insights](./docs/src/observability-insights.md)
+- [Agent Skills](./docs/src/skills.md) · [Expanding AI Tools](./docs/src/expanding-ai-tools.md) · [Knowledge Base Management](./docs/src/kb-management.md)
 
 ## Optional Features
 

--- a/docs/src/agent-factory.md
+++ b/docs/src/agent-factory.md
@@ -24,12 +24,16 @@ Creates a new AgentCore Runtime by starting a Step Function execution.
 
 **Parameters:**
 - `agentName` (string): The unique name identifier for the agent runtime
-- `configValue` (string): A JSON string containing the agent configuration conforming to the AgentConfiguration schema (for single agents) or SwarmConfiguration schema (for swarm agents)
-- `architectureType` (ArchitectureType, optional): `SINGLE` or `SWARM`. Defaults to `SINGLE` when omitted
+- `configValue` (string): A JSON string containing the agent configuration. The schema it must conform to depends on `architectureType` (see Validation below)
+- `architectureType` (ArchitectureType, optional): `SINGLE`, `AGENTS_AS_TOOLS`, `SWARM`, or `GRAPH`. Defaults to `SINGLE` when omitted
 
 **Validation:**
 - First validates the input is valid JSON
-- Then validates against the `AgentConfiguration` Pydantic model (when `architectureType` is `SINGLE` or omitted) or the `SwarmConfiguration` model (when `architectureType` is `SWARM`)
+- Then validates against the Pydantic model matching `architectureType`:
+  - `SINGLE` (or omitted) → `AgentConfiguration`
+  - `AGENTS_AS_TOOLS` → `AgentsAsToolsConfiguration`
+  - `SWARM` → `SwarmConfiguration`
+  - `GRAPH` → `GraphConfiguration`
 
 **Returns:**
 - The `agentName` if Step Function execution started successfully

--- a/docs/src/agentic-patterns/agents-as-tools.md
+++ b/docs/src/agentic-patterns/agents-as-tools.md
@@ -54,14 +54,14 @@ In the **Agents as Tools** step:
 
 There is **no role field on this step** — the orchestrator reads each sub-agent's own Description (the one you set when creating the sub-agent) from its A2A agent card. To change how the orchestrator perceives a sub-agent, edit that sub-agent's Description (create a new version of the sub-agent), don't try to override it here.
 
-![Agents as Tools — Step 1: Adding sub-agents with endpoint and role configuration](../../imgs/agentic-patterns/agents-as-tools-01.png)
+![Agents as Tools — Step 1: Adding sub-agents by selecting an existing agent and its endpoint](../../imgs/agentic-patterns/agents-as-tools-01.png)
 
 ### 4. Configure the orchestrator
 
 In the **Orchestrator Configuration** step:
 
 1. **Model**: Select the LLM model for the orchestrator (e.g. Claude Haiku 4.5)
-2. **Instructions**: Write a system prompt that tells the orchestrator how to use its sub-agents. Reference the sub-agents by their roles and explain the delegation strategy.
+2. **Instructions**: Write a system prompt that tells the orchestrator how to use its sub-agents. Refer to each sub-agent by name and explain the delegation strategy — but remember the orchestrator decides *which* sub-agent fits a task from that sub-agent's own Description (its A2A card), not from anything you write here.
 3. **Conversation Manager**: Choose how conversation history is managed (Sliding Window is recommended)
 4. **Additional Tools** (optional): Add extra tools, knowledge bases, or MCP servers that the orchestrator can use directly alongside its sub-agent tools
 
@@ -100,7 +100,7 @@ For each sub-agent, fill in **both** Instructions (how it should behave) and Des
 Create each one through the UI:
 
 1. **Agent Factory** → **Create Agent** → **Single Agent**
-2. Set the agent name, instructions, **description**, and model (e.g. `us.anthropic.claude-haiku-4-5-20251001-v1:0`)
+2. Set the agent name, instructions, **description**, and model (e.g. Claude Haiku 4.5)
 3. Do **not** add any tools — the agents will simulate their responses
 4. Wait for "Ready" status
 
@@ -190,7 +190,7 @@ To update an agents-as-tools configuration:
 ## How It Works Under the Hood
 
 1. The UI sends a `createAgentCoreRuntime` mutation with `architectureType: AGENTS_AS_TOOLS` and the orchestrator config as `configValue`
-2. The Agent Factory Resolver validates the config against `OrchestratorConfiguration` (Pydantic), verifies all referenced runtime IDs exist, and rewrites each sub-agent's `runtimeId` from the HTTP runtime id to the **A2A twin ARN** (sub-agents deploy as twin runtimes — HTTP for UI standalone access, A2A for orchestrator calls)
+2. The Agent Factory Resolver validates the config against `AgentsAsToolsConfiguration` (Pydantic), verifies all referenced runtime IDs exist, and rewrites each sub-agent's `runtimeId` from the HTTP runtime id to the **A2A twin ARN** (sub-agents deploy as twin runtimes — HTTP for UI standalone access, A2A for orchestrator calls)
 3. The Step Function invokes the Create Runtime Version Lambda, which selects the agents-as-tools Docker container (`docker-agents-as-tools/`)
 4. At runtime, the container's `data_source.py` loads the orchestrator configuration from DynamoDB
 5. `factory.py` creates a Strands `Agent` with the orchestrator's model and instructions, then wires each sub-agent in via Strands' `A2AClientToolProvider`:

--- a/docs/src/agentic-patterns/graph-agents.md
+++ b/docs/src/agentic-patterns/graph-agents.md
@@ -181,7 +181,7 @@ A linear pipeline where content is researched, written, and reviewed.
 
 Create each one through the UI:
 1. **Agent Factory** → **Create Agent** → **Single Agent**
-2. Set the agent name, instructions, and model (e.g. `us.anthropic.claude-haiku-4-5-20251001-v1:0`)
+2. Set the agent name, instructions, and model (e.g. Claude Haiku 4.5)
 3. Wait for "Ready" status
 
 ### Step 2 — Create the graph

--- a/docs/src/agentic-patterns/swarm-agents.md
+++ b/docs/src/agentic-patterns/swarm-agents.md
@@ -13,6 +13,8 @@ A swarm agent consists of:
 
 Unlike single agents where one agent handles everything, swarm agents hand off conversations between specialised agents. For example, a software development swarm might have a researcher, a coder, a reviewer, and an architect — each handling their area of expertise and handing off when another specialist is needed.
 
+The swarm is built on the [Strands Agents](https://strandsagents.com/) multi-agent swarm primitive and runs as a containerized runtime on Amazon Bedrock AgentCore.
+
 ## Prerequisites
 
 Before creating a swarm agent, you need:
@@ -64,7 +66,7 @@ These defaults work well for most use cases. Increase timeouts for complex multi
 
 ### 6. Review and create
 
-Review the configuration summary and click **Create**. The swarm agent will go through the same creation pipeline as single agents (Step Function → AgentCore Runtime).
+Review the configuration summary and click **Create Runtime**. The swarm agent will go through the same creation pipeline as single agents (Step Function → AgentCore Runtime).
 
 ### 7. Test the swarm
 
@@ -89,7 +91,7 @@ A team of specialised agents collaborating on a software task.
 
 Create each one through the UI:
 1. **Agent Factory** → **Create Agent** → **Single Agent**
-2. Set the agent name, instructions, and model (e.g. `us.anthropic.claude-haiku-4-5-20251001-v1:0`)
+2. Set the agent name, instructions, and model (e.g. Claude Haiku 4.5)
 3. Wait for "Ready" status
 
 ### Step 2 — Create the swarm
@@ -139,6 +141,18 @@ To inspect an existing swarm agent's configuration:
 3. Click on a version to open the **View Version** modal
 4. The modal displays: entry agent, agent references with endpoints, orchestrator settings, and conversation manager
 
+## Creating a New Version
+
+To update a swarm's configuration:
+
+1. Select the swarm in the **Agent Factory** table
+2. Click **New version**
+3. The wizard opens with the existing configuration pre-populated
+4. Modify the agent references, entry agent, orchestrator settings, or conversation manager as needed
+5. Click **Create Runtime** to deploy the new version
+
+> Updating a swarm only changes the swarm-level config (which agents participate, the entry agent, limits). To change a *member* agent's model, instructions, or tools, create a new version of that single agent and point the referenced endpoint (e.g. DEFAULT) at it — the swarm resolves each reference's endpoint to a specific version when it loads members, so the member only changes once that endpoint moves.
+
 ## How It Works Under the Hood
 
 1. The UI sends a `createAgentCoreRuntime` mutation with `architectureType: SWARM` and the swarm config as `configValue`
@@ -146,6 +160,24 @@ To inspect an existing swarm agent's configuration:
 3. The Step Function invokes the Create Runtime Version Lambda, which selects the swarm Docker container
 4. At runtime, the swarm container's `data_source.py` loads each referenced agent's configuration from DynamoDB
 5. The swarm orchestrator manages handoffs between agents based on the orchestrator settings
+
+## Best Practices
+
+### Designing the swarm
+
+- **Give each member a single, clear specialty** — overlapping responsibilities cause agents to hand off back and forth instead of converging.
+- **Write handoff cues into member instructions** — tell each agent *when* its job is done and *which* specialist should take over next (the swarm reads these to route handoffs).
+- **Pick the entry agent deliberately** — it should be a triage/coordinator role that can route the first message, not a deep specialist.
+- **Tune limits to the workflow** — raise execution and node timeouts for long multi-step tasks; lower max handoffs if agents loop.
+
+### When to use swarm vs. other patterns
+
+| Pattern | Best for |
+|---|---|
+| **Single Agent** | Focused tasks with direct tool access — the simplest and fastest to set up |
+| **Agents as Tools** | Dynamic delegation where an orchestrator decides which specialists to invoke |
+| **Swarm** | Collaborative workflows where agents hand off conversations to each other |
+| **Graph** | Predefined workflows with fixed execution paths and conditional routing |
 
 ## Troubleshooting
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,68 +1,124 @@
 # API Reference
 
-The following table documents the [GraphQL API schema](../../src/api/schema/schema.graphql).
+> [← Documentation index](./index.md)
 
-| FieldName | Type | Functionality | Callable from Internet | Authorized Callers | Comments |
-|-----------|------|---------------|------------------------|-------------------|----------|
-| sendQuery | Mutation | Send user message to the backend for an agent runtime to process | Yes | User authenticated via Cognito | Fire and forget approach - the client sends the query and subscribes to receive response |
-| publishResponse | Mutation | Publish to the client the tokens and the final agent answer | No | Lambda function |  |
-| receiveMessages | Subscription | Subscription on publishResponse | Yes | User authenticated via Cognito |  |
-| listSessions | Query | List all user's chatbot sessions | Yes | User authenticated via Cognito |  |
-| getSession | Query | Get a specific user's session by session id | Yes | User authenticated via Cognito | Allows to reload a conversation to visualize or continue it |
-| deleteUserSessions | Mutation | Delete all the user sessions | Yes | User authenticated via Cognito |  |
-| deleteSession | Mutation | Delete a specific user session | Yes | User authenticated via Cognito |  |
-| renameSession | Mutation | Modify a session title | Yes | User authenticated via Cognito | By default, a session title is composed of the first 100 characters of the first user message |
-| saveToolActions | Mutation | Save tool actions for a specific message in a session | Yes | User authenticated via Cognito | Persists user friendly description of the agent's tool invocations to the session history |
-| updateMessageExecutionTime | Mutation | Update execution time for a message in a session | Yes | User authenticated via Cognito |  |
-| publishFeedback | Mutation | Publish user's feedback on an agent generated response | Yes | User authenticated via Cognito | Thumbs up/down and free-text form feedback |
-| getPresignedUrl | Query | Get S3 object presigned URL | Yes | User authenticated via Cognito | Used to display the document that corresponds to a reference if the agent is using a knowledge base as data source |
-| listKnowledgeBases | Query | List available Bedrock Knowledge Bases | Yes | User authenticated via Cognito | This filters on AWS tags: stack name and environment |
-| listDataSources | Query | List data sources associated with a Bedrock Knowledge Base | Yes | User authenticated via Cognito |  |
-| listDocuments | Query | List documents in a data source | Yes | User authenticated via Cognito |  |
-| getInputPrefix | Query | Get the raw input prefix associated with a knowledge base data source | Yes | User authenticated via Cognito |  |
-| checkOnProcessStarted | Query | Check if document processing has started for a given set of S3 objects. | Yes | User authenticated via Cognito | Used when user uploads documents through the UI. This could potentially be refactored with a mutation/subscription pattern |
-| checkOnProcessCompleted | Query | Check if document processing has completed for a given set of S3 objects. | Yes | User authenticated via Cognito | Used when user uploads documents through the UI. This could potentially be refactored with a mutation/subscription pattern. |
-| checkOnDocumentsRemoved | Query | Check if documents have been removed from DynamoDB that stores the doc processing states | Yes | User authenticated via Cognito | Used when user deletes documents through the UI. This could potentially be refactored with a mutation/subscription pattern. |
-| checkOnSyncInProgress | Query | Check if a knowledge base data source sync is currently in progress. | Yes | User authenticated via Cognito | Used when user adds/deletes documents through the UI. This could potentially be refactored with a mutation/subscription pattern. |
-| deleteDocument | Mutation | Delete a document from a data source | Yes | User authenticated via Cognito |  |
-| createKnowledgeBase | Mutation | Create a new Bedrock Knowledge Base from the application | Yes | User authenticated via Cognito |  |
-| deleteKnowledgeBase | Mutation | Delete an existing Bedrock Knowledge Base from the application | Yes | User authenticated via Cognito |  |
-| createDataSource | Mutation | Create a new S3 data source and attach it to an existing Bedrock Knowledge Base | Yes | User authenticated via Cognito |  |
-| deleteDataSource | Mutation | Remove an existing S3 data source from a Bedrock Knowledge Base | Yes | User authenticated via Cognito |  |
-| syncKnowledgeBase | Mutation | Synchronize a Bedrock Knowledge Base | Yes | User authenticated via Cognito | Used a fallback mechanism because Knowledge Base synchronization is automatically done. |
-| getDocumentMetadata | Query | Get the metadata associated with a document | Yes | User authenticated via Cognito |  |
-| updateMetadata | Mutation | Update the metadata of a single document | Yes | User authenticated via Cognito |  |
-| batchUpdateMetadata | Mutation | Update the metadata of a set of documents | Yes | User authenticated via Cognito | Used to upload the metadata as JSONL |
-| listAvailableTools | Query | List the AI tools that can be attached to an agent | Yes | User authenticated via Cognito |  |
-| listAvailableMcpServers | Query | List the MCP Servers that can be attached to an agent | Yes | User authenticated via Cognito |  |
-| listRuntimeAgents | Query | List AgentCore runtimes | Yes | User authenticated via Cognito | This filters on AWS tags: stack name and environment |
-| getRuntimeConfigurationByVersion | Query | Get the configuration (model, agent instructions, tools, and knowledge bases) associated with a specific runtime version | Yes | User authenticated via Cognito |  |
-| getRuntimeConfigurationByQualifier | Query | Get the configuration (model, agent instructions, tools, and knowledge bases) associated with a specific endpoint label | Yes | User authenticated via Cognito | Qualifier = endpoint name |
-| getDefaultRuntimeConfiguration | Query | Get the configuration (model, agent instructions, tools, and knowledge bases) associated with the DEFAULT endpoint | Yes | User authenticated via Cognito | Qualifier = DEFAULT that is the latest version |
-| listAgentVersions | Query | List all the versions of an AgentCore runtime | Yes | User authenticated via Cognito |  |
-| listAgentEndpoints | Query | List all the endpoints (qualifiers) of an AgentCore runtime | Yes | User authenticated via Cognito |  |
-| getFavoriteRuntime | Query | Get the favorite AgentCore runtime and endpoint names | Yes | User authenticated via Cognito | The chatbot is initialized with the favorite runtime if any. |
-| createAgentCoreRuntime | Mutation | Create an AgentCore runtime | Yes | User authenticated via Cognito |  |
-| tagAgentCoreRuntime | Mutation | Tag an AgentCore runtime version with a label | Yes | User authenticated via Cognito | This creates de-facto an endpoint |
-| deleteAgentRuntime | Mutation | Delete an AgentCore runtime | Yes | User authenticated via Cognito |  |
-| deleteAgentRuntimeEndpoints | Mutation | Delete an AgentCore runtime endpoint | Yes | User authenticated via Cognito |  |
-| updateFavoriteRuntime | Mutation | Update the favorite AgentCore runtime and endpoint | Yes | User authenticated via Cognito |  |
-| resetFavoriteRuntime | Mutation | Remove the favorite endpoint for a given user | Yes | User authenticated via Cognito |  |
-| publishRuntimeUpdate | Mutation | Notify on AgentCore Runtime Update | No | Lambda Function | Used for both delete runtime and delete endpoints |
-| receiveUpdateNotification | Subscription |Receive AgentCore Runtime update | Yes | User authenticated via Cognito |  |
-| listEvaluators | Query | List all evaluation configurations | Yes | User authenticated via Cognito | Returns evaluator metadata including status, progress, and pass rates |
-| getEvaluator | Query | Get a specific evaluator by ID | Yes | User authenticated via Cognito | Includes detailed results if evaluation is completed |
-| createEvaluator | Mutation | Create a new evaluation configuration | Yes | User authenticated via Cognito | Defines test cases, evaluator type, and target agent |
-| deleteEvaluator | Mutation | Delete an evaluator and its results | Yes | User authenticated via Cognito | Removes all associated S3 results |
-| runEvaluation | Mutation | Start an evaluation run | Yes | User authenticated via Cognito | Queues test cases to SQS for processing |
-| publishEvaluationUpdate | Mutation | Publish evaluation status update | No | Lambda Function |  |
-| receiveEvaluationUpdate | Subscription | Receive evaluation status updates | Yes | User authenticated via Cognito | Subscribes to publishEvaluationUpdate |
-| registerMcpServer | Mutation | Register an MCP server | Yes | User authenticated via Cognito |  |
-| deleteMcpServer | Mutation | Delete an MCP server | Yes | User authenticated via Cognito |  |
-| listExperiments | Query | List all experiments | Yes | User authenticated via Cognito |  |
-| getExperiment | Query | Get a specific experiment by ID | Yes | User authenticated via Cognito |  |
-| getExperimentPresignedUrl | Query | Get a presigned URL for experiment S3 objects | Yes | User authenticated via Cognito |  |
-| createExperiment | Mutation | Create a new experiment | Yes | User authenticated via Cognito |  |
-| updateExperiment | Mutation | Update an existing experiment | Yes | User authenticated via Cognito |  |
-| deleteExperiment | Mutation | Delete an experiment | Yes | User authenticated via Cognito |  |
-| runExperiment | Mutation | Run an experiment | Yes | User authenticated via Cognito |  |
+This page documents the AppSync GraphQL API. The authoritative source for argument and return types is the [GraphQL schema](../../src/api/schema/schema.graphql) — refer to it for exact input/output shapes.
+
+> **Authorization:** Every operation is callable over the internet and requires a user authenticated via Amazon Cognito (`@aws_cognito_user_pools`), **except** the three `publish*` mutations (`publishResponse`, `publishRuntimeUpdate`, `publishEvaluationUpdate`), which are invoked **only by backend Lambda functions** via IAM (`@aws_iam`) and are not user-callable. The tables below note only the exceptions in the **Auth** column.
+
+> **Note:** The chat data path does **not** go through this API. The browser streams to AgentCore directly over a SigV4-signed WebSocket — including tool-step updates. AppSync is used for CRUD (sessions, agents, knowledge bases, evaluations, experiments, skills) and for runtime/evaluation status notifications via subscriptions. See [Architecture](./architecture.md).
+
+## Chat & Messaging
+
+User messages are sent to the agent over the direct WebSocket, not through this API (there is no `sendQuery` mutation — it was removed when chat moved to the direct WebSocket). The operations below cover the AppSync side-channel that delivers responses and tool-action descriptions back to the browser, plus feedback.
+
+| Operation | Type | Functionality | Auth | Comments |
+|-----------|------|---------------|------|----------|
+| publishResponse | Mutation | Publish response tokens and the final agent answer to the client | Lambda only | The browser subscribes via `receiveMessages` |
+| receiveMessages | Subscription | Subscribe to `publishResponse` for a session | | |
+| publishFeedback | Mutation | Publish a user's feedback on an agent-generated response | | Thumbs up/down and free-text feedback |
+
+## Sessions
+
+| Operation | Type | Functionality | Auth | Comments |
+|-----------|------|---------------|------|----------|
+| listSessions | Query | List all of the user's chatbot sessions | | |
+| getSession | Query | Get a specific session by session id | | Allows reloading a conversation to view or continue it |
+| deleteUserSessions | Mutation | Delete all of the user's sessions | | |
+| deleteSession | Mutation | Delete a specific user session | | |
+| renameSession | Mutation | Modify a session title | | A session title defaults to the first 100 characters of the first user message |
+| saveToolActions | Mutation | Save tool actions for a specific message in a session | | Persists a user-friendly description of the agent's tool invocations to the session history |
+| saveVoiceSession | Mutation | Persist a voice-to-voice conversation's history to a session | | Used by Nova Sonic voice sessions to save the transcript and runtime/endpoint |
+| updateMessageExecutionTime | Mutation | Update the execution time for a message in a session | | |
+
+## Knowledge Bases & Documents
+
+| Operation | Type | Functionality | Auth | Comments |
+|-----------|------|---------------|------|----------|
+| listKnowledgeBases | Query | List available Bedrock Knowledge Bases | | Filters on AWS tags: stack name and environment |
+| createKnowledgeBase | Mutation | Create a new Bedrock Knowledge Base from the application | | |
+| deleteKnowledgeBase | Mutation | Delete an existing Bedrock Knowledge Base | | |
+| listDataSources | Query | List data sources associated with a Knowledge Base | | |
+| createDataSource | Mutation | Create a new S3 data source and attach it to a Knowledge Base | | |
+| deleteDataSource | Mutation | Remove an S3 data source from a Knowledge Base | | |
+| getInputPrefix | Query | Get the raw input prefix associated with a data source | | |
+| syncKnowledgeBase | Mutation | Synchronize a Knowledge Base | | A fallback mechanism — Knowledge Base synchronization normally runs automatically |
+| listDocuments | Query | List documents in a data source | | |
+| deleteDocument | Mutation | Delete a document from a data source | | |
+| getDocumentMetadata | Query | Get the metadata associated with a document | | |
+| updateMetadata | Mutation | Update the metadata of a single document | | |
+| batchUpdateMetadata | Mutation | Update the metadata of a set of documents | | Used to upload metadata as JSONL |
+| getPresignedUrl | Query | Get an S3 object presigned URL | | Used to display the document behind a knowledge-base reference |
+| checkOnProcessStarted | Query | Check whether document processing has started for a set of S3 objects | | Polled after the user uploads documents through the UI |
+| checkOnProcessCompleted | Query | Check whether document processing has completed for a set of S3 objects | | Polled after the user uploads documents through the UI |
+| checkOnDocumentsRemoved | Query | Check whether documents have been removed from the doc-processing state table | | Polled after the user deletes documents through the UI |
+| checkOnSyncInProgress | Query | Check whether a data-source sync is currently in progress | | Polled after the user adds/deletes documents through the UI |
+
+## Agent Runtimes (Agent Factory)
+
+| Operation | Type | Functionality | Auth | Comments |
+|-----------|------|---------------|------|----------|
+| listRuntimeAgents | Query | List AgentCore runtimes | | Filters on AWS tags: stack name and environment |
+| createAgentCoreRuntime | Mutation | Create an AgentCore runtime | | See [Agent Factory Operations](./agent-factory.md) for the `architectureType` → config-schema mapping |
+| tagAgentCoreRuntime | Mutation | Tag an AgentCore runtime version with a label | | Tagging a version is what creates an endpoint (qualifier) |
+| deleteAgentRuntime | Mutation | Delete an AgentCore runtime | | |
+| deleteAgentRuntimeEndpoints | Mutation | Delete an AgentCore runtime endpoint | | |
+| listAgentVersions | Query | List all versions of an AgentCore runtime | | |
+| listAgentEndpoints | Query | List all endpoints (qualifiers) of an AgentCore runtime | | |
+| getRuntimeConfigurationByVersion | Query | Get the configuration for a specific runtime version | | Configuration = model, instructions, tools, knowledge bases |
+| getRuntimeConfigurationByQualifier | Query | Get the configuration for a specific endpoint label | | Qualifier = endpoint name |
+| getDefaultRuntimeConfiguration | Query | Get the configuration for the DEFAULT endpoint | | DEFAULT qualifier points to the latest version |
+| getFavoriteRuntime | Query | Get the user's favorite AgentCore runtime and endpoint | | The chatbot initializes with the favorite runtime if set |
+| updateFavoriteRuntime | Mutation | Update the user's favorite AgentCore runtime and endpoint | | |
+| resetFavoriteRuntime | Mutation | Remove the favorite endpoint for the user | | |
+| publishRuntimeUpdate | Mutation | Notify on an AgentCore runtime update | Lambda only | Used for both delete-runtime and delete-endpoints |
+| receiveUpdateNotification | Subscription | Receive AgentCore runtime updates | | |
+
+## Tools, MCP Servers & Building Blocks
+
+| Operation | Type | Functionality | Auth | Comments |
+|-----------|------|---------------|------|----------|
+| listAvailableTools | Query | List the AI tools that can be attached to an agent | | |
+| listAvailableMcpServers | Query | List the MCP servers that can be attached to an agent | | |
+| registerMcpServer | Mutation | Register an MCP server | | |
+| deleteMcpServer | Mutation | Delete an MCP server | | |
+| listAvailableStateClasses | Query | List the state classes available to swarm/graph agents | | |
+| listAvailableDeterministicNodes | Query | List the deterministic nodes available to graph agents | | |
+
+## Skills
+
+| Operation | Type | Functionality | Auth | Comments |
+|-----------|------|---------------|------|----------|
+| listSkills | Query | List all registered agent skills | | See [Agent Skills](./skills.md) |
+| getSkillContent | Query | Get a skill's content by name | | |
+| createSkill | Mutation | Create a new skill | | |
+| updateSkill | Mutation | Update an existing skill's description or content | | |
+| deleteSkill | Mutation | Delete a skill | | |
+| listSkillResources | Query | List the resource files attached to a skill | | |
+| getSkillResource | Query | Get a single skill resource file by path | | |
+| uploadSkillResource | Mutation | Upload a resource file to a skill | | |
+| deleteSkillResource | Mutation | Delete a skill resource file by path | | |
+
+## Evaluations
+
+| Operation | Type | Functionality | Auth | Comments |
+|-----------|------|---------------|------|----------|
+| listEvaluators | Query | List all evaluation configurations | | Returns evaluator metadata including status, progress, and pass rates |
+| getEvaluator | Query | Get a specific evaluator by ID | | Includes detailed results when the evaluation is completed |
+| createEvaluator | Mutation | Create a new evaluation configuration | | Defines test cases, evaluator type, and target agent |
+| deleteEvaluator | Mutation | Delete an evaluator and its results | | Removes all associated S3 results |
+| runEvaluation | Mutation | Start an evaluation run | | Queues test cases to SQS for processing |
+| publishEvaluationUpdate | Mutation | Publish an evaluation status update | Lambda only | |
+| receiveEvaluationUpdate | Subscription | Receive evaluation status updates | | Subscribes to `publishEvaluationUpdate` |
+
+## Experiments
+
+| Operation | Type | Functionality | Auth | Comments |
+|-----------|------|---------------|------|----------|
+| listExperiments | Query | List all experiments | | |
+| getExperiment | Query | Get a specific experiment by ID | | |
+| getExperimentPresignedUrl | Query | Get a presigned URL for experiment S3 objects | | |
+| createExperiment | Mutation | Create a new experiment | | |
+| updateExperiment | Mutation | Update an existing experiment | | |
+| deleteExperiment | Mutation | Delete an experiment | | |
+| runExperiment | Mutation | Run an experiment | | |

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -36,13 +36,15 @@
 |----------|------|
 | λ Notify Runtime Update | Notifies the frontend via AppSync when runtime status changes (creation complete, deletion complete) |
 
-> **Note:** Tool steps ("Using X…", arguments, success/error status) are no longer
-> rephrased by an LLM and routed through SNS. The AgentCore container now emits them
-> **directly over the browser WebSocket** alongside the chat stream (see [Real-Time
-> Communication](#real-time-communication-direct-websocket)). The former side-channel
-> — the `agentTools` SNS topic and the Agent Tools Handler Lambda — has been removed.
+> **Note:** Tool steps ("Using X…", arguments, success/error status) are emitted by the
+> AgentCore container **directly over the browser WebSocket** alongside the chat stream
+> (see [Real-Time Communication](#real-time-communication-direct-websocket)). AppSync is
+> used only to notify the frontend of runtime status changes, not for the live chat or
+> tool-step stream.
 
-## Agent Core Infrastructure
+## AgentCore Infrastructure
+
+Each agentic pattern ships as its own container image. For how to build and use each, see the pattern guides: [Single Agent](./agentic-patterns/single-agent.md), [Agents as Tools](./agentic-patterns/agents-as-tools.md), [Swarm](./agentic-patterns/swarm-agents.md), and [Graph](./agentic-patterns/graph-agents.md).
 
 | Resource | Role |
 |----------|------|
@@ -79,13 +81,14 @@ Browser → SigV4 presigned URL → wss://bedrock-agentcore.<region>.amazonaws.c
 
 ## Amazon Bedrock — Foundation Models
 
+The default configuration (`iac-cdk/bin/config.ts`) ships the three text models below. Add any other Bedrock model — including the voice model — to `supportedModels` in your `config.yaml`; see [How to Deploy](./how-to-deploy.md).
+
 | Model | Use Case |
 |-------|----------|
-| Claude Opus 4.7 | Complex reasoning, high-quality responses |
 | Claude Sonnet 4.6 | Balanced performance/cost, extended thinking |
 | Claude Haiku 4.5 | Fast responses, cost-efficient |
 | Amazon Nova 2 Lite | Fast text inference |
-| Amazon Nova Sonic | Voice-to-voice bidirectional streaming (BidiAgent) |
+| Amazon Nova 2 Sonic | Voice-to-voice bidirectional streaming (BidiAgent) — add to enable voice |
 
 ## Data Processing *(optional)*
 

--- a/docs/src/development-guide.md
+++ b/docs/src/development-guide.md
@@ -1,5 +1,7 @@
 # Development Guide
 
+> [← Documentation index](./index.md)
+
 ## Overview
 
 The Agentic Chatbot Accelerator is a full-stack web application built with AWS CDK that enables rapid deployment of agentic chatbots powered by AWS Bedrock AgentCore and AWS Strands. This guide covers the complete development workflow from setup to deployment.

--- a/docs/src/evaluation.md
+++ b/docs/src/evaluation.md
@@ -72,7 +72,7 @@ AppSync → EvaluationResolver → SQS Queue → EvaluationExecutor → DynamoDB
 
 ## Available Evaluators
 
-The system supports nine evaluator types — eight from the Strands Evaluation SDK plus one custom evaluator:
+The system supports nine evaluator types — eight from the Strands Evaluation SDK plus one custom evaluator (**StructuredOutputEvaluator**, defined in `evaluation-executor/evaluator.py`; it is deterministic and needs no LLM):
 
 | Evaluator | Purpose | Requires Rubric | Requires Trajectory | Best For |
 |-----------|---------|-----------------|---------------------|----------|
@@ -110,8 +110,8 @@ StructuredOutputEvaluator, OutputEvaluator
 
 ## Pass/Fail Logic
 
-- **Pass threshold**: Configurable via `passThreshold` in `config.yaml`
-- **Overall pass**: Based on **average score** across all evaluators
+- **Pass threshold**: Configurable via `passThreshold` in `config.yaml` (default `0.8`)
+- **Overall pass**: The test case passes when the **average score across all selected evaluators** is `>= passThreshold`
 - **Individual evaluators**: Each produces a score from 0.0 to 1.0
 
 Example (with passThreshold: 0.8):
@@ -120,6 +120,8 @@ OutputEvaluator: 100%
 HelpfulnessEvaluator: 83%
 Average: 91.5% → PASSED (>= 80%)
 ```
+
+> **Note on binary evaluators**: `GoalSuccessRateEvaluator` and `StructuredOutputEvaluator` emit only `1.0` or `0.0`. Because the overall result is a plain average, mixing a binary evaluator with graded ones pulls the average sharply on failure (e.g. a `0.0` binary score alongside a `1.0` graded score averages to `0.5`). If you need a binary evaluator to be strictly gating, run it in its own evaluation rather than averaging it with rubric-based ones.
 
 ## Concurrency and Throttling
 
@@ -261,7 +263,7 @@ For `InteractionsEvaluator`, use the `expected_interactions` field to define the
 4. **Provide clear expected outputs**: Evaluators compare against your expected output
 5. **Define expected_trajectory for workflow validation**: Use this with `TrajectoryEvaluator` to verify action sequences
 6. **Test iteratively**: Run small test sets first to validate evaluator selection
-7. **Monitor pass rates**: A consistent pass rate below 70% may indicate evaluator mismatch
+7. **Monitor pass rates**: A consistently low pass rate (e.g. most cases falling well under your `passThreshold`) may indicate an evaluator mismatch rather than a bad agent — revisit which evaluators you've selected for the agent type
 8. **Use StructuredOutputEvaluator for JSON outputs**: For agents that return structured data (e.g., extracted `loop_id`, `template_tags`), this evaluator provides deterministic field-level comparison without LLM costs. Use `null` in `expected_output` to assert a field should be absent.
 
 ## Related Resources

--- a/docs/src/expanding-ai-tools.md
+++ b/docs/src/expanding-ai-tools.md
@@ -64,7 +64,7 @@ These steps will create an MCP server on AgentCore Gateway using AWS Lambda func
 
 
 #### Configuration
-**Add** MCP server details in the `bin/config.yaml` file. The MCP URL is automatically composed at deployment time based on the runtime or gateway ID you provide, along with the AWS region and account ID from your deployment context.
+**Add** MCP server details in the `iac-cdk/bin/config.yaml` file. The MCP URL is automatically composed at deployment time based on the runtime or gateway ID you provide, along with the AWS region and account ID from your deployment context.
 
 For each MCP server, you must specify exactly one of:
 - **runtimeId**: The runtime identifier from your AgentCore Runtime deployment (visible in the AgentCore console or returned when creating the runtime)
@@ -239,7 +239,7 @@ class MyTool(AbstractToolObject):
 
 ### 1. Implement Tool Logic
 
-Add your tool to [lib/agent-core/docker/src/registry.py](../../src/agent-core/docker/src/registry.py):
+Define your tool in [src/agent-core/shared/base_registry.py](../../src/agent-core/shared/base_registry.py), where the `@tool` decorator, `AbstractToolObject`, `ToolFactory`, and `TOOL_FACTORY_MAP` all live. (The per-container [registry.py](../../src/agent-core/docker/src/registry.py) imports `TOOL_FACTORY_MAP` from there — you don't edit it.)
 
 ```python
 # Function-based example
@@ -266,7 +266,7 @@ class MLModelTool(AbstractToolObject):
 
 ### 2. Register Tool Factory
 
-Add factory method to `ToolFactory` class:
+Add a factory method to the `ToolFactory` class (in the same `base_registry.py`):
 
 ```python
 class ToolFactory:
@@ -294,10 +294,11 @@ TOOL_FACTORY_MAP = {
 
 ### 4. Register in Configuration
 
-Create a `config.yaml` in the [iac-cdk/bin/ folder](../../iac-cdk/bin/) with your custom toolRegistry:
+Add your tools to the `toolRegistry` block in [iac-cdk/bin/config.yaml](../../iac-cdk/bin/) (create the file if it does not yet exist — it overrides the defaults in `config.ts`):
 
 ```yaml
 toolRegistry:
+  # ... existing tools
   - name: "get_current_time"
     description: "Get the current date and time in the specified timezone. Helpful when user refers to relative time (yesterday, today, this year, now, etc.)"
     invokesSubAgent: false
@@ -305,12 +306,11 @@ toolRegistry:
     description: "Invoke a sub-agent to handle specialized tasks or domain-specific queries that require dedicated processing"
     invokesSubAgent: true
   - name: "analyze_data"
-    description: "Analyze scientific datasets with statistical methods",
-    invokesSubAgent: false,
+    description: "Analyze scientific datasets with statistical methods"
+    invokesSubAgent: false
   - name: "ml_model_tool"
-    description: "Invoke ML models for predictions and analysis",
-    invokesSubAgent: false,
-    # ... existing tools
+    description: "Invoke ML models for predictions and analysis"
+    invokesSubAgent: false
 ```
 
 ## Advanced Tool Patterns

--- a/docs/src/how-to-deploy.md
+++ b/docs/src/how-to-deploy.md
@@ -152,7 +152,7 @@ allowedGeoRegions: []
 # dataProcessingParameters: omitted
 # knowledgeBaseParameters: omitted
 supportedModels:
-    Claude Haiku 3.5: "[REGION-PREFIX].anthropic.claude-3-5-haiku-20241022-v1:0"
+    Claude Haiku 4.5: "[REGION-PREFIX].anthropic.claude-haiku-4-5-20251001-v1:0"
     # ... other models
 toolRegistry:
   - name: "get_current_time"
@@ -180,7 +180,7 @@ Include `agentRuntimeConfig` in your configuration to automatically deploy an ag
 ```yaml
 agentRuntimeConfig:
     modelInferenceParameters:
-        modelId: "[REGION-PREFIX].anthropic.claude-3-5-haiku-20241022-v1:0"
+        modelId: "[REGION-PREFIX].anthropic.claude-haiku-4-5-20251001-v1:0"
         parameters:
             temperature: 0.5
             maxTokens: 4096

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,38 @@
+# Documentation
+
+The complete documentation map for the Agentic Chatbot Accelerator. The guides are grouped to follow the agent lifecycle — deploy the harness, build and extend agents, then run, evaluate, and operate them.
+
+## Getting Started
+
+- [How to Deploy (CDK)](./how-to-deploy.md) — prerequisites, the three-phase `make deploy`, and deployment scenarios (full / minimal / pre-configured runtime / experiments).
+- [Terraform Deployment](../../iac-terraform/README.md) — the experimental Terraform path.
+- [Development Guide](./development-guide.md) — local development workflow, project structure, IDE setup, and code quality tooling.
+
+## Building Agents
+
+- [Agent Factory Operations](./agent-factory.md) — the GraphQL operations behind the Agent Factory (create/update/delete runtimes), by execution model.
+- [Expanding the AI Tools Family](./expanding-ai-tools.md) — register MCP servers and add custom function/object tools to extend agent capabilities.
+- [Agent Skills](./skills.md) — give agents on-demand access to modular instruction packages they discover and activate only when relevant.
+- [Knowledge Base Management](./kb-management.md) — the document-processing pipeline and Bedrock Knowledge Base for RAG.
+
+### Agentic Patterns
+
+- [Single Agent](./agentic-patterns/single-agent.md) — one agent with direct access to tools, knowledge bases, and MCP servers.
+- [Agents as Tools](./agentic-patterns/agents-as-tools.md) — an orchestrator that delegates to specialized sub-agents as callable tools.
+- [Swarm](./agentic-patterns/swarm-agents.md) — collaborative agents that hand off conversations to each other.
+- [Graph](./agentic-patterns/graph-agents.md) — agent workflows defined as directed graphs with conditional routing.
+
+## Running & Operating
+
+- [Agent Evaluation](./evaluation.md) — systematically test agent responses with the Strands Evaluation SDK.
+- [Observability & Insights](./observability-insights.md) — X-Ray distributed tracing and CloudWatch Logs Insights queries for monitoring agents.
+- [Troubleshooting](./troubleshooting.md) — common issues during development and deployment, and how to resolve them.
+
+## Reference
+
+- [AWS Architecture](./architecture.md) — system architecture, real-time communication, and the AWS resources deployed.
+- [API Reference](./api.md) — the GraphQL API schema and operations.
+
+---
+
+For creating and modifying agents from your editor, see the [agent-creator Claude Code plugin](../../.claude/plugins/agent-creator/README.md). To contribute, see [CONTRIBUTING.md](../../CONTRIBUTING.md).

--- a/docs/src/kb-management.md
+++ b/docs/src/kb-management.md
@@ -1,6 +1,6 @@
 # Knowledge Base Management
 
-> ⚠️ **Note:** The Knowledge Base feature is optional. It is only available when `knowledgeBaseParameters` and `dataProcessingParameters` are configured in `bin/config.yaml`. If these parameters are omitted, the Knowledge Base navigation items will not appear in the UI. See [How to Deploy](./how-to-deploy.md#deployment-scenarios) for more details on deployment configurations.
+> ⚠️ **Note:** The Knowledge Base feature is optional. It is only available when `knowledgeBaseParameters` and `dataProcessingParameters` are configured in `iac-cdk/bin/config.yaml` (which overrides the defaults in `iac-cdk/bin/config.ts`). If these parameters are omitted, the Knowledge Base navigation items will not appear in the UI. See [How to Deploy](./how-to-deploy.md#deployment-scenarios) for more details on deployment configurations.
 
 ## Document Processing Pipeline
 

--- a/docs/src/observability-insights.md
+++ b/docs/src/observability-insights.md
@@ -6,6 +6,17 @@ This guide explains how to query and analyze AgentCore runtime logs using Amazon
 
 When an AgentCore runtime is deployed, it automatically logs metrics and events to CloudWatch Logs. CloudWatch Insights provides a powerful query language to extract meaningful insights from these logs.
 
+This guide focuses on the **CloudWatch Logs Insights** queries available out of the box. For distributed, span-level tracing across agent invocations (including multi-agent calls), enable **X-Ray Transaction Search** — see [Distributed Tracing with X-Ray](#distributed-tracing-with-x-ray) below.
+
+## Distributed Tracing with X-Ray
+
+The accelerator can provision [AWS X-Ray Transaction Search](https://docs.aws.amazon.com/xray/latest/devguide/transaction-search.html) to trace agent invocations end to end. Enable it by adding the `agentCoreObservability` block to your deployment configuration (CDK `config.yaml` / Terraform `tfvars`); see [How to Deploy](./how-to-deploy.md). When enabled, the stack:
+
+- Turns on X-Ray Transaction Search so traces are indexed and searchable in the CloudWatch console (**CloudWatch → X-Ray traces → Transaction Search**), with the indexing percentage controlled by `indexingPercentage`.
+- Surfaces an `X-Ray P99 (s)` latency widget on the generated CloudWatch dashboard.
+
+Use X-Ray when you need to follow a single request across the orchestrator and its sub-agents; use the Logs Insights queries below for aggregate token, cache, and latency analysis.
+
 ## How to Run Queries
 
 1. Navigate to **CloudWatch** → **Logs** → **Logs Insights** in the AWS Console

--- a/docs/src/skills.md
+++ b/docs/src/skills.md
@@ -1,5 +1,7 @@
 # Agent Skills
 
+> [← Documentation index](./index.md)
+
 Skills give agents on-demand access to specialized instructions without bloating the system prompt. Instead of front-loading every possible instruction into a single prompt, you define modular skill packages that the agent discovers and activates only when relevant.
 
 This feature implements the [Agent Skills specification](https://agentskills.io/specification) via the Strands SDK `AgentSkills` plugin.

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -1,5 +1,7 @@
 # Troubleshooting Guide
 
+> [← Documentation index](./index.md)
+
 This guide covers common issues encountered during development and deployment of the Agentic Chatbot Accelerator.
 
 ## Deployment Issues


### PR DESCRIPTION
## Summary

Documentation-only PR. Repositions the project as a **"full-stack agentic harness on AWS"** and then does a thorough accuracy, consistency, and navigation pass across the docs tree (every factual claim was verified against source, not just the prose).

## What changed

**Framing**
- README now leads with the agentic-harness positioning (tagline + a lifecycle-oriented intro) without dropping the product name.

**Accuracy** (verified against source)
- `expanding-ai-tools.md`: tool-registry symbols (`@tool`, `AbstractToolObject`, `ToolFactory`, `TOOL_FACTORY_MAP`) now point at `base_registry.py` where they actually live; fixed invalid YAML.
- `agent-factory.md`: `createAgentCoreRuntime` now documents all four `architectureType` values and their validation models (was SINGLE/SWARM only).
- `agents-as-tools.md`: fixed the "role field" contradiction and the resolver schema name (`AgentsAsToolsConfiguration`).
- `api.md`: rewritten to match the GraphQL schema exactly — dropped the removed `sendQuery`, added the missing Skills/voice/graph operations, grouped by domain, collapsed ~60 redundant auth cells into one note, and fixed stale TODO prose.
- `observability-insights.md`: added the X-Ray Transaction Search section the README promised but the doc omitted.
- `architecture.md` / `CLAUDE.md`: corrected the chat data-plane description (tool steps stream over the direct WebSocket; the old `agentTools` SNS side-channel is gone).

**Consistency**
- Reconciled the model lineup to the `config.ts` defaults across all docs (removed the nonexistent "Opus 4.7", fixed "Nova Sonic" → "Nova 2 Sonic", dropped stale Haiku 3.5 references, standardized friendly names).
- Brought `swarm-agents.md` to parity with the other pattern docs (Creating a New Version, Best Practices, comparison table, Strands link).
- Standardized `iac-cdk/bin/config.yaml` path references.

**Navigation**
- Added `docs/src/index.md` as the documentation map, linked it from the README, and surfaced the previously-orphaned `skills`, `development-guide`, and `troubleshooting` docs.

## Follow-up (not in this PR)

⚠️ **Dead code to remove:** while correcting the chat data-plane docs I confirmed the `chatMessages` SNS topic → Outgoing Message Handler path is dead. Its producer `send_to_client` (`src/shared/layers/python-sdk/genai_core/api_helper/message_handler.py`) has no callers, and the resolver comment in `iac-cdk/lib/api/websocket-resolvers.ts` ("Publishes AI-rephrased tool descriptions to browser") is stale. This should be removed in a separate **code** PR — out of scope here since this PR is docs-only.

## Test plan
- [x] All relative doc links verified to resolve
- [x] `api.md` operations cross-checked for exact parity with `schema.graphql`
