### PR TITLE
✨ Migrate agent runtime config from DynamoDB to AgentCore configuration bundles

### DIFF
--- a/.ash/.ash.yaml
+++ b/.ash/.ash.yaml
@@ -36,12 +36,21 @@ global_settings:
       reason: 'Python virtual environment'
     - path: '**/.ruff_cache/**'
       reason: 'Ruff cache — high-entropy hashes in CACHEDIR.TAG, not secrets'
+    - path: '**/.pytest_cache/**'
+      reason: 'Pytest cache — high-entropy hash in CACHEDIR.TAG, not a secret (same as .ruff_cache)'
 
     # ASH itself
     - path: '.ash/'
       reason: 'ASH working directory and config'
     - path: '**/ash_output/**'
       reason: 'ASH scan output (also covers container path)'
+
+    # Local, gitignored config files (present in the working tree, not in the
+    # repo / CI checkout — high-entropy runtime IDs read as secrets)
+    - path: 'iac-cdk/bin/config-demo.yaml'
+      reason: 'Gitignored local demo config — AgentCore runtime IDs, not secrets'
+    - path: 'iac-cdk/bin/config.yaml'
+      reason: 'Gitignored local deploy config — AgentCore runtime IDs, not secrets'
 
     # Repo caches and docs assets
     - path: 'cache/'

--- a/.ash/.ash.yaml
+++ b/.ash/.ash.yaml
@@ -66,6 +66,21 @@ global_settings:
     - path: 'CLAUDE.md'
       reason: 'AI coding assistant configuration'
 
+  # Per-finding suppressions (rule_id + path) — distinct from ignore_paths
+  # (which drop whole files); these keep the file scanned but silence one rule.
+  suppressions:
+    # semgrep supply-chain rule suggesting `exclude-newer` under [tool.uv]. The
+    # relative-duration form ("7 days") requires uv >= 0.9.17, but the repo / CI
+    # / tooling images are not yet pinned there; adding it breaks
+    # uv lock/sync/run on older uv with a cryptic date-parse error. Revisit
+    # (add the cooldown) once uv is bumped to >= 0.9.17 everywhere.
+    # ASH matches `path` with fnmatch against the repo-relative finding path, so
+    # `*pyproject.toml` covers both the root `pyproject.toml` and the nested
+    # `src/agent-core/*/pyproject.toml` (a `**/` prefix would miss the bare root).
+    - rule_id: 'package_managers.uv.uv-missing-dependency-cooldown.uv-missing-dependency-cooldown'
+      path: '*pyproject.toml'
+      reason: 'exclude-newer relative-duration needs uv>=0.9.17; repo/CI not yet pinned there. Tracked as a follow-up.'
+
 converters:
   archive:
     enabled: false

--- a/docs/adr/0001-config-read-via-control-plane.md
+++ b/docs/adr/0001-config-read-via-control-plane.md
@@ -1,7 +1,7 @@
 # 0001 — Read agent config from bundles via the control plane, not Gateway/baggage
 
 - Status: Accepted
-- Date: 2026-07-20
+- Date: 2026-07-20 (revised 2026-07-21: fail-fast on fetch failure instead of embedded-default fallback)
 - Context: [configuration-bundles story](../../local/user-stories/configuration-bundles/story.md), [design doc](../../local/user-stories/configuration-bundles/design-doc.md)
 
 ## Context
@@ -15,11 +15,12 @@ This accelerator's chat data plane is **browser-direct WebSocket** to `wss://…
 
 ## Decision
 
-Containers read configuration via the **control plane**: `get_configuration_bundle_version(BUNDLE_ID, BUNDLE_VERSION)`, with `BUNDLE_ID` and `BUNDLE_VERSION` supplied as container environment variables (mirroring today's `agentName`/`createdAt` pointer-env pattern). The fetch is wrapped in try/except with a fallback to embedded defaults, per AWS's runtime guidance.
+Containers read configuration via the **control plane**: `get_configuration_bundle_version(BUNDLE_ID, BUNDLE_VERSION)`, with `BUNDLE_ID` and `BUNDLE_VERSION` supplied as container environment variables (mirroring today's `agentName`/`createdAt` pointer-env pattern). A failed or empty fetch **raises** and the container fails to start — we deliberately do **not** fall back to embedded defaults, so a misconfigured or missing bundle surfaces immediately rather than silently serving a generic agent. This preserves the fail-fast behavior of today's DynamoDB read path (which also raises when the config item is missing).
 
 ## Consequences
 
 - **Positive:** Works without a Gateway; minimal change to the existing pointer-env + startup-fetch shape; the parsed `AgentConfiguration` is unchanged.
 - **Positive:** We control the component key (see [ADR-0002](0002-bundle-identity-and-component-keying.md)) since we address the bundle explicitly rather than via injected baggage.
 - **Negative / deferred:** Gateway-driven A/B testing and the Recommendations flow (which rely on baggage injection) are out of scope; adopting them later would add the Gateway to the data plane — a separate, larger decision.
+- **Trade-off (fail-fast over graceful fallback):** A bad bundle takes the runtime down instead of degrading to a default agent. We accept this because a silently-substituted generic agent is a worse failure mode than a hard, observable startup error, and the write path (put-config-bundle before create-runtime) makes a missing bundle a deploy-time bug rather than a steady-state condition.
 - **Cost:** One control-plane API call at container cold start, plus least-privilege `bedrock-agentcore-control:GetConfigurationBundleVersion` on the container task role.

--- a/docs/adr/0001-config-read-via-control-plane.md
+++ b/docs/adr/0001-config-read-via-control-plane.md
@@ -1,0 +1,25 @@
+# 0001 — Read agent config from bundles via the control plane, not Gateway/baggage
+
+- Status: Accepted
+- Date: 2026-07-20
+- Context: [configuration-bundles story](../../local/user-stories/configuration-bundles/story.md), [design doc](../../local/user-stories/configuration-bundles/design-doc.md)
+
+## Context
+
+We are migrating per-agent runtime configuration from `agentCoreRuntimeTable` (DynamoDB) to AgentCore configuration bundles. AWS documents two ways for a container to read a bundle at runtime:
+
+1. **SDK / baggage** — `BedrockAgentCoreContext.get_config_bundle()` reads the active bundle reference from a W3C **baggage** header (`aws.agentcore.configbundle_arn` / `_version`). In production this header is injected by the **AgentCore Gateway** during A/B tests. Without a bundle reference in the request context, the call returns `{}`.
+2. **Control plane** — `bedrock-agentcore-control get_configuration_bundle_version(bundleId, versionId)` returns `components[<key>].configuration` directly, with no baggage and no Gateway involved.
+
+This accelerator's chat data plane is **browser-direct WebSocket** to `wss://…/runtimes/<ARN>/ws`. There is **no AgentCore Gateway** in the path, and we do not use A/B testing. The SDK/baggage path would therefore observe no bundle reference and return `{}`.
+
+## Decision
+
+Containers read configuration via the **control plane**: `get_configuration_bundle_version(BUNDLE_ID, BUNDLE_VERSION)`, with `BUNDLE_ID` and `BUNDLE_VERSION` supplied as container environment variables (mirroring today's `agentName`/`createdAt` pointer-env pattern). The fetch is wrapped in try/except with a fallback to embedded defaults, per AWS's runtime guidance.
+
+## Consequences
+
+- **Positive:** Works without a Gateway; minimal change to the existing pointer-env + startup-fetch shape; the parsed `AgentConfiguration` is unchanged.
+- **Positive:** We control the component key (see [ADR-0002](0002-bundle-identity-and-component-keying.md)) since we address the bundle explicitly rather than via injected baggage.
+- **Negative / deferred:** Gateway-driven A/B testing and the Recommendations flow (which rely on baggage injection) are out of scope; adopting them later would add the Gateway to the data plane — a separate, larger decision.
+- **Cost:** One control-plane API call at container cold start, plus least-privilege `bedrock-agentcore-control:GetConfigurationBundleVersion` on the container task role.

--- a/docs/adr/0002-bundle-identity-and-component-keying.md
+++ b/docs/adr/0002-bundle-identity-and-component-keying.md
@@ -1,0 +1,26 @@
+# 0002 — Bundle identity and single stable-id component keying
+
+- Status: Accepted
+- Date: 2026-07-20
+- Context: [configuration-bundles story](../../local/user-stories/configuration-bundles/story.md), [design doc](../../local/user-stories/configuration-bundles/design-doc.md)
+- Supersedes: story §7 (which proposed ARN-keyed components)
+
+## Context
+
+A configuration bundle holds `components` keyed by an identifier, each with a `configuration` object. The AWS examples key components by the **runtime ARN**. Two facts make an ARN key awkward here:
+
+1. **Circular dependency.** With direct control-plane reads ([ADR-0001](0001-config-read-via-control-plane.md)), the container needs `BUNDLE_ID`/`BUNDLE_VERSION` as env vars at runtime-create time. If the component were keyed by the runtime ARN, the ARN would not exist until the runtime is created — forcing a create-runtime → create-bundle → update-runtime-env sequence with extra control-plane calls and more failure states in the state machine.
+2. **Naming.** Bundle **names** forbid hyphens (`[a-zA-Z][a-zA-Z0-9_]{0,99}`), but agent names may contain them, so the name alone can't be the durable identifier.
+
+## Decision
+
+1. **One bundle per agent, one component keyed by a stable agent id** (the `agentCoreSummaryTable` partition key). Both the HTTP runtime and the A2A twin read that same component (identical config). The bundle is created **before** the runtime, so `BUNDLE_ID`/`BUNDLE_VERSION` flow cleanly into the runtime's container env — no create→update dance.
+2. **Bundle identity of record lives in `agentCoreSummaryTable`.** On create, derive a sanitized bundle-name *prefix* from the agent name, let AWS append its random suffix, and persist the returned `bundleId` and `bundleArn`. All later reads/updates/ports use the stored `bundleId` — we never reverse-map an agent name to a bundle.
+3. **Versions** map 1:1: each config change is a new immutable bundle version (chained via `parentVersionIds`); `QualifierToVersion` stores the active `versionId`.
+
+## Consequences
+
+- **Positive:** No circular dependency; the write path is a straight line (put-bundle → create-runtime → update-summary). Sub-agents keep their own bundles and are resolved via the summary table as today.
+- **Positive:** Robust to hyphenated agent names and name collisions (AWS suffix + stored id).
+- **Negative:** Diverges from the ARN-keyed AWS examples; anyone inspecting bundles directly must know the component key is the agent id, not the ARN. Documented in the design doc's cross-cutting contract.
+- **Trade-off:** A single shared component means HTTP and A2A twins cannot diverge in config; acceptable because they are twins of the same agent by design.

--- a/iac-cdk/lib/aca-stack.ts
+++ b/iac-cdk/lib/aca-stack.ts
@@ -127,7 +127,6 @@ export class AcaStack extends cdk.Stack {
             graphAgentCoreContainer: agentCoreInfra.graphImageAsset,
             agentsAsToolsAgentCoreContainer: agentCoreInfra.agentsAsToolsImageAsset,
             agentCoreExecutionRole: agentCoreInfra.executionRole,
-            agentCoreRuntimeTable: agentCoreInfra.agentCoreRuntimeTable,
             agentCoreSummaryTable: agentCoreInfra.agentCoreSummaryTable,
             toolRegistryTable: agentCoreInfra.toolRegistry,
             stateClassRegistryTable: agentCoreInfra.stateClassRegistry,

--- a/iac-cdk/lib/agent-core/index.ts
+++ b/iac-cdk/lib/agent-core/index.ts
@@ -43,7 +43,6 @@ export class AcaAgentCoreContainer extends Construct {
     public readonly graphImageAsset: CodeBuildDockerImage;
     public readonly agentsAsToolsImageAsset: CodeBuildDockerImage;
     public readonly executionRole: Role;
-    public readonly agentCoreRuntimeTable: dynamodb.Table;
     public readonly toolRegistry: dynamodb.Table;
     public readonly stateClassRegistry: dynamodb.Table;
     public readonly deterministicNodeRegistry: dynamodb.Table;
@@ -56,31 +55,12 @@ export class AcaAgentCoreContainer extends Construct {
 
         const prefix = generatePrefix(this);
 
-        // Table where agents' configuration are stored
-        const agentCoreRuntimeTable = new dynamodb.Table(this, "AgentCoreRuntimeCfgTable", {
-            tableName: `${prefix}-agentCoreRuntimeCfgTable`,
-            partitionKey: {
-                name: "AgentName",
-                type: dynamodb.AttributeType.STRING,
-            },
-            sortKey: {
-                name: "CreatedAt",
-                type: dynamodb.AttributeType.NUMBER,
-            },
-            billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
-            encryption: dynamodb.TableEncryption.AWS_MANAGED,
-            removalPolicy: cdk.RemovalPolicy.DESTROY,
-            pointInTimeRecoverySpecification: {
-                pointInTimeRecoveryEnabled: true,
-            },
-        });
-        agentCoreRuntimeTable.addLocalSecondaryIndex({
-            indexName: "byAgentNameAndVersion",
-            sortKey: {
-                name: "AgentRuntimeVersion",
-                type: dynamodb.AttributeType.STRING,
-            },
-        });
+        // Per-agent runtime configuration is stored in AgentCore configuration
+        // bundles (control-plane), not DynamoDB — see ADR-0001/ADR-0002 and the
+        // configuration-bundles migration. The former `agentCoreRuntimeCfgTable`
+        // (+ its `byAgentNameAndVersion` LSI) was removed here; the summary table
+        // (below) keeps the bundle identity fields (BundleId/BundleArn) and the
+        // QualifierToVersion → bundle-versionId mapping.
 
         // Table where tools' specifications are defined
         const toolRegistry = new dynamodb.Table(this, "ToolRegistry", {
@@ -656,18 +636,24 @@ export class AcaAgentCoreContainer extends Construct {
                 ],
             }),
             new iam.PolicyStatement({
-                effect: iam.Effect.ALLOW,
-                actions: ["dynamodb:GetItem"],
-                resources: [agentCoreRuntimeTable.tableArn],
-            }),
-            new iam.PolicyStatement({
                 sid: "DynamoDBQueryForSwarmAgentReferences",
                 effect: iam.Effect.ALLOW,
+                // Swarm/graph orchestrators resolve referenced sub-agents via the
+                // summary table (QualifierToVersion → bundle versionId, and the
+                // A2A twin ARN). The former runtime-config table + LSI are gone.
                 actions: ["dynamodb:Query"],
+                resources: [agentCoreSummaryTable.tableArn],
+            }),
+            new iam.PolicyStatement({
+                sid: "AgentCoreReadConfigurationBundle",
+                effect: iam.Effect.ALLOW,
+                // Containers read their own (and referenced sub-agents') config
+                // from configuration bundle versions via the control plane
+                // (ADR-0001). Bundle ids are name-suffixed, not path-scoped, so
+                // configuration-bundle/* is the tightest available resource.
+                actions: ["bedrock-agentcore:GetConfigurationBundleVersion"],
                 resources: [
-                    agentCoreRuntimeTable.tableArn,
-                    `${agentCoreRuntimeTable.tableArn}/index/*`,
-                    agentCoreSummaryTable.tableArn,
+                    `arn:aws:bedrock-agentcore:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:configuration-bundle/*`,
                 ],
             }),
             new iam.PolicyStatement({
@@ -688,172 +674,25 @@ export class AcaAgentCoreContainer extends Construct {
         });
 
         if (props.config.agentRuntimeConfig) {
-            const repository = imageAsset.repository;
-
-            const agentRuntimeArtifact = agentcore.AgentRuntimeArtifact.fromEcrRepository(
-                repository,
-                imageAsset.imageTag,
+            // GUARD (configuration-bundles migration): the deploy-time default
+            // agent still creates the AgentCore Runtime *before* the seeder
+            // creates its config bundle, so BUNDLE_ID/BUNDLE_VERSION cannot be
+            // injected into the container env at create time (ADR-0002 requires
+            // the bundle to exist first). The container would then fail to load
+            // its config. Restructuring the seeder into
+            // create-bundle → create-runtime(with BUNDLE env) → update-summary
+            // is tracked as a follow-up. Fail loudly here rather than deploy a
+            // default agent that cannot start.
+            throw new Error(
+                "config.agentRuntimeConfig (deploy-time default agent) is not yet " +
+                    "supported after the configuration-bundles migration: the seeder " +
+                    "must create the config bundle before the runtime so BUNDLE_ID/" +
+                    "BUNDLE_VERSION can be injected. Create the default agent via the " +
+                    "Agent Factory UI instead, or complete the seeder restructure " +
+                    "(see the configuration-bundles design doc, T8 follow-up).",
             );
-
-            const agentName = `${prefix}-default-agent`.replace(/-/g, "_");
-
-            const agentConfig = props.config.agentRuntimeConfig;
-
-            // Compute hash from user-provided config ONLY
-            // This ensures consistent hashing across CDK synthesis runs
-            const configString = stableStringify(agentConfig);
-            const hash = crypto
-                .createHash("sha256")
-                .update(configString)
-                .update(imageAsset.imageTag)
-                .digest();
-            const createdAt = Number(hash.readBigUInt64BE(0) % BigInt(Number.MAX_SAFE_INTEGER));
-
-            // Enrich tool parameters with runtime values (KB id) AFTER hashing
-            const enrichedToolParameters = { ...agentConfig.toolParameters };
-            for (const toolName of agentConfig.tools) {
-                if (toolName.startsWith("retrieve_from_kb") && props.knowledgeBaseId) {
-                    enrichedToolParameters[toolName] = {
-                        ...enrichedToolParameters[toolName],
-                        kb_id: props.knowledgeBaseId,
-                    };
-                }
-            }
-            const configToSeed = {
-                ...agentConfig,
-                toolParameters: enrichedToolParameters,
-            };
-
-            let memory: agentcore.Memory | undefined = undefined;
-
-            if (agentConfig.memoryCfg) {
-                memory = new agentcore.Memory(this, "DefaultMemory", {
-                    memoryName: `${prefix}-default-memory`.replace(/-/g, "_"),
-                    description: agentConfig.memoryCfg.description,
-                    expirationDuration: cdk.Duration.days(agentConfig.memoryCfg.retentionDays),
-                });
-            }
-
-            const runtime = new agentcore.Runtime(this, "DefaultRuntime", {
-                runtimeName: agentName,
-                description: agentConfig.description,
-                agentRuntimeArtifact: agentRuntimeArtifact,
-                executionRole: executionRole,
-                networkConfiguration: RuntimeNetworkConfiguration.usingPublicNetwork(),
-                environmentVariables: {
-                    accountId: cdk.Aws.ACCOUNT_ID,
-                    agentName: agentName,
-                    createdAt: createdAt.toString(),
-                    tableName: agentCoreRuntimeTable.tableName,
-                    toolRegistry: toolRegistry.tableName,
-                    mcpServerRegistry: mcpServerRegistry.tableName,
-                    // Sessions table name for container-side history persistence
-                    // (follows the same {prefix}-sessionsTable naming convention)
-                    ...(props.sessionsTableName && {
-                        sessionsTableName: props.sessionsTableName,
-                    }),
-                    ...(memory && {
-                        memoryId: memory.memoryId,
-                    }),
-                    ...(props.config.bedrockAccessRoleArn && {
-                        bedrockAccessRoleArn: props.config.bedrockAccessRoleArn,
-                    }),
-                    // Skills bucket for runtime skill loading
-                    ...(props.skillsBucketName && {
-                        skillsBucket: props.skillsBucketName,
-                    }),
-                },
-                tags: {
-                    Owner: "CDK",
-                },
-                ...(agentConfig.lifecycleCfg && {
-                    lifecycleConfiguration: {
-                        idleRuntimeSessionTimeout: cdk.Duration.minutes(
-                            agentConfig.lifecycleCfg.idleRuntimeSessionTimeoutInMinutes,
-                        ),
-                        maxLifetime: cdk.Duration.hours(
-                            agentConfig.lifecycleCfg.maxLifetimeInHours,
-                        ),
-                    },
-                }),
-            });
-
-            // Create seeder Lambda with custom resource for config-change-aware seeding
-            const seederLambda = createLambda(this, {
-                name: `${prefix}-agentcore-seeder`,
-                asset: "seeder",
-                handler: "index.handler",
-                timeout: 1,
-                memorySize: 128,
-                shared: props.shared,
-                dir: path.join(__dirname, "../../../src/agent-core"),
-                envs: {
-                    CFG_TABLE_NAME: agentCoreRuntimeTable.tableName,
-                    DASHBOARD_TABLE_NAME: agentCoreSummaryTable.tableName,
-                },
-            });
-            agentCoreRuntimeTable.grantWriteData(seederLambda);
-            agentCoreSummaryTable.grantReadWriteData(seederLambda);
-
-            const seederProvider = new cr.Provider(this, "SeederProvider", {
-                onEventHandler: seederLambda,
-            });
-
-            const configHash = hash.toString("hex");
-            new cdk.CustomResource(this, "AgentRuntimeSeed", {
-                serviceToken: seederProvider.serviceToken,
-                properties: {
-                    item: JSON.stringify({
-                        AgentName: agentName,
-                        CreatedAt: createdAt,
-                        AgentRuntimeArn: runtime.agentRuntimeArn,
-                        AgentRuntimeId: runtime.agentRuntimeId,
-                        AgentRuntimeVersion: runtime.agentRuntimeVersion,
-                        ConfigurationValue: stableStringify(configToSeed),
-                    }),
-                    configHash: configHash, // Forces update when config changes
-                },
-            });
-
-            NagSuppressions.addResourceSuppressions(
-                seederProvider,
-                [
-                    {
-                        id: "AwsSolutions-IAM4",
-                        reason: "IAM role implicitly created by CDK for Lambda basic execution.",
-                    },
-                    {
-                        id: "AwsSolutions-IAM5",
-                        reason: "IAM role implicitly created by CDK.",
-                    },
-                    {
-                        id: "AwsSolutions-L1",
-                        reason: "Lambda runtime version is managed by CDK custom resource provider framework construct.",
-                    },
-                ],
-                true,
-            );
-            NagSuppressions.addResourceSuppressions(
-                seederLambda,
-                [
-                    {
-                        id: "AwsSolutions-IAM4",
-                        reason: "IAM role implicitly created by CDK for Lambda basic execution.",
-                    },
-                    {
-                        id: "AwsSolutions-IAM5",
-                        reason: "IAM role implicitly created by CDK.",
-                    },
-                ],
-                true,
-            );
-            new CfnOutput(this, "DefaultAgentCoreRuntime", {
-                value: runtime.agentRuntimeId,
-                description: "Identifier of the default AgentCore Runtime",
-            });
         }
 
-        this.agentCoreRuntimeTable = agentCoreRuntimeTable;
         this.toolRegistry = toolRegistry;
         this.stateClassRegistry = stateClassRegistry;
         this.deterministicNodeRegistry = deterministicNodeRegistry;

--- a/iac-cdk/lib/api/agent-core-runtime.ts
+++ b/iac-cdk/lib/api/agent-core-runtime.ts
@@ -32,7 +32,6 @@ export interface AgentCoreApisProps {
     readonly swarmAgentCoreContainer: CodeBuildDockerImage;
     readonly graphAgentCoreContainer: CodeBuildDockerImage;
     readonly agentsAsToolsAgentCoreContainer: CodeBuildDockerImage;
-    readonly agentCoreRuntimeTable: dynamodb.Table;
     readonly agentCoreSummaryTable: dynamodb.Table;
     readonly toolRegistryTable: dynamodb.Table;
     readonly mcpServerRegistryTable: dynamodb.Table;
@@ -82,7 +81,6 @@ export class AgentCoreApis extends Construct {
                 GRAPH_CONTAINER_URI: props.graphAgentCoreContainer.imageUri,
                 AGENTS_AS_TOOLS_CONTAINER_URI: props.agentsAsToolsAgentCoreContainer.imageUri,
                 AGENT_CORE_RUNTIME_ROLE_ARN: props.agentCoreExecutionRole.roleArn,
-                AGENT_CORE_RUNTIME_TABLE: props.agentCoreRuntimeTable.tableName,
                 AGENT_CORE_SUMMARY_TABLE: props.agentCoreSummaryTable.tableName,
                 TOOL_REGISTRY_TABLE: props.toolRegistryTable.tableName,
                 MCP_SERVER_REGISTRY_TABLE: props.mcpServerRegistryTable.tableName,
@@ -95,8 +93,20 @@ export class AgentCoreApis extends Construct {
             tracing: lambda.Tracing.ACTIVE,
         });
         // Permissions
-        props.agentCoreRuntimeTable.grantReadWriteData(agentCoreRuntimeCreationResolver);
         props.agentCoreSummaryTable.grantReadWriteData(agentCoreRuntimeCreationResolver);
+        // Config-read GraphQL queries (getDefaultRuntimeConfiguration, etc.) now
+        // read agent config from configuration bundle versions via the control
+        // plane (the runtime config table was removed) — see ADR-0001.
+        agentCoreRuntimeCreationResolver.addToRolePolicy(
+            new iam.PolicyStatement({
+                sid: "ReadConfigurationBundle",
+                effect: iam.Effect.ALLOW,
+                actions: ["bedrock-agentcore:GetConfigurationBundleVersion"],
+                resources: [
+                    `arn:aws:bedrock-agentcore:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:configuration-bundle/*`,
+                ],
+            }),
+        );
 
         // Bedrock AgentCore — least-privilege: only the API actions this resolver Lambda invokes
         agentCoreRuntimeCreationResolver.addToRolePolicy(
@@ -507,10 +517,20 @@ export class AgentCoreApis extends Construct {
             dir: path.join(__dirname, "../../../src/api"),
             envs: {
                 ...props.shared.defaultEnvironmentVariables,
-                VERSIONS_TABLE_NAME: props.agentCoreRuntimeTable.tableName,
             },
         });
-        props.agentCoreRuntimeTable.grantReadWriteData(removeRuntimeVersions);
+        // T12: on agent delete, remove the agent's configuration bundle (by the
+        // bundleId passed from the summary row) instead of purging version rows.
+        removeRuntimeVersions.addToRolePolicy(
+            new iam.PolicyStatement({
+                sid: "DeleteConfigurationBundle",
+                effect: iam.Effect.ALLOW,
+                actions: ["bedrock-agentcore:DeleteConfigurationBundle"],
+                resources: [
+                    `arn:aws:bedrock-agentcore:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:configuration-bundle/*`,
+                ],
+            }),
+        );
 
         const substitutionsDeleteRuntime = {
             listRuntimeEndpointFunctionArn: listEndpointsFunc.functionArn,
@@ -622,14 +642,12 @@ export class AgentCoreApis extends Construct {
                 GRAPH_CONTAINER_URI: props.graphAgentCoreContainer.imageUri,
                 AGENTS_AS_TOOLS_CONTAINER_URI: props.agentsAsToolsAgentCoreContainer.imageUri,
                 AGENT_CORE_RUNTIME_ROLE_ARN: props.agentCoreExecutionRole.roleArn,
-                AGENT_CORE_RUNTIME_TABLE: props.agentCoreRuntimeTable.tableName,
                 TOOL_REGISTRY_TABLE: props.toolRegistryTable.tableName,
                 MCP_SERVER_REGISTRY_TABLE: props.mcpServerRegistryTable.tableName,
                 ACCOUNT_ID: cdk.Aws.ACCOUNT_ID,
                 ENVIRONMENT_TAG: transformedTags.Environment,
                 STACK_TAG: transformedTags.Stack,
                 SESSIONS_TABLE_NAME: `${prefix}-sessionsTable`,
-                AGENTS_TABLE_NAME: props.agentCoreRuntimeTable.tableName,
                 AGENTS_SUMMARY_TABLE_NAME: props.agentCoreSummaryTable.tableName,
                 ...(props.config.bedrockAccessRoleArn && {
                     BEDROCK_ACCESS_ROLE_ARN: props.config.bedrockAccessRoleArn,
@@ -695,6 +713,35 @@ export class AgentCoreApis extends Construct {
             }),
         );
 
+        // T4/T5: writes the agent config into an AgentCore configuration bundle
+        // (create or new version) before the runtime is created, so the create
+        // SFN can inject BUNDLE_ID/BUNDLE_VERSION into the container env.
+        const putConfigBundleFunc = createLambda(this, {
+            name: `${prefix}-putConfigBundle`,
+            asset: "put-config-bundle",
+            handler: "index.handler",
+            timeout: 1,
+            memorySize: 128,
+            shared: props.shared,
+            dir: path.join(__dirname, "../../../src/api"),
+            envs: {
+                ...props.shared.defaultEnvironmentVariables,
+            },
+        });
+        putConfigBundleFunc.addToRolePolicy(
+            new iam.PolicyStatement({
+                sid: "PutConfigurationBundle",
+                effect: iam.Effect.ALLOW,
+                // CreateConfigurationBundle is not resource-scopable (no ARN
+                // exists pre-create); Update is scoped to configuration-bundle/*.
+                actions: [
+                    "bedrock-agentcore:CreateConfigurationBundle",
+                    "bedrock-agentcore:UpdateConfigurationBundle",
+                ],
+                resources: ["*"],
+            }),
+        );
+
         const substitutionsCreateRuntime = {
             startMemoryCreationFuncArn: startMemoryCreationFunc.functionArn,
             checkOnExistingMemoryFunctionArn: checkOnExistingMemory.functionArn,
@@ -703,7 +750,7 @@ export class AgentCoreApis extends Construct {
             checkOnRuntimeCreationFunc: checkOnRuntimeCreationFunc.functionArn,
             notifyRuntimeUpdateFunctionArn: notifyRuntimeUpdate.functionArn,
             summaryTableArn: props.agentCoreSummaryTable.tableArn,
-            agentVersionTableArn: props.agentCoreRuntimeTable.tableArn,
+            putConfigBundleFuncArn: putConfigBundleFunc.functionArn,
         };
 
         const stateMachineCreateRuntime = new sfn.StateMachine(scope, "CreateRuntimeStateMachine", {
@@ -726,9 +773,9 @@ export class AgentCoreApis extends Construct {
         checkOnCreateMemoryFunc.grantInvoke(stateMachineCreateRuntime);
         startRuntimeCreationFunc.grantInvoke(stateMachineCreateRuntime);
         checkOnRuntimeCreationFunc.grantInvoke(stateMachineCreateRuntime);
+        putConfigBundleFunc.grantInvoke(stateMachineCreateRuntime);
         notifyRuntimeUpdate.grantInvoke(stateMachineCreateRuntime);
         props.agentCoreSummaryTable.grantReadWriteData(stateMachineCreateRuntime);
-        props.agentCoreRuntimeTable.grantWriteData(stateMachineCreateRuntime);
 
         stateMachineCreateRuntime.grantStartExecution(agentCoreRuntimeCreationResolver);
         agentCoreRuntimeCreationResolver.addEnvironment(
@@ -756,6 +803,7 @@ export class AgentCoreApis extends Construct {
             checkOnCreateMemoryFunc,
             startRuntimeCreationFunc,
             checkOnRuntimeCreationFunc,
+            putConfigBundleFunc,
             stateMachineCreateRuntime,
         ].forEach((element) => {
             NagSuppressions.addResourceSuppressions(

--- a/iac-cdk/lib/api/agent-core-runtime.ts
+++ b/iac-cdk/lib/api/agent-core-runtime.ts
@@ -101,7 +101,10 @@ export class AgentCoreApis extends Construct {
             new iam.PolicyStatement({
                 sid: "ReadConfigurationBundle",
                 effect: iam.Effect.ALLOW,
-                actions: ["bedrock-agentcore:GetConfigurationBundleVersion"],
+                actions: [
+                    "bedrock-agentcore:GetConfigurationBundleVersion",
+                    "bedrock-agentcore:ListConfigurationBundleVersions",
+                ],
                 resources: [
                     `arn:aws:bedrock-agentcore:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:configuration-bundle/*`,
                 ],
@@ -177,6 +180,10 @@ export class AgentCoreApis extends Construct {
             {
                 type: "Query",
                 field: "listAgentVersions",
+            },
+            {
+                type: "Query",
+                field: "listAgentBundleVersions",
             },
             {
                 type: "Query",

--- a/iac-cdk/lib/api/index.ts
+++ b/iac-cdk/lib/api/index.ts
@@ -39,7 +39,6 @@ export interface ChatbotApiProps {
     readonly swarmAgentCoreContainer: CodeBuildDockerImage;
     readonly graphAgentCoreContainer: CodeBuildDockerImage;
     readonly agentsAsToolsAgentCoreContainer: CodeBuildDockerImage;
-    readonly agentCoreRuntimeTable: dynamodb.Table;
     readonly toolRegistryTable: dynamodb.Table;
     readonly stateClassRegistryTable: dynamodb.Table;
     readonly deterministicNodeRegistryTable: dynamodb.Table;

--- a/iac-cdk/test/aca.test.ts
+++ b/iac-cdk/test/aca.test.ts
@@ -1,15 +1,110 @@
-// import * as cdk from 'aws-cdk-lib';
-// import { Template } from 'aws-cdk-lib/assertions';
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: MIT-0
 
-// example test. To run these tests, uncomment this file along with the
-// example resource in lib/aca-stack.ts
-test("SQS Queue Created", () => {
-    //   const app = new cdk.App();
-    //     // WHEN
-    //   const stack = new Aca.AcaStack(app, 'MyTestStack');
-    //     // THEN
-    //   const template = Template.fromStack(stack);
-    //   template.hasResourceProperties('AWS::SQS::Queue', {
-    //     VisibilityTimeout: 300
-    //   });
+import * as cdk from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import { getConfig } from "../bin/config";
+import { AcaStack } from "../lib/aca-stack";
+import { BuilderStack } from "../lib/builder-stack";
+
+// Synthesize the application stack once and reuse the template across the
+// configuration-bundles migration assertions (T11). The stacks are wired the
+// same way as bin/aca.ts so the template matches a real deploy.
+function synthTemplate(): Template {
+    const app = new cdk.App();
+    const config = getConfig();
+    const builderStack = new BuilderStack(app, "test-aca-builder", {
+        lambdaArchitecture: lambda.Architecture.X86_64,
+    });
+    const acaStack = new AcaStack(app, "test-aca", {
+        config,
+        builder: builderStack,
+    });
+    acaStack.addDependency(builderStack);
+    return Template.fromStack(acaStack);
+}
+
+describe("configuration-bundles migration (T11)", () => {
+    let template: Template;
+
+    beforeAll(() => {
+        template = synthTemplate();
+    });
+
+    test("no runtime-config DynamoDB table remains", () => {
+        // The per-agent runtime-config table + its LSI were removed; agent
+        // config now lives in AgentCore configuration bundles (ADR-0001/0002).
+        const tables = template.findResources("AWS::DynamoDB::Table");
+        for (const [, resource] of Object.entries(tables)) {
+            const name: string | undefined = resource.Properties?.TableName;
+            expect(name).not.toMatch(/agentCoreRuntimeCfgTable/i);
+            // The byAgentNameAndVersion LSI only existed on the removed table.
+            const lsis = resource.Properties?.LocalSecondaryIndexes ?? [];
+            for (const lsi of lsis) {
+                expect(lsi.IndexName).not.toEqual("byAgentNameAndVersion");
+            }
+        }
+    });
+
+    test("summary table is still present", () => {
+        // The summary table is retained and gained the bundle identity fields.
+        template.hasResourceProperties("AWS::DynamoDB::Table", {
+            TableName: Match.stringLikeRegexp("agentCoreSummaryTable"),
+        });
+    });
+
+    test("no lambda carries the removed AGENT_CORE_RUNTIME_TABLE env var", () => {
+        const fns = template.findResources("AWS::Lambda::Function");
+        for (const [, resource] of Object.entries(fns)) {
+            const vars = resource.Properties?.Environment?.Variables ?? {};
+            expect(Object.keys(vars)).not.toContain("AGENT_CORE_RUNTIME_TABLE");
+            expect(Object.keys(vars)).not.toContain("VERSIONS_TABLE_NAME");
+            expect(Object.keys(vars)).not.toContain("AGENTS_TABLE_NAME");
+        }
+    });
+
+    test("put-config-bundle lambda is present", () => {
+        template.hasResourceProperties("AWS::Lambda::Function", {
+            FunctionName: Match.stringLikeRegexp("putConfigBundle"),
+        });
+    });
+
+    test("bundle IAM actions are wired with least-privilege scoping", () => {
+        // Assert each bundle action appears in some IAM policy. Create/List are
+        // not resource-scopable (Resource "*"); Update/Get/GetVersion/Delete are
+        // scoped to configuration-bundle/*.
+        const policies = template.findResources("AWS::IAM::Policy");
+        const allStatements: any[] = [];
+        for (const [, resource] of Object.entries(policies)) {
+            const statements = resource.Properties?.PolicyDocument?.Statement ?? [];
+            allStatements.push(...statements);
+        }
+
+        const actionsInPolicies = new Set<string>();
+        for (const stmt of allStatements) {
+            const actions = Array.isArray(stmt.Action) ? stmt.Action : [stmt.Action];
+            for (const a of actions) {
+                if (typeof a === "string") actionsInPolicies.add(a);
+            }
+        }
+
+        expect(actionsInPolicies).toContain("bedrock-agentcore:CreateConfigurationBundle");
+        expect(actionsInPolicies).toContain("bedrock-agentcore:UpdateConfigurationBundle");
+        expect(actionsInPolicies).toContain("bedrock-agentcore:GetConfigurationBundleVersion");
+        expect(actionsInPolicies).toContain("bedrock-agentcore:DeleteConfigurationBundle");
+
+        // The resource-scopable bundle actions must target configuration-bundle
+        // ARNs (not "*"). Verify GetConfigurationBundleVersion is so scoped.
+        const scopedGetVersion = allStatements.some((stmt) => {
+            const actions = Array.isArray(stmt.Action) ? stmt.Action : [stmt.Action];
+            if (!actions.includes("bedrock-agentcore:GetConfigurationBundleVersion")) {
+                return false;
+            }
+            const resources = Array.isArray(stmt.Resource) ? stmt.Resource : [stmt.Resource];
+            return resources.some((r: any) => JSON.stringify(r).includes("configuration-bundle/"));
+        });
+        expect(scopedGetVersion).toBe(true);
+    });
 });

--- a/iac-terraform/main.tf
+++ b/iac-terraform/main.tf
@@ -316,8 +316,6 @@ module "agent_core_apis" {
   agents_as_tools_container_uri = module.agent_core.agents_as_tools_container_uri
 
   # DynamoDB tables
-  agent_core_runtime_table_name  = module.agent_core.agent_runtime_config_table_name
-  agent_core_runtime_table_arn   = module.agent_core.agent_runtime_config_table_arn
   agent_core_summary_table_name  = module.agent_core.agent_summary_table_name
   agent_core_summary_table_arn   = module.agent_core.agent_summary_table_arn
   tool_registry_table_name       = module.agent_core.tool_registry_table_name

--- a/iac-terraform/modules/agent_core/agentcore_runtime.tf
+++ b/iac-terraform/modules/agent_core/agentcore_runtime.tf
@@ -55,7 +55,6 @@ resource "aws_bedrockagentcore_agent_runtime" "default" {
       accountId         = data.aws_caller_identity.current.account_id
       agentName         = local.agent_name
       createdAt         = local.created_at
-      tableName         = aws_dynamodb_table.agent_runtime_config.name
       toolRegistry      = aws_dynamodb_table.tool_registry.name
       mcpServerRegistry = aws_dynamodb_table.mcp_server_registry.name
       memoryId          = var.agent_runtime_config.memory_config != null ? aws_bedrockagentcore_memory.default[0].id : ""
@@ -146,30 +145,12 @@ locals {
   created_at = var.agent_runtime_config != null ? parseint(substr(local.config_hash, 0, 8), 16) : 0
 }
 
-# -----------------------------------------------------------------------------
-# Seed Agent Runtime Configuration to DynamoDB
-# This stores the full agent configuration for runtime access
-# -----------------------------------------------------------------------------
-
-resource "aws_dynamodb_table_item" "agent_runtime_config" {
-  count = var.agent_runtime_config != null ? 1 : 0
-
-  table_name = aws_dynamodb_table.agent_runtime_config.name
-  hash_key   = aws_dynamodb_table.agent_runtime_config.hash_key
-  range_key  = aws_dynamodb_table.agent_runtime_config.range_key
-
-  # Use enriched_config_json which includes kb_id injected into retrieve_from_kb tool parameters
-  item = jsonencode({
-    AgentName           = { S = local.agent_name }
-    CreatedAt           = { N = tostring(local.created_at) }
-    AgentRuntimeArn     = { S = aws_bedrockagentcore_agent_runtime.default[0].agent_runtime_arn }
-    AgentRuntimeId      = { S = aws_bedrockagentcore_agent_runtime.default[0].agent_runtime_id }
-    AgentRuntimeVersion = { S = aws_bedrockagentcore_agent_runtime.default[0].agent_runtime_version }
-    ConfigurationValue  = { S = local.enriched_config_json }
-  })
-
-  depends_on = [aws_bedrockagentcore_agent_runtime.default]
-}
+# NOTE (configuration-bundles migration): the former "Seed Agent Runtime
+# Configuration to DynamoDB" resource (aws_dynamodb_table_item.agent_runtime_config)
+# was removed with the runtime-config table. The deploy-time default agent is
+# guarded off (see the agent_runtime_config validation in variables.tf); when the
+# seeder is restructured to create the config bundle before the runtime, the
+# config will live in an AgentCore configuration bundle, not DynamoDB.
 
 # -----------------------------------------------------------------------------
 # Seed Agent Summary to DynamoDB

--- a/iac-terraform/modules/agent_core/iam.tf
+++ b/iac-terraform/modules/agent_core/iam.tf
@@ -211,21 +211,24 @@ data "aws_iam_policy_document" "agentcore_execution" {
     ]
   }
 
-  # DynamoDB Access - Agent Runtime Config Table
+  # DynamoDB Query - For swarm agent references. Swarm/graph orchestrators
+  # resolve referenced sub-agents via the summary table (QualifierToVersion →
+  # bundle versionId, and the A2A twin ARN). The former runtime-config table +
+  # LSI are gone.
   statement {
-    actions   = ["dynamodb:GetItem"]
-    resources = [aws_dynamodb_table.agent_runtime_config.arn]
+    sid       = "DynamoDBQueryForSwarmAgentReferences"
+    actions   = ["dynamodb:Query"]
+    resources = [aws_dynamodb_table.agent_summary.arn]
   }
 
-  # DynamoDB Query - For swarm agent references (query runtime config table + indexes and summary table)
+  # Containers read their own (and referenced sub-agents') config from
+  # configuration bundle versions via the control plane (ADR-0001). Bundle ids
+  # are name-suffixed, not path-scoped, so configuration-bundle/* is the
+  # tightest available resource.
   statement {
-    sid     = "DynamoDBQueryForSwarmAgentReferences"
-    actions = ["dynamodb:Query"]
-    resources = [
-      aws_dynamodb_table.agent_runtime_config.arn,
-      "${aws_dynamodb_table.agent_runtime_config.arn}/index/*",
-      aws_dynamodb_table.agent_summary.arn,
-    ]
+    sid       = "AgentCoreReadConfigurationBundle"
+    actions   = ["bedrock-agentcore:GetConfigurationBundleVersion"]
+    resources = ["arn:aws:bedrock-agentcore:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:configuration-bundle/*"]
   }
 
   # DynamoDB Access - Tool and MCP Server Registries

--- a/iac-terraform/modules/agent_core/main.tf
+++ b/iac-terraform/modules/agent_core/main.tf
@@ -29,49 +29,12 @@ data "aws_region" "current" {}
 # DynamoDB Tables
 # -----------------------------------------------------------------------------
 
-# Agent Runtime Configuration Table
-# Stores agent configurations with versioning support
-resource "aws_dynamodb_table" "agent_runtime_config" {
-  name         = "${local.name_prefix}-agentCoreRuntimeCfgTable"
-  billing_mode = "PAY_PER_REQUEST"
-
-  hash_key  = "AgentName"
-  range_key = "CreatedAt"
-
-  attribute {
-    name = "AgentName"
-    type = "S"
-  }
-
-  attribute {
-    name = "CreatedAt"
-    type = "N"
-  }
-
-  attribute {
-    name = "AgentRuntimeVersion"
-    type = "S"
-  }
-
-  local_secondary_index {
-    name            = "byAgentNameAndVersion"
-    projection_type = "ALL"
-    range_key       = "AgentRuntimeVersion"
-  }
-
-  point_in_time_recovery {
-    enabled = true
-  }
-
-  server_side_encryption {
-    enabled     = true
-    kms_key_arn = var.kms_key_arn
-  }
-
-  tags = {
-    Name = "${local.name_prefix}-agentCoreRuntimeCfgTable"
-  }
-}
+# Per-agent runtime configuration is stored in AgentCore configuration bundles
+# (control-plane), not DynamoDB — see ADR-0001/ADR-0002 and the
+# configuration-bundles migration. The former `agentCoreRuntimeCfgTable`
+# (+ its `byAgentNameAndVersion` LSI) was removed here; the summary table (below)
+# keeps the bundle identity fields (BundleId/BundleArn) and the
+# QualifierToVersion → bundle-versionId mapping.
 
 # Tool Registry Table
 # Stores tool specifications available to agents

--- a/iac-terraform/modules/agent_core/outputs.tf
+++ b/iac-terraform/modules/agent_core/outputs.tf
@@ -7,16 +7,6 @@ SPDX-License-Identifier: MIT-0
 # DynamoDB Table Outputs
 # -----------------------------------------------------------------------------
 
-output "agent_runtime_config_table_name" {
-  description = "Name of the DynamoDB table storing agent runtime configurations"
-  value       = aws_dynamodb_table.agent_runtime_config.name
-}
-
-output "agent_runtime_config_table_arn" {
-  description = "ARN of the DynamoDB table storing agent runtime configurations"
-  value       = aws_dynamodb_table.agent_runtime_config.arn
-}
-
 output "tool_registry_table_name" {
   description = "Name of the DynamoDB table storing tool registry"
   value       = aws_dynamodb_table.tool_registry.name

--- a/iac-terraform/modules/agent_core/variables.tf
+++ b/iac-terraform/modules/agent_core/variables.tf
@@ -143,6 +143,19 @@ variable "agent_runtime_config" {
     }))
   })
   default = null
+
+  # GUARD (configuration-bundles migration, mirrors the CDK synth-time throw):
+  # the deploy-time default agent still creates the AgentCore Runtime *before*
+  # its config bundle exists, so BUNDLE_ID/BUNDLE_VERSION cannot be injected
+  # into the container env at create time (ADR-0002 requires the bundle first).
+  # The container would then fail to load its config. Restructuring the seeder
+  # into create-bundle → create-runtime(with BUNDLE env) → update-summary is
+  # tracked as a follow-up. Fail loudly rather than deploy an agent that cannot
+  # start.
+  validation {
+    condition     = var.agent_runtime_config == null
+    error_message = "agent_runtime_config (deploy-time default agent) is not yet supported after the configuration-bundles migration: the seeder must create the config bundle before the runtime so BUNDLE_ID/BUNDLE_VERSION can be injected. Create the default agent via the Agent Factory UI instead, or complete the seeder restructure (see the configuration-bundles design doc, T8 follow-up)."
+  }
 }
 
 # -----------------------------------------------------------------------------

--- a/iac-terraform/modules/agent_core_apis/lambdas/main.tf
+++ b/iac-terraform/modules/agent_core_apis/lambdas/main.tf
@@ -81,7 +81,6 @@ resource "aws_lambda_function" "agent_core_resolver" {
       GRAPH_CONTAINER_URI                = var.graph_container_uri
       AGENTS_AS_TOOLS_CONTAINER_URI      = var.agents_as_tools_container_uri
       AGENT_CORE_RUNTIME_ROLE_ARN        = var.agent_core_execution_role_arn
-      AGENT_CORE_RUNTIME_TABLE           = var.agent_core_runtime_table_name
       AGENT_CORE_SUMMARY_TABLE           = var.agent_core_summary_table_name
       TOOL_REGISTRY_TABLE                = var.tool_registry_table_name
       MCP_SERVER_REGISTRY_TABLE          = var.mcp_server_registry_table_name
@@ -203,23 +202,6 @@ resource "aws_iam_role_policy" "agent_core_resolver_bedrock" {
 # DynamoDB access policy
 data "aws_iam_policy_document" "agent_core_resolver_dynamodb" {
   statement {
-    sid    = "RuntimeTableAccess"
-    effect = "Allow"
-    actions = [
-      "dynamodb:GetItem",
-      "dynamodb:PutItem",
-      "dynamodb:UpdateItem",
-      "dynamodb:DeleteItem",
-      "dynamodb:Query",
-      "dynamodb:Scan"
-    ]
-    resources = [
-      var.agent_core_runtime_table_arn,
-      "${var.agent_core_runtime_table_arn}/index/*"
-    ]
-  }
-
-  statement {
     sid    = "SummaryTableAccess"
     effect = "Allow"
     actions = [
@@ -251,6 +233,26 @@ resource "aws_iam_role_policy" "agent_core_resolver_dynamodb" {
   name   = "${local.name_prefix}-agentCoreResolver-dynamodb"
   role   = aws_iam_role.agent_core_resolver.id
   policy = data.aws_iam_policy_document.agent_core_resolver_dynamodb.json
+}
+
+# Config-read GraphQL queries (getDefaultRuntimeConfiguration, etc.) now read
+# agent config from configuration bundle versions via the control plane (the
+# runtime config table was removed) — see ADR-0001. Bundle ids are
+# name-suffixed, not path-scoped, so configuration-bundle/* is the tightest
+# available resource.
+data "aws_iam_policy_document" "agent_core_resolver_bundle" {
+  statement {
+    sid       = "ReadConfigurationBundle"
+    effect    = "Allow"
+    actions   = ["bedrock-agentcore:GetConfigurationBundleVersion"]
+    resources = ["arn:aws:bedrock-agentcore:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:configuration-bundle/*"]
+  }
+}
+
+resource "aws_iam_role_policy" "agent_core_resolver_bundle" {
+  name   = "${local.name_prefix}-agentCoreResolver-bundle"
+  role   = aws_iam_role.agent_core_resolver.id
+  policy = data.aws_iam_policy_document.agent_core_resolver_bundle.json
 }
 
 # PassRole permission for Bedrock AgentCore

--- a/iac-terraform/modules/agent_core_apis/lambdas/outputs.tf
+++ b/iac-terraform/modules/agent_core_apis/lambdas/outputs.tf
@@ -118,6 +118,11 @@ output "remove_references_function_arn" {
   value       = aws_lambda_function.step_function_lambdas["remove_references"].arn
 }
 
+output "put_config_bundle_function_arn" {
+  description = "ARN of the put config bundle Lambda"
+  value       = aws_lambda_function.put_config_bundle.arn
+}
+
 # -----------------------------------------------------------------------------
 # Notify Runtime Update Lambda (Node.js)
 # -----------------------------------------------------------------------------

--- a/iac-terraform/modules/agent_core_apis/lambdas/step_functions.tf
+++ b/iac-terraform/modules/agent_core_apis/lambdas/step_functions.tf
@@ -132,12 +132,10 @@ locals {
     remove_references = {
       name        = "removeRuntimeReferences"
       asset       = "delete-agent-runtime-references"
-      description = "Removes runtime version references from DynamoDB"
+      description = "Deletes the agent's AgentCore configuration bundle on runtime delete"
       permissions = []
       resource    = ""
-      extra_envs = {
-        VERSIONS_TABLE_NAME = var.agent_core_runtime_table_name
-      }
+      extra_envs  = {}
     }
   }
 }
@@ -290,38 +288,21 @@ resource "aws_iam_role_policy" "delete_runtime_workload_identity" {
   })
 }
 
-# DynamoDB access for remove_references function
-resource "aws_iam_role_policy" "remove_references_dynamodb" {
-  name = "${local.name_prefix}-removeRuntimeReferences-dynamodb"
+# T12: on agent delete, remove the agent's configuration bundle (by the bundleId
+# passed from the summary row) instead of purging version rows. Delete is scoped
+# to configuration-bundle/* (bundle ids are name-suffixed, not path-scoped).
+resource "aws_iam_role_policy" "remove_references_bundle" {
+  name = "${local.name_prefix}-removeRuntimeReferences-bundle"
   role = aws_iam_role.step_function_lambdas["remove_references"].id
 
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
       {
-        Sid    = "RuntimeTableAccess"
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem",
-          "dynamodb:PutItem",
-          "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem",
-          "dynamodb:Query",
-          "dynamodb:Scan"
-        ]
-        Resource = [
-          var.agent_core_runtime_table_arn,
-          "${var.agent_core_runtime_table_arn}/index/*"
-        ]
-      },
-      {
-        Sid    = "KMSAccess"
-        Effect = "Allow"
-        Action = [
-          "kms:Decrypt",
-          "kms:GenerateDataKey*"
-        ]
-        Resource = [var.kms_key_arn]
+        Sid      = "DeleteConfigurationBundle"
+        Effect   = "Allow"
+        Action   = ["bedrock-agentcore:DeleteConfigurationBundle"]
+        Resource = "arn:aws:bedrock-agentcore:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:configuration-bundle/*"
       }
     ]
   })
@@ -386,14 +367,12 @@ resource "aws_lambda_function" "create_runtime_version" {
         GRAPH_CONTAINER_URI           = var.graph_container_uri
         AGENTS_AS_TOOLS_CONTAINER_URI = var.agents_as_tools_container_uri
         AGENT_CORE_RUNTIME_ROLE_ARN   = var.agent_core_execution_role_arn
-        AGENT_CORE_RUNTIME_TABLE      = var.agent_core_runtime_table_name
         TOOL_REGISTRY_TABLE           = var.tool_registry_table_name
         MCP_SERVER_REGISTRY_TABLE     = var.mcp_server_registry_table_name
         ACCOUNT_ID                    = data.aws_caller_identity.current.account_id
         ENVIRONMENT_TAG               = var.environment_tag
         STACK_TAG                     = var.stack_tag
         SESSIONS_TABLE_NAME           = "${local.name_prefix}-sessionsTable"
-        AGENTS_TABLE_NAME             = var.agent_core_runtime_table_name
         AGENTS_SUMMARY_TABLE_NAME     = var.agent_core_summary_table_name
       },
       var.bedrock_access_role_arn != null ? { BEDROCK_ACCESS_ROLE_ARN = var.bedrock_access_role_arn } : {}
@@ -475,6 +454,118 @@ resource "aws_iam_role_policy" "create_runtime_version_passrole" {
             "iam:PassedToService" = "bedrock-agentcore.amazonaws.com"
           }
         }
+      }
+    ]
+  })
+}
+
+# -----------------------------------------------------------------------------
+# Put Config Bundle Lambda (T4/T5)
+# Writes the agent config into an AgentCore configuration bundle (create or new
+# version) BEFORE the runtime is created, so the create SFN can inject
+# BUNDLE_ID/BUNDLE_VERSION into the container env (ADR-0002).
+# -----------------------------------------------------------------------------
+
+resource "aws_cloudwatch_log_group" "put_config_bundle" {
+  # checkov:skip=CKV_AWS_338:Log retention configurable, 7 days acceptable
+  name              = "/aws/lambda/${local.name_prefix}-putConfigBundle"
+  retention_in_days = 7
+  kms_key_id        = var.kms_key_arn
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-putConfigBundle-logs"
+  })
+}
+
+data "archive_file" "put_config_bundle" {
+  type        = "zip"
+  source_dir  = "${local.functions_dir}/put-config-bundle"
+  output_path = "${path.module}/../../../../iac-terraform/build/put-config-bundle.zip"
+  excludes    = ["__pycache__", "*.pyc", ".pytest_cache", "genai_core"]
+}
+
+resource "aws_lambda_function" "put_config_bundle" {
+  # checkov:skip=CKV_AWS_116:DLQ handled by Step Functions retry
+  # checkov:skip=CKV_AWS_117:VPC not required for this function
+  # checkov:skip=CKV_AWS_272:Code signing not required for internal functions
+  # checkov:skip=CKV_AWS_115:Concurrency limit managed at account level
+  # checkov:skip=CKV_AWS_173:Environment variables do not contain secrets
+  function_name = "${local.name_prefix}-putConfigBundle"
+  description   = "Creates or versions the agent's AgentCore configuration bundle"
+
+  filename         = data.archive_file.put_config_bundle.output_path
+  source_code_hash = data.archive_file.put_config_bundle.output_base64sha256
+  handler          = "index.handler"
+  runtime          = var.python_runtime
+  architectures    = [var.lambda_architecture]
+  timeout          = 60
+  memory_size      = 128
+
+  role = aws_iam_role.put_config_bundle.arn
+
+  layers = [
+    var.powertools_layer_arn,
+    var.boto3_layer_arn,
+    var.genai_core_layer_arn,
+  ]
+
+  environment {
+    variables = {
+      POWERTOOLS_SERVICE_NAME = "putConfigBundle"
+      POWERTOOLS_LOG_LEVEL    = "INFO"
+      REGION_NAME             = data.aws_region.current.id
+    }
+  }
+
+  tracing_config {
+    mode = "Active"
+  }
+
+  depends_on = [aws_cloudwatch_log_group.put_config_bundle]
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-putConfigBundle"
+  })
+}
+
+resource "aws_iam_role" "put_config_bundle" {
+  name               = "${local.name_prefix}-putConfigBundle-role"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-putConfigBundle-role"
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "put_config_bundle_basic" {
+  role       = aws_iam_role.put_config_bundle.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy_attachment" "put_config_bundle_xray" {
+  role       = aws_iam_role.put_config_bundle.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+}
+
+# CreateConfigurationBundle is not resource-scopable (no ARN exists pre-create);
+# Update is scoped to configuration-bundle/*. Mirrors the CDK PutConfigurationBundle
+# statement which uses Resource "*" for both under the existing IAM5 suppression.
+resource "aws_iam_role_policy" "put_config_bundle_bedrock" {
+  # checkov:skip=CKV_AWS_355:CreateConfigurationBundle is not resource-scopable
+  name = "${local.name_prefix}-putConfigBundle-bedrock"
+  role = aws_iam_role.put_config_bundle.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "PutConfigurationBundle"
+        Effect = "Allow"
+        Action = [
+          "bedrock-agentcore:CreateConfigurationBundle",
+          "bedrock-agentcore:UpdateConfigurationBundle",
+        ]
+        Resource = "*"
       }
     ]
   })

--- a/iac-terraform/modules/agent_core_apis/lambdas/variables.tf
+++ b/iac-terraform/modules/agent_core_apis/lambdas/variables.tf
@@ -69,16 +69,6 @@ variable "agents_as_tools_container_uri" {
 # DynamoDB Tables
 # -----------------------------------------------------------------------------
 
-variable "agent_core_runtime_table_name" {
-  description = "Name of the agent core runtime versions DynamoDB table"
-  type        = string
-}
-
-variable "agent_core_runtime_table_arn" {
-  description = "ARN of the agent core runtime versions DynamoDB table"
-  type        = string
-}
-
 variable "agent_core_summary_table_name" {
   description = "Name of the agent core summary DynamoDB table"
   type        = string

--- a/iac-terraform/modules/agent_core_apis/main.tf
+++ b/iac-terraform/modules/agent_core_apis/main.tf
@@ -53,8 +53,6 @@ module "lambdas" {
   agents_as_tools_container_uri = var.agents_as_tools_container_uri
 
   # DynamoDB tables
-  agent_core_runtime_table_name  = var.agent_core_runtime_table_name
-  agent_core_runtime_table_arn   = var.agent_core_runtime_table_arn
   agent_core_summary_table_name  = var.agent_core_summary_table_name
   agent_core_summary_table_arn   = var.agent_core_summary_table_arn
   tool_registry_table_name       = var.tool_registry_table_name
@@ -116,10 +114,10 @@ module "state_machines" {
   check_create_runtime_function_arn   = module.lambdas.check_create_runtime_function_arn
   remove_references_function_arn      = module.lambdas.remove_references_function_arn
   notify_runtime_update_function_arn  = module.lambdas.notify_runtime_update_function_arn
+  put_config_bundle_function_arn      = module.lambdas.put_config_bundle_function_arn
 
   # DynamoDB tables
   agent_core_summary_table_arn = var.agent_core_summary_table_arn
-  agent_core_runtime_table_arn = var.agent_core_runtime_table_arn
 
   # KMS
   kms_key_arn = var.kms_key_arn

--- a/iac-terraform/modules/agent_core_apis/state_machines/main.tf
+++ b/iac-terraform/modules/agent_core_apis/state_machines/main.tf
@@ -116,6 +116,7 @@ data "aws_iam_policy_document" "step_functions_lambda" {
       var.check_create_runtime_function_arn,
       var.remove_references_function_arn,
       var.notify_runtime_update_function_arn,
+      var.put_config_bundle_function_arn,
     ]
   }
 }
@@ -141,18 +142,6 @@ data "aws_iam_policy_document" "step_functions_dynamodb" {
     resources = [
       var.agent_core_summary_table_arn,
       "${var.agent_core_summary_table_arn}/index/*"
-    ]
-  }
-
-  statement {
-    sid    = "RuntimeTableAccess"
-    effect = "Allow"
-    actions = [
-      "dynamodb:PutItem",
-      "dynamodb:UpdateItem"
-    ]
-    resources = [
-      var.agent_core_runtime_table_arn
     ]
   }
 
@@ -262,7 +251,7 @@ resource "aws_sfn_state_machine" "create_runtime" {
     checkOnRuntimeCreationFunc       = var.check_create_runtime_function_arn
     notifyRuntimeUpdateFunctionArn   = var.notify_runtime_update_function_arn
     summaryTableArn                  = var.agent_core_summary_table_arn
-    agentVersionTableArn             = var.agent_core_runtime_table_arn
+    putConfigBundleFuncArn           = var.put_config_bundle_function_arn
   })
 
   logging_configuration {

--- a/iac-terraform/modules/agent_core_apis/state_machines/variables.tf
+++ b/iac-terraform/modules/agent_core_apis/state_machines/variables.tf
@@ -84,17 +84,17 @@ variable "notify_runtime_update_function_arn" {
   type        = string
 }
 
+variable "put_config_bundle_function_arn" {
+  description = "ARN of the put config bundle Lambda"
+  type        = string
+}
+
 # -----------------------------------------------------------------------------
 # DynamoDB Tables
 # -----------------------------------------------------------------------------
 
 variable "agent_core_summary_table_arn" {
   description = "ARN of the agent core summary DynamoDB table"
-  type        = string
-}
-
-variable "agent_core_runtime_table_arn" {
-  description = "ARN of the agent core runtime versions DynamoDB table"
   type        = string
 }
 

--- a/iac-terraform/modules/agent_core_apis/variables.tf
+++ b/iac-terraform/modules/agent_core_apis/variables.tf
@@ -69,16 +69,6 @@ variable "agents_as_tools_container_uri" {
 # DynamoDB Tables
 # -----------------------------------------------------------------------------
 
-variable "agent_core_runtime_table_name" {
-  description = "Name of the agent core runtime versions DynamoDB table"
-  type        = string
-}
-
-variable "agent_core_runtime_table_arn" {
-  description = "ARN of the agent core runtime versions DynamoDB table"
-  type        = string
-}
-
 variable "agent_core_summary_table_name" {
   description = "Name of the agent core summary DynamoDB table"
   type        = string

--- a/iac-terraform/outputs.tf
+++ b/iac-terraform/outputs.tf
@@ -85,11 +85,6 @@ output "lambda_architecture" {
 # DynamoDB tables, ECR repository, and AgentCore Runtime resources
 # -----------------------------------------------------------------------------
 
-output "agent_runtime_config_table_name" {
-  description = "Name of the DynamoDB table storing agent runtime configurations"
-  value       = module.agent_core.agent_runtime_config_table_name
-}
-
 output "tool_registry_table_name" {
   description = "Name of the DynamoDB table storing tool registry"
   value       = module.agent_core.tool_registry_table_name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dev = [
     "pre-commit>=4.2.0",
     "ruff>=0.12.5",
     "aws-lambda-powertools>=3.4.1",
+    "aws-xray-sdk>=2.14.0",
     "boto3>=1.40.55",
     "ipykernel>=6.29.5",
     "opensearch-py>=2.8.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,6 @@ dev = [
 ]
 
 [tool.uv]
-# Wait 7 days before resolving newly published package versions — newly
-# published packages can be malicious or unstable (supply-chain hardening).
-exclude-newer = "7 days"
 override-dependencies = [
     "urllib3>=2.6.3",
     "asteval>=1.0.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,9 @@ dev = [
 ]
 
 [tool.uv]
+# Wait 7 days before resolving newly published package versions — newly
+# published packages can be malicious or unstable (supply-chain hardening).
+exclude-newer = "7 days"
 override-dependencies = [
     "urllib3>=2.6.3",
     "asteval>=1.0.6",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,49 @@
+# Operator scripts
+
+Out-of-band scripts run by an operator (not part of any Lambda or deploy). Run
+with **least-privilege** AWS credentials — prefer a scoped role over admin.
+
+## `port_config_to_bundles.py`
+
+Migrates every existing agent's configuration from the legacy runtime config
+table (`<prefix>-agentCoreRuntimeCfgTable`) into an AgentCore **configuration
+bundle**, then backfills `BundleId` / `BundleArn` and rewrites
+`QualifierToVersion.DEFAULT` in `<prefix>-agentCoreSummaryTable`.
+
+**Run and verify this BEFORE the CDK infra task (T8) removes the runtime config
+table** — once the table is gone the source data is unavailable.
+
+### Idempotency
+
+Keyed on the summary row's `BundleId`: if it is present and the bundle still
+exists, the agent is skipped. Safe to re-run — a second run reports every agent
+as already ported. A recorded-but-missing bundle is re-created.
+
+### Usage
+
+```bash
+# Dry-run first — reports intended actions, mutates nothing.
+python scripts/port_config_to_bundles.py --all --prefix <prefix> --region us-east-1 --dry-run
+
+# Port every agent.
+python scripts/port_config_to_bundles.py --all --prefix <prefix> --region us-east-1
+
+# Port specific agents (repeatable).
+python scripts/port_config_to_bundles.py --agent my-agent --agent other --prefix <prefix>
+
+# Port the full version history (chained), not just the current DEFAULT.
+python scripts/port_config_to_bundles.py --all --prefix <prefix> --full-history
+```
+
+`--prefix` may be supplied via the `ACA_PREFIX` env var. `--profile` selects an
+AWS named profile. The region must be one of the confirmed bundle regions (the
+script fails fast otherwise) and control-plane calls back off on throttling.
+
+By default only the current DEFAULT version is ported (1:1 with the runtime
+model); pass `--full-history` to chain every prior version into the bundle.
+
+### Tests
+
+```bash
+cd scripts && uv run pytest tests/ -q
+```

--- a/scripts/port_config_to_bundles.py
+++ b/scripts/port_config_to_bundles.py
@@ -1,0 +1,439 @@
+#!/usr/bin/env python3
+# ---------------------------------------------------------------------------- #
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# SPDX-License-Identifier: MIT-0
+# ---------------------------------------------------------------------------- #
+"""Port existing agent configs from the runtime table into AgentCore bundles.
+
+Standalone, re-runnable operator script. For every agent recorded in the
+summary table it:
+
+  1. resolves the current DEFAULT config from the legacy runtime config table
+     (``agentCoreRuntimeCfgTable``);
+  2. creates one AgentCore configuration bundle per agent — component keyed by
+     the agent name, mirroring the deploy/runtime path (ADR-0002);
+  3. backfills ``BundleId`` / ``BundleArn`` into the summary table and rewrites
+     ``QualifierToVersion.DEFAULT`` to the bundle's versionId.
+
+Idempotency is keyed on the summary row's ``BundleId``: if it is present and the
+bundle still exists, the agent is skipped. This MUST be run and verified before
+the CDK infra task (T8) removes the runtime config table.
+
+Usage:
+    python scripts/port_config_to_bundles.py --all [--dry-run]
+    python scripts/port_config_to_bundles.py --agent my-agent --agent other
+    python scripts/port_config_to_bundles.py --all --region us-east-1 --profile dev
+
+Flags:
+    --all                 Port every agent in the summary table.
+    --agent NAME          Port only NAME (repeatable). Mutually exclusive with --all.
+    --dry-run             Report intended actions without mutating anything.
+    --full-history        Port every version of each agent (oldest->newest,
+                          chained) instead of only the current DEFAULT version.
+    --prefix PREFIX       Resource name prefix (default: env ACA_PREFIX). Tables
+                          are ``<prefix>-agentCoreSummaryTable`` and
+                          ``<prefix>-agentCoreRuntimeCfgTable``.
+    --region REGION       AWS region (must be a bundle-supported region).
+    --profile PROFILE     AWS named profile (prefer least-privilege creds).
+
+Least privilege: run with scoped credentials (read the two tables, write the
+summary table, create/get bundles) rather than admin — see the repo's global
+production-safety rules.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+import uuid
+from typing import Optional
+
+import boto3
+from botocore.config import Config
+from botocore.exceptions import ClientError
+from pydantic import BaseModel
+
+# Regions where configuration bundles are available (story §11). The script
+# fails fast outside this set rather than emitting confusing API errors.
+CONFIRMED_BUNDLE_REGIONS = {
+    "us-east-1",
+    "us-east-2",
+    "us-west-2",
+    "eu-central-1",
+    "eu-west-1",
+    "eu-west-2",
+    "eu-west-3",
+    "eu-north-1",
+    "ap-south-1",
+    "ap-southeast-1",
+    "ap-northeast-1",
+    "ap-northeast-2",
+    "ca-central-1",
+}
+
+BUNDLE_NAME_MAX = 100
+
+# Bounded exponential backoff for throttled control-plane calls. No published
+# per-account bundle quota exists, so we back off defensively rather than
+# assume unlimited throughput.
+_THROTTLE_CODES = {"ThrottlingException", "TooManyRequestsException"}
+_MAX_RETRIES = 6
+_BASE_DELAY_SECONDS = 0.5
+
+
+class PortResult(BaseModel):
+    """Outcome of porting a single agent."""
+
+    agent_name: str
+    bundle_id: Optional[str] = None
+    bundle_arn: Optional[str] = None
+    default_version_id: Optional[str] = None
+    skipped: bool = False
+    dry_run: bool = False
+    error: Optional[str] = None
+
+
+def sanitize_bundle_name(agent_name: str) -> str:
+    """Derive a valid bundle name from an agent name.
+
+    Mirrors ``put-config-bundle`` (T4) and the seeder (T7): non-word chars ->
+    ``_``, ensure it starts with a letter, cap at ``BUNDLE_NAME_MAX``. Kept in
+    sync by hand — see ``src/api/functions/put-config-bundle/index.py``.
+    """
+    import re
+
+    sanitized = re.sub(r"[^a-zA-Z0-9_]", "_", agent_name)
+    if not sanitized or not sanitized[0].isalpha():
+        sanitized = f"a_{sanitized}"
+    return sanitized[:BUNDLE_NAME_MAX]
+
+
+def _with_backoff(func, *args, sleep=time.sleep, **kwargs):
+    """Call a control-plane function, retrying throttles with exponential backoff."""
+    for attempt in range(_MAX_RETRIES):
+        try:
+            return func(*args, **kwargs)
+        except ClientError as err:
+            code = err.response.get("Error", {}).get("Code", "")
+            if code in _THROTTLE_CODES and attempt < _MAX_RETRIES - 1:
+                sleep(_BASE_DELAY_SECONDS * (2**attempt))
+                continue
+            raise
+    raise RuntimeError("unreachable")  # pragma: no cover
+
+
+def _bundle_exists(bac_client, bundle_id: str) -> bool:
+    """True if the bundle still exists (idempotency probe)."""
+    try:
+        _with_backoff(bac_client.get_configuration_bundle, bundleId=bundle_id)
+        return True
+    except ClientError as err:
+        if err.response.get("Error", {}).get("Code", "") == "ResourceNotFoundException":
+            return False
+        raise
+
+
+def _get_summary_row(summary_table, agent_name: str) -> Optional[dict]:
+    """Fetch an agent's summary row (or None)."""
+    response = summary_table.get_item(Key={"AgentName": agent_name})
+    return response.get("Item")
+
+
+def _default_version(summary_row: dict) -> Optional[str]:
+    """The current DEFAULT AgentRuntimeVersion recorded in the summary row."""
+    return (summary_row.get("QualifierToVersion") or {}).get("DEFAULT")
+
+
+def _config_rows_for_agent(runtime_table, agent_name: str) -> list[dict]:
+    """All runtime config rows for an agent, oldest -> newest by CreatedAt."""
+    rows: list[dict] = []
+    kwargs = {
+        "KeyConditionExpression": "AgentName = :name",
+        "ExpressionAttributeValues": {":name": agent_name},
+        "ScanIndexForward": True,  # ascending CreatedAt
+    }
+    response = runtime_table.query(**kwargs)
+    rows.extend(response.get("Items", []))
+    while "LastEvaluatedKey" in response:
+        response = runtime_table.query(
+            **kwargs, ExclusiveStartKey=response["LastEvaluatedKey"]
+        )
+        rows.extend(response.get("Items", []))
+    return rows
+
+
+def _select_rows(rows: list[dict], default_version: Optional[str], full_history: bool):
+    """Pick which config rows to port.
+
+    Current-only (default): the single row whose ``AgentRuntimeVersion`` matches
+    the summary DEFAULT, else the newest row. Full-history: every row (already
+    ordered oldest -> newest for correct parent chaining).
+    """
+    if full_history:
+        return rows
+    if default_version is not None:
+        match = [r for r in rows if r.get("AgentRuntimeVersion") == default_version]
+        if match:
+            return match[:1]
+    return rows[-1:]  # newest
+
+
+def port_agent(
+    agent_name: str,
+    *,
+    summary_table,
+    runtime_table,
+    bac_client,
+    dry_run: bool = False,
+    full_history: bool = False,
+) -> PortResult:
+    """Port one agent's config row(s) to a bundle and backfill the summary row.
+
+    Idempotent: if the summary row already carries a ``BundleId`` and that bundle
+    still exists, the agent is skipped (``skipped=True``) without creating a
+    duplicate. Reuses the same create/version control-plane logic as T4.
+    """
+    summary_row = _get_summary_row(summary_table, agent_name)
+    if summary_row is None:
+        return PortResult(agent_name=agent_name, error="no summary row")
+
+    existing_bundle_id = summary_row.get("BundleId")
+    if existing_bundle_id and _bundle_exists(bac_client, existing_bundle_id):
+        return PortResult(
+            agent_name=agent_name,
+            bundle_id=existing_bundle_id,
+            bundle_arn=summary_row.get("BundleArn"),
+            default_version_id=_default_version(summary_row),
+            skipped=True,
+        )
+
+    default_version = _default_version(summary_row)
+    rows = _config_rows_for_agent(runtime_table, agent_name)
+    if not rows:
+        return PortResult(
+            agent_name=agent_name, error="no config rows in runtime table"
+        )
+
+    to_port = _select_rows(rows, default_version, full_history)
+
+    if dry_run:
+        return PortResult(
+            agent_name=agent_name,
+            default_version_id=default_version,
+            dry_run=True,
+        )
+
+    bundle_id: Optional[str] = None
+    bundle_arn: Optional[str] = None
+    parent_version_id: Optional[str] = None
+    default_version_id: Optional[str] = None
+
+    for row in to_port:
+        config_value = row["ConfigurationValue"]
+        components = {
+            agent_name: {"configuration": {"ConfigurationValue": config_value}}
+        }
+        if bundle_id is None:
+            response = _with_backoff(
+                bac_client.create_configuration_bundle,
+                bundleName=sanitize_bundle_name(agent_name),
+                components=components,
+                clientToken=str(uuid.uuid4()),
+                commitMessage="Ported from runtime config table",
+            )
+            bundle_id = response["bundleId"]
+            bundle_arn = response["bundleArn"]
+            version_id = response["versionId"]
+        else:
+            response = _with_backoff(
+                bac_client.update_configuration_bundle,
+                bundleId=bundle_id,
+                components=components,
+                parentVersionIds=[parent_version_id],
+                clientToken=str(uuid.uuid4()),
+                commitMessage="Ported from runtime config table (history)",
+            )
+            version_id = response["versionId"]
+
+        parent_version_id = version_id
+        if row.get("AgentRuntimeVersion") == default_version:
+            default_version_id = version_id
+
+    # Current-only, or a summary DEFAULT with no matching row: the bundle head is
+    # the effective default.
+    if default_version_id is None:
+        default_version_id = parent_version_id
+
+    _backfill_summary(
+        summary_table,
+        agent_name=agent_name,
+        bundle_id=bundle_id,  # type: ignore[arg-type]
+        bundle_arn=bundle_arn,  # type: ignore[arg-type]
+        default_version_id=default_version_id,  # type: ignore[arg-type]
+    )
+
+    return PortResult(
+        agent_name=agent_name,
+        bundle_id=bundle_id,
+        bundle_arn=bundle_arn,
+        default_version_id=default_version_id,
+        skipped=False,
+    )
+
+
+def _backfill_summary(
+    summary_table,
+    *,
+    agent_name: str,
+    bundle_id: str,
+    bundle_arn: str,
+    default_version_id: str,
+) -> None:
+    """Write BundleId/BundleArn and point QualifierToVersion.DEFAULT at the bundle."""
+    summary_table.update_item(
+        Key={"AgentName": agent_name},
+        UpdateExpression=(
+            "SET BundleId = :bid, BundleArn = :barn, "
+            "QualifierToVersion.#default = :ver"
+        ),
+        ExpressionAttributeNames={"#default": "DEFAULT"},
+        ExpressionAttributeValues={
+            ":bid": bundle_id,
+            ":barn": bundle_arn,
+            ":ver": default_version_id,
+        },
+    )
+
+
+def _iter_all_agents(summary_table) -> list[str]:
+    """Every agent name in the summary table (paginated scan)."""
+    names: list[str] = []
+    response = summary_table.scan(ProjectionExpression="AgentName")
+    names.extend(item["AgentName"] for item in response.get("Items", []))
+    while "LastEvaluatedKey" in response:
+        response = summary_table.scan(
+            ProjectionExpression="AgentName",
+            ExclusiveStartKey=response["LastEvaluatedKey"],
+        )
+        names.extend(item["AgentName"] for item in response.get("Items", []))
+    return names
+
+
+def run(
+    agent_names: list[str],
+    *,
+    summary_table,
+    runtime_table,
+    bac_client,
+    dry_run: bool = False,
+    full_history: bool = False,
+) -> list[PortResult]:
+    """Port the given agents and return per-agent results."""
+    results: list[PortResult] = []
+    for name in agent_names:
+        try:
+            results.append(
+                port_agent(
+                    name,
+                    summary_table=summary_table,
+                    runtime_table=runtime_table,
+                    bac_client=bac_client,
+                    dry_run=dry_run,
+                    full_history=full_history,
+                )
+            )
+        except ClientError as err:
+            results.append(PortResult(agent_name=name, error=str(err)))
+    return results
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    scope = parser.add_mutually_exclusive_group(required=True)
+    scope.add_argument("--all", action="store_true", help="Port every agent.")
+    scope.add_argument(
+        "--agent", action="append", default=[], metavar="NAME", help="Port one agent."
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--full-history", action="store_true")
+    parser.add_argument("--prefix", default=None)
+    parser.add_argument("--region", default=None)
+    parser.add_argument("--profile", default=None)
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    """CLI entrypoint. Returns a process exit code."""
+    import os
+
+    args = _build_parser().parse_args(argv)
+
+    prefix = args.prefix or os.environ.get("ACA_PREFIX")
+    if not prefix:
+        print("error: --prefix or ACA_PREFIX is required", file=sys.stderr)
+        return 2
+
+    session = boto3.Session(profile_name=args.profile, region_name=args.region)
+    region = session.region_name
+    if region not in CONFIRMED_BUNDLE_REGIONS:
+        print(
+            f"error: region {region!r} is not a confirmed bundle region "
+            f"({', '.join(sorted(CONFIRMED_BUNDLE_REGIONS))})",
+            file=sys.stderr,
+        )
+        return 2
+
+    dynamodb = session.resource("dynamodb")
+    summary_table = dynamodb.Table(f"{prefix}-agentCoreSummaryTable")
+    runtime_table = dynamodb.Table(f"{prefix}-agentCoreRuntimeCfgTable")
+    bac_client = session.client(
+        "bedrock-agentcore-control", config=Config(retries={"mode": "standard"})
+    )
+
+    agent_names = _iter_all_agents(summary_table) if args.all else args.agent
+    if not agent_names:
+        print("No agents to port.")
+        return 0
+
+    mode = "DRY-RUN" if args.dry_run else "PORT"
+    print(f"[{mode}] {len(agent_names)} agent(s) in {region} (prefix {prefix})")
+
+    results = run(
+        agent_names,
+        summary_table=summary_table,
+        runtime_table=runtime_table,
+        bac_client=bac_client,
+        dry_run=args.dry_run,
+        full_history=args.full_history,
+    )
+
+    failures = 0
+    for result in results:
+        if result.error:
+            failures += 1
+            print(f"  ✗ {result.agent_name}: {result.error}")
+        elif result.dry_run:
+            print(
+                f"  ~ {result.agent_name}: would port (DEFAULT={result.default_version_id})"
+            )
+        elif result.skipped:
+            print(
+                f"  = {result.agent_name}: already ported (bundle {result.bundle_id})"
+            )
+        else:
+            print(
+                f"  ✓ {result.agent_name}: bundle {result.bundle_id} "
+                f"version {result.default_version_id}"
+            )
+
+    print(
+        f"Done: {len(results) - failures} ok, {failures} failed "
+        f"({sum(r.skipped for r in results)} skipped)."
+    )
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -1,0 +1,13 @@
+# ---------------------------------------------------------------------------- #
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# SPDX-License-Identifier: MIT-0
+# ---------------------------------------------------------------------------- #
+"""Pytest configuration for the port-config-to-bundles script tests."""
+
+import sys
+from pathlib import Path
+
+# Add the scripts root so `import port_config_to_bundles` resolves the module
+# under test (it is a standalone operator script, not a Lambda handler).
+sys.path.insert(0, str(Path(__file__).parent.parent))

--- a/scripts/tests/test_port_config_to_bundles.py
+++ b/scripts/tests/test_port_config_to_bundles.py
@@ -1,0 +1,250 @@
+# ---------------------------------------------------------------------------- #
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# SPDX-License-Identifier: MIT-0
+# ---------------------------------------------------------------------------- #
+"""Unit tests for the port-config-to-bundles operator script."""
+
+from unittest.mock import MagicMock
+
+import port_config_to_bundles as port
+import pytest
+from botocore.exceptions import ClientError
+
+CONFIG_V1 = '{"systemPrompt": "v1", "modelId": "anthropic.claude-x"}'
+CONFIG_V2 = '{"systemPrompt": "v2", "modelId": "anthropic.claude-x"}'
+
+
+def _not_found(op="GetConfigurationBundle"):
+    return ClientError(
+        {"Error": {"Code": "ResourceNotFoundException", "Message": "gone"}}, op
+    )
+
+
+@pytest.fixture
+def tables():
+    summary = MagicMock(name="summary_table")
+    runtime = MagicMock(name="runtime_table")
+    bac = MagicMock(name="bac_client")
+    return summary, runtime, bac
+
+
+def _summary_row(**overrides):
+    row = {"AgentName": "my-agent", "QualifierToVersion": {"DEFAULT": "2"}}
+    row.update(overrides)
+    return row
+
+
+def _runtime_rows():
+    return [
+        {
+            "AgentName": "my-agent",
+            "CreatedAt": 100,
+            "AgentRuntimeVersion": "1",
+            "ConfigurationValue": CONFIG_V1,
+        },
+        {
+            "AgentName": "my-agent",
+            "CreatedAt": 200,
+            "AgentRuntimeVersion": "2",
+            "ConfigurationValue": CONFIG_V2,
+        },
+    ]
+
+
+def test_create_path_ports_default_version(tables):
+    summary, runtime, bac = tables
+    summary.get_item.return_value = {"Item": _summary_row()}
+    runtime.query.return_value = {"Items": _runtime_rows()}
+    bac.create_configuration_bundle.return_value = {
+        "bundleId": "b-1",
+        "bundleArn": "arn:b-1",
+        "versionId": "ver-2",
+    }
+
+    result = port.port_agent(
+        "my-agent", summary_table=summary, runtime_table=runtime, bac_client=bac
+    )
+
+    # Only the DEFAULT (version "2") row is ported → single create, no update.
+    bac.create_configuration_bundle.assert_called_once()
+    bac.update_configuration_bundle.assert_not_called()
+    kwargs = bac.create_configuration_bundle.call_args.kwargs
+    assert kwargs["bundleName"] == "my_agent"  # hyphen -> underscore
+    assert kwargs["components"] == {
+        "my-agent": {"configuration": {"ConfigurationValue": CONFIG_V2}}
+    }
+
+    assert result.bundle_id == "b-1"
+    assert result.default_version_id == "ver-2"
+    assert result.skipped is False
+
+    # Summary backfilled with bundle fields + DEFAULT pointer.
+    values = summary.update_item.call_args.kwargs["ExpressionAttributeValues"]
+    assert values[":bid"] == "b-1"
+    assert values[":barn"] == "arn:b-1"
+    assert values[":ver"] == "ver-2"
+
+
+def test_idempotent_skip_when_bundle_exists(tables):
+    summary, runtime, bac = tables
+    summary.get_item.return_value = {
+        "Item": _summary_row(BundleId="b-1", BundleArn="arn:b-1")
+    }
+    # Bundle still exists → get succeeds.
+    bac.get_configuration_bundle.return_value = {"bundleId": "b-1"}
+
+    result = port.port_agent(
+        "my-agent", summary_table=summary, runtime_table=runtime, bac_client=bac
+    )
+
+    assert result.skipped is True
+    assert result.bundle_id == "b-1"
+    bac.create_configuration_bundle.assert_not_called()
+    bac.update_configuration_bundle.assert_not_called()
+    summary.update_item.assert_not_called()
+
+
+def test_stale_bundle_id_reports_recreated(tables):
+    summary, runtime, bac = tables
+    # Summary claims a bundle, but it no longer exists → re-create, not skip.
+    summary.get_item.return_value = {"Item": _summary_row(BundleId="ghost")}
+    bac.get_configuration_bundle.side_effect = _not_found()
+    runtime.query.return_value = {"Items": _runtime_rows()}
+    bac.create_configuration_bundle.return_value = {
+        "bundleId": "b-2",
+        "bundleArn": "arn:b-2",
+        "versionId": "ver-2",
+    }
+
+    result = port.port_agent(
+        "my-agent", summary_table=summary, runtime_table=runtime, bac_client=bac
+    )
+
+    assert result.skipped is False
+    assert result.bundle_id == "b-2"
+    bac.create_configuration_bundle.assert_called_once()
+
+
+def test_dry_run_mutates_nothing(tables):
+    summary, runtime, bac = tables
+    summary.get_item.return_value = {"Item": _summary_row()}
+    runtime.query.return_value = {"Items": _runtime_rows()}
+
+    result = port.port_agent(
+        "my-agent",
+        summary_table=summary,
+        runtime_table=runtime,
+        bac_client=bac,
+        dry_run=True,
+    )
+
+    assert result.dry_run is True
+    assert result.default_version_id == "2"
+    bac.create_configuration_bundle.assert_not_called()
+    summary.update_item.assert_not_called()
+
+
+def test_full_history_chains_versions(tables):
+    summary, runtime, bac = tables
+    summary.get_item.return_value = {"Item": _summary_row()}
+    runtime.query.return_value = {"Items": _runtime_rows()}
+    bac.create_configuration_bundle.return_value = {
+        "bundleId": "b-1",
+        "bundleArn": "arn:b-1",
+        "versionId": "ver-1",
+    }
+    bac.update_configuration_bundle.return_value = {
+        "bundleId": "b-1",
+        "bundleArn": "arn:b-1",
+        "versionId": "ver-2",
+    }
+
+    result = port.port_agent(
+        "my-agent",
+        summary_table=summary,
+        runtime_table=runtime,
+        bac_client=bac,
+        full_history=True,
+    )
+
+    # v1 -> create, v2 -> update chained onto ver-1.
+    bac.create_configuration_bundle.assert_called_once()
+    bac.update_configuration_bundle.assert_called_once()
+    upd = bac.update_configuration_bundle.call_args.kwargs
+    assert upd["parentVersionIds"] == ["ver-1"]
+    assert upd["components"] == {
+        "my-agent": {"configuration": {"ConfigurationValue": CONFIG_V2}}
+    }
+    # DEFAULT (version "2") maps to the second bundle version.
+    assert result.default_version_id == "ver-2"
+
+
+def test_no_summary_row_reports_error(tables):
+    summary, runtime, bac = tables
+    summary.get_item.return_value = {}
+
+    result = port.port_agent(
+        "my-agent", summary_table=summary, runtime_table=runtime, bac_client=bac
+    )
+
+    assert result.error == "no summary row"
+    bac.create_configuration_bundle.assert_not_called()
+
+
+def test_no_config_rows_reports_error(tables):
+    summary, runtime, bac = tables
+    summary.get_item.return_value = {"Item": _summary_row()}
+    runtime.query.return_value = {"Items": []}
+
+    result = port.port_agent(
+        "my-agent", summary_table=summary, runtime_table=runtime, bac_client=bac
+    )
+
+    assert result.error == "no config rows in runtime table"
+
+
+def test_backoff_retries_throttle_then_succeeds():
+    calls = {"n": 0}
+
+    def flaky():
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise ClientError(
+                {"Error": {"Code": "ThrottlingException", "Message": "slow down"}},
+                "CreateConfigurationBundle",
+            )
+        return "ok"
+
+    sleeps = []
+    result = port._with_backoff(flaky, sleep=sleeps.append)
+
+    assert result == "ok"
+    assert calls["n"] == 3
+    assert len(sleeps) == 2  # backed off twice before the third success
+
+
+def test_run_captures_per_agent_client_error(tables):
+    summary, runtime, bac = tables
+    summary.get_item.side_effect = ClientError(
+        {"Error": {"Code": "AccessDeniedException", "Message": "no"}}, "GetItem"
+    )
+
+    results = port.run(
+        ["a"], summary_table=summary, runtime_table=runtime, bac_client=bac
+    )
+
+    assert len(results) == 1
+    assert results[0].error is not None
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("my-agent", "my_agent"),
+        ("123agent", "a_123agent"),
+        ("valid_Name1", "valid_Name1"),
+    ],
+)
+def test_sanitize_bundle_name(raw, expected):
+    assert port.sanitize_bundle_name(raw) == expected

--- a/src/agent-core/docker-agents-as-tools/pyproject.toml
+++ b/src/agent-core/docker-agents-as-tools/pyproject.toml
@@ -20,9 +20,6 @@ dependencies = [
 [tool.uv]
 package = false
 prerelease = "allow"
-# Wait 7 days before resolving newly published package versions — newly
-# published packages can be malicious or unstable (supply-chain hardening).
-exclude-newer = "7 days"
 # Override: install botocore WITHOUT [crt] extra to avoid awscrt version conflict
 # between mcp-proxy-for-aws (needs awscrt==0.31.2 via botocore[crt])
 # and strands-agents[bidi] (needs awscrt~=0.28.2 via aws-sdk-bedrock-runtime).

--- a/src/agent-core/docker-agents-as-tools/pyproject.toml
+++ b/src/agent-core/docker-agents-as-tools/pyproject.toml
@@ -20,6 +20,9 @@ dependencies = [
 [tool.uv]
 package = false
 prerelease = "allow"
+# Wait 7 days before resolving newly published package versions — newly
+# published packages can be malicious or unstable (supply-chain hardening).
+exclude-newer = "7 days"
 # Override: install botocore WITHOUT [crt] extra to avoid awscrt version conflict
 # between mcp-proxy-for-aws (needs awscrt==0.31.2 via botocore[crt])
 # and strands-agents[bidi] (needs awscrt~=0.28.2 via aws-sdk-bedrock-runtime).

--- a/src/agent-core/docker-agents-as-tools/pyproject.toml
+++ b/src/agent-core/docker-agents-as-tools/pyproject.toml
@@ -24,4 +24,8 @@ prerelease = "allow"
 # between mcp-proxy-for-aws (needs awscrt==0.31.2 via botocore[crt])
 # and strands-agents[bidi] (needs awscrt~=0.28.2 via aws-sdk-bedrock-runtime).
 # CRT is a performance optimization, not required for correctness.
-override-dependencies = ["botocore>=1.42.86"]
+# Floor must track boto3: boto3/botocore are lockstep-coupled (boto3 1.43.x
+# imports symbols like DocumentModifiedShape from the matching botocore). A
+# lower floor let botocore lock to 1.43.30 while boto3 advanced to 1.43.52,
+# crashing `import boto3` at container startup.
+override-dependencies = ["botocore>=1.43.52"]

--- a/src/agent-core/docker-agents-as-tools/pyproject.toml
+++ b/src/agent-core/docker-agents-as-tools/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "strands-agents[bidi,a2a]==1.41.0",
     "strands-agents-tools[a2a-client]==0.7.0",
     "strands-agents-evals==0.1.8",
-    "bedrock-agentcore==1.6.4",
+    "bedrock-agentcore>=1.8",
     "mcp-proxy-for-aws==1.2.0",
     "pydantic==2.12.5",
     "boto3>=1.42.86",

--- a/src/agent-core/docker-agents-as-tools/src/data_source.py
+++ b/src/agent-core/docker-agents-as-tools/src/data_source.py
@@ -20,7 +20,19 @@ class OrchestratorConfigurationLoader(BaseConfigurationLoader):
     """Loader for orchestrator agent to be used in an `agents as tools` framework"""
 
     def parse_configuration(self) -> OrchestratorConfiguration:
-        configuration_str = self._fetch_item_from_dynamodb(entity_type="orchestrator")
+        """Parse the orchestrator configuration sourced from the config bundle.
+
+        Fetches ConfigurationValue via _fetch_config_from_bundle (control plane)
+        and deserializes to OrchestratorConfiguration.
+
+        Returns:
+            OrchestratorConfiguration: Parsed orchestrator configuration
+
+        Raises:
+            ClientError: If the control-plane fetch fails
+            ValueError: If configuration not found or invalid
+        """
+        configuration_str = self._fetch_config_from_bundle(entity_type="orchestrator")
 
         parsed_cfg = deserialize(configuration_str, OrchestratorConfiguration)
 
@@ -32,7 +44,7 @@ class OrchestratorConfigurationLoader(BaseConfigurationLoader):
 
 
 def parse_configuration(logger: Logger) -> OrchestratorConfiguration:
-    """Parse orchestrator configuration from DynamoDB.
+    """Parse orchestrator configuration from the config bundle.
 
     Args:
         logger (Logger): Logger instance for logging events
@@ -41,7 +53,7 @@ def parse_configuration(logger: Logger) -> OrchestratorConfiguration:
         OrchestratorConfiguration: Parsed orchestrator configuration
 
     Raises:
-        ClientError: If DynamoDB read fails
+        ClientError: If the control-plane fetch fails
         ValueError: If configuration not found or invalid
     """
     loader = OrchestratorConfigurationLoader(logger)

--- a/src/agent-core/docker-agents-as-tools/tests/conftest.py
+++ b/src/agent-core/docker-agents-as-tools/tests/conftest.py
@@ -1,0 +1,13 @@
+# ---------------------------------------------------------------------------- #
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# SPDX-License-Identifier: MIT-0
+# ---------------------------------------------------------------------------- #
+"""Pytest configuration for agents-as-tools tests."""
+
+import sys
+from pathlib import Path
+
+# Add the image root to sys.path so `import src.*` resolves the same way the
+# container does (src/ is copied to the image root).
+sys.path.insert(0, str(Path(__file__).parent.parent))

--- a/src/agent-core/docker-agents-as-tools/tests/test_data_source.py
+++ b/src/agent-core/docker-agents-as-tools/tests/test_data_source.py
@@ -1,0 +1,61 @@
+# ---------------------------------------------------------------------------- #
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# SPDX-License-Identifier: MIT-0
+# ---------------------------------------------------------------------------- #
+"""Tests for the orchestrator config loader sourcing from a bundle (T2).
+
+Run with:
+    pytest tests/test_data_source.py -v
+"""
+
+import json
+import logging
+from unittest.mock import patch
+
+import pytest
+from botocore.exceptions import ClientError
+from src.data_source import OrchestratorConfigurationLoader
+
+VALID_CONFIG = {
+    "modelInferenceParameters": {
+        "modelId": "us.anthropic.claude-sonnet-4-6",
+        "parameters": {"maxTokens": 4096, "temperature": 0.7},
+    },
+    "instructions": "You are an orchestrator.",
+    "agentsAsTools": [
+        {
+            "runtimeId": "arn:aws:bedrock-agentcore:...:runtime/sub",
+            "endpoint": "DEFAULT",
+        }
+    ],
+}
+
+
+def _make_loader() -> OrchestratorConfigurationLoader:
+    loader = OrchestratorConfigurationLoader.__new__(OrchestratorConfigurationLoader)
+    loader._logger = logging.getLogger("test")
+    return loader
+
+
+def test_parse_configuration_from_bundle():
+    loader = _make_loader()
+    with patch.object(
+        loader, "_fetch_config_from_bundle", return_value=json.dumps(VALID_CONFIG)
+    ) as fetch:
+        cfg = loader.parse_configuration()
+
+    fetch.assert_called_once_with(entity_type="orchestrator")
+    assert cfg.instructions == "You are an orchestrator."
+    assert len(cfg.agentsAsTools) == 1
+
+
+def test_parse_configuration_propagates_fetch_error():
+    loader = _make_loader()
+    err = ClientError(
+        {"Error": {"Code": "ResourceNotFoundException", "Message": "nope"}},
+        "GetConfigurationBundleVersion",
+    )
+    with patch.object(loader, "_fetch_config_from_bundle", side_effect=err):
+        with pytest.raises(ClientError):
+            loader.parse_configuration()

--- a/src/agent-core/docker-agents-as-tools/uv.lock
+++ b/src/agent-core/docker-agents-as-tools/uv.lock
@@ -6,7 +6,7 @@ requires-python = ">=3.13"
 prerelease-mode = "allow"
 
 [manifest]
-overrides = [{ name = "botocore", specifier = ">=1.42.86" }]
+overrides = [{ name = "botocore", specifier = ">=1.43.52" }]
 
 [[package]]
 name = "a2a-sdk"
@@ -487,16 +487,16 @@ wheels = [
 
 [[package]]
 name = "botocore"
-version = "1.43.30"
+version = "1.43.53"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/dd/6df8586de6cc036eec2e491b1a65c489c43d9722929aef407c20b7323329/botocore-1.43.30.tar.gz", hash = "sha256:19ed560cb35ae43bf010d37da429a553c07063bf7efea0f2cb53be8a78d3e3d5", size = 15520608, upload-time = "2026-06-15T20:32:45.439Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/6b/ebcefacc4de3cd4f1c449540d86877f76c2f5e586a620831012decbb2b2c/botocore-1.43.53.tar.gz", hash = "sha256:36d93dd8db68ee75f6b61ca9f775161b8168844e4601698701530e6efdded141", size = 15720336, upload-time = "2026-07-21T19:28:41.547Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/b0/9343b5007ad24363c63455facfb0859e9765cf245eebffee8233056b9696/botocore-1.43.30-py3-none-any.whl", hash = "sha256:26b1dded84d89b396180916f56900bd2ab1c0d545a66d1d2c3eeb40f772935b2", size = 15205423, upload-time = "2026-06-15T20:32:40.827Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/e5/1b60e394f0fff97ee70dd16913382b7dffda85b98e639c0c9e8ff56cfaa7/botocore-1.43.53-py3-none-any.whl", hash = "sha256:b7ee9a70d187e5348883c820990ccd9436ab14e2bd6622741fc96fe561e816b8", size = 15404628, upload-time = "2026-07-21T19:28:37.475Z" },
 ]
 
 [[package]]

--- a/src/agent-core/docker-agents-as-tools/uv.lock
+++ b/src/agent-core/docker-agents-as-tools/uv.lock
@@ -50,7 +50,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "aws-opentelemetry-distro", specifier = "==0.15.0" },
-    { name = "bedrock-agentcore", specifier = "==1.6.4" },
+    { name = "bedrock-agentcore", specifier = ">=1.8" },
     { name = "boto3", specifier = ">=1.42.86" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "mcp-proxy-for-aws", specifier = "==1.2.0" },
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "bedrock-agentcore"
-version = "1.6.4"
+version = "1.18.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
@@ -466,23 +466,23 @@ dependencies = [
     { name = "uvicorn" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/54/6d/6dfd3e9f05fb3fff256312cf7a9cee11d849281dfd4d32fa7aaf3cea87e9/bedrock_agentcore-1.6.4.tar.gz", hash = "sha256:7b3e12361ca432ab1cada5e191e6f3cfa9536cd5cedafc37058f670b263bdabf", size = 521801, upload-time = "2026-04-23T20:08:25.401Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/e8/8149bb168ef3825884685eb98ef868f5bb5f796e4ea58eb98e8df3248937/bedrock_agentcore-1.18.1.tar.gz", hash = "sha256:ed4aa8822e39aa5846b9d68d1461afee19f2f795c1f6d71a61bc650ecc00ee31", size = 1030729, upload-time = "2026-07-17T19:55:21.354Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/cc/298426f7601172fab91a7c4fe6c0f7a07ecbdaeb2413f1e8dc5d79aacbd7/bedrock_agentcore-1.6.4-py3-none-any.whl", hash = "sha256:a20f76f23cf08f4c081704eeb85c1899340163066b1612458c93963055a5e3dd", size = 168734, upload-time = "2026-04-23T20:08:23.467Z" },
+    { url = "https://files.pythonhosted.org/packages/45/fe/26cc0a66920035d2740c062bd46df252b15708b7723e13ccae0ab7b334db/bedrock_agentcore-1.18.1-py3-none-any.whl", hash = "sha256:6d8001f09cdfca0a20650ea691426149f521037d8d56917057fc191c00801086", size = 450684, upload-time = "2026-07-17T19:55:19.334Z" },
 ]
 
 [[package]]
 name = "boto3"
-version = "1.43.30"
+version = "1.43.52"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/47/2db3e7c1317019d800a1b4181059656842b8aec69ad578ac01a73eba3b89/boto3-1.43.30.tar.gz", hash = "sha256:6b1ee360f363a457f67a8f5702f522043d8a32d67a97c362ad12075d8b5b531e", size = 113154, upload-time = "2026-06-15T20:32:58.123Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/93/5f98e422ced57a359e3b7827ab79b359d67456abb9c5840b0c5eb7b90e6b/boto3-1.43.52.tar.gz", hash = "sha256:3da09a393c050906d407023bee5fb5b5fb333378513af1a1a51159db870b572f", size = 112680, upload-time = "2026-07-20T19:31:28.396Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/61/4031fd64c458ab7e01879e6ac8b42e256e37139df551315beafe04e74b57/boto3-1.43.30-py3-none-any.whl", hash = "sha256:89e982463d94773136ccf69be77cccd54ff1ce351a6aadd1d3437fcb693681b5", size = 140534, upload-time = "2026-06-15T20:32:55.646Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/57/31e6f45c3e236273f9f83f047ae579a90c4be8c6dc1b8366d63a6dcd9841/boto3-1.43.52-py3-none-any.whl", hash = "sha256:1af1950c2b2400267c93d971d588367fc73554e02b4f435a50a5e930a7c93526", size = 140026, upload-time = "2026-07-20T19:31:26.247Z" },
 ]
 
 [[package]]
@@ -3017,14 +3017,14 @@ wheels = [
 
 [[package]]
 name = "s3transfer"
-version = "0.18.0"
+version = "0.19.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/1f/12417f7f493fc45e1f9fd5d4a9b6c125cf8d2cf3f8ddbdfab3e76406e9d6/s3transfer-0.18.0.tar.gz", hash = "sha256:3760b8b7ec1315da54048b2d626276732bee4300d054d492d4e1d43e20d4ecbd", size = 160560, upload-time = "2026-05-28T19:39:09.124Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/da/4bef7ce7bb989b222aa4785a413896dbec53306dfc59c6ce7d16a7ffbd6a/s3transfer-0.19.1.tar.gz", hash = "sha256:d3d6371dc3f1e5c5427b2b457bcf13bcf87bec334c95aed18642eae61f6926f3", size = 165354, upload-time = "2026-07-10T19:32:04.849Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/58/a58fc997655386daa2e25784e30c288aa3e3819e401f77029ee4899fb55a/s3transfer-0.18.0-py3-none-any.whl", hash = "sha256:239c13b09e65ad0346e1be7348b8a202dcad44ac7ea7c6eb858fc881dce739b6", size = 88572, upload-time = "2026-05-28T19:39:07.999Z" },
+    { url = "https://files.pythonhosted.org/packages/24/23/e84c64ad0e8bc59cd1b2ef98def848deff0ef3456c542afe74d51e9e8c85/s3transfer-0.19.1-py3-none-any.whl", hash = "sha256:d5fd7005ee39307455ad5f310b5ea67f4b1960d7fed5b3671ee50c249de675de", size = 90072, upload-time = "2026-07-10T19:32:03.673Z" },
 ]
 
 [[package]]

--- a/src/agent-core/docker-graph/pyproject.toml
+++ b/src/agent-core/docker-graph/pyproject.toml
@@ -18,6 +18,3 @@ dependencies = [
 
 [tool.uv]
 package = false
-# Wait 7 days before resolving newly published package versions — newly
-# published packages can be malicious or unstable (supply-chain hardening).
-exclude-newer = "7 days"

--- a/src/agent-core/docker-graph/pyproject.toml
+++ b/src/agent-core/docker-graph/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "strands-agents[a2a]==1.41.0",
     "mcp-proxy-for-aws==1.2.0",
     "pydantic==2.12.3",
-    "bedrock-agentcore==1.6.4",
+    "bedrock-agentcore>=1.8",
     "boto3>=1.42.86",
     "httpx>=0.27.0",
     "aws-opentelemetry-distro==0.14.1",

--- a/src/agent-core/docker-graph/pyproject.toml
+++ b/src/agent-core/docker-graph/pyproject.toml
@@ -18,3 +18,6 @@ dependencies = [
 
 [tool.uv]
 package = false
+# Wait 7 days before resolving newly published package versions — newly
+# published packages can be malicious or unstable (supply-chain hardening).
+exclude-newer = "7 days"

--- a/src/agent-core/docker-graph/src/data_source.py
+++ b/src/agent-core/docker-graph/src/data_source.py
@@ -38,8 +38,17 @@ class GraphConfigurationLoader(BaseConfigurationLoader):
         return self._get_lazy_table("agentsSummaryTableName", "_summary_table")
 
     def parse_configuration(self) -> GraphConfiguration:
-        """Fetch and deserialize graph configuration from DynamoDB."""
-        configuration_str = self._fetch_item_from_dynamodb(entity_type="graph")
+        """Fetch and deserialize graph configuration from the config bundle.
+
+        Fetches the top-level graph ConfigurationValue via _fetch_config_from_bundle
+        (control plane). Sub-agent nodes are still resolved via the summary/agents
+        tables at execution time (unchanged).
+
+        Raises:
+            ClientError: If the control-plane fetch fails
+            ValueError: If configuration not found or invalid
+        """
+        configuration_str = self._fetch_config_from_bundle(entity_type="graph")
 
         parsed_cfg: GraphConfiguration = deserialize(
             configuration_str, GraphConfiguration
@@ -58,6 +67,6 @@ class GraphConfigurationLoader(BaseConfigurationLoader):
 
 
 def parse_configuration(logger: Logger) -> GraphConfiguration:
-    """Parse graph configuration from DynamoDB."""
+    """Parse graph configuration from the config bundle."""
     loader = GraphConfigurationLoader(logger)
     return loader.parse_configuration()

--- a/src/agent-core/docker-graph/tests/conftest.py
+++ b/src/agent-core/docker-graph/tests/conftest.py
@@ -135,35 +135,11 @@ def sample_graph_configuration(
     )
 
 
-@pytest.fixture
-def mock_dynamodb_table(sample_graph_configuration):
-    """Mock DynamoDB table returning the sample graph configuration."""
-    config_json = sample_graph_configuration.model_dump_json()
-
-    mock_table = MagicMock()
-    mock_table.get_item.return_value = {
-        "Item": {
-            "AgentName": "test-graph-agent",
-            "CreatedAt": 1700000000,
-            "ConfigurationValue": config_json,
-        }
-    }
-
-    mock_dynamodb_resource = MagicMock()
-    mock_dynamodb_resource.Table.return_value = mock_table
-
-    with patch.dict(
-        "os.environ",
-        {
-            "tableName": "test-agents-table",
-            "agentName": "test-graph-agent",
-            "createdAt": "1700000000",
-            "AWS_REGION": "us-east-1",
-            "agentsTableName": "test-agents-summary",
-            "agentsSummaryTableName": "test-agents-summary",
-        },
-    ), patch("boto3.resource", return_value=mock_dynamodb_resource):
-        yield mock_table
+# NOTE: the former `mock_dynamodb_table` fixture (which patched a `tableName`
+# env var and mocked the DynamoDB config read) was removed with the
+# configuration-bundles migration — the container config read path is now the
+# control-plane bundle fetch, exercised via patch.object on
+# `_fetch_config_from_bundle` in test_data_source.py.
 
 
 @pytest.fixture

--- a/src/agent-core/docker-graph/tests/test_data_source.py
+++ b/src/agent-core/docker-graph/tests/test_data_source.py
@@ -1,0 +1,59 @@
+# ---------------------------------------------------------------------------- #
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# SPDX-License-Identifier: MIT-0
+# ---------------------------------------------------------------------------- #
+"""Tests for the graph config loader sourcing the top-level config from a bundle (T2).
+
+Sub-agent node resolution (summary/agents tables, factory ARN lookups) is
+unchanged; these tests only assert the top-level graph config is fetched from the
+bundle and that fetch failures propagate.
+
+Run with:
+    pytest tests/test_data_source.py -v
+"""
+
+import json
+import logging
+from unittest.mock import patch
+
+import pytest
+from botocore.exceptions import ClientError
+from src.data_source import GraphConfigurationLoader
+
+VALID_CONFIG = {
+    "nodes": [{"id": "start", "agentName": "researcher"}],
+    "edges": [{"source": "start", "target": "__end__"}],
+    "entryPoint": "start",
+}
+
+
+def _make_loader() -> GraphConfigurationLoader:
+    loader = GraphConfigurationLoader.__new__(GraphConfigurationLoader)
+    loader._logger = logging.getLogger("test")
+    loader._agents_table = None
+    loader._summary_table = None
+    return loader
+
+
+def test_parse_configuration_from_bundle():
+    loader = _make_loader()
+    with patch.object(
+        loader, "_fetch_config_from_bundle", return_value=json.dumps(VALID_CONFIG)
+    ) as fetch:
+        cfg = loader.parse_configuration()
+
+    fetch.assert_called_once_with(entity_type="graph")
+    assert cfg.entryPoint == "start"
+    assert [n.id for n in cfg.nodes] == ["start"]
+
+
+def test_parse_configuration_propagates_fetch_error():
+    loader = _make_loader()
+    err = ClientError(
+        {"Error": {"Code": "ResourceNotFoundException", "Message": "nope"}},
+        "GetConfigurationBundleVersion",
+    )
+    with patch.object(loader, "_fetch_config_from_bundle", side_effect=err):
+        with pytest.raises(ClientError):
+            loader.parse_configuration()

--- a/src/agent-core/docker-graph/uv.lock
+++ b/src/agent-core/docker-graph/uv.lock
@@ -43,7 +43,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "aws-opentelemetry-distro", specifier = "==0.14.1" },
-    { name = "bedrock-agentcore", specifier = "==1.6.4" },
+    { name = "bedrock-agentcore", specifier = ">=1.8" },
     { name = "boto3", specifier = ">=1.42.86" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", specifier = ">=0.27.0" },
@@ -250,36 +250,34 @@ wheels = [
 
 [[package]]
 name = "awscrt"
-version = "0.32.2"
+version = "0.36.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/92/cb/980fe60c4209af71d036276217f8b9f372f958e290c15d2849a3de4dcd23/awscrt-0.32.2.tar.gz", hash = "sha256:a4f48805e8a66237923f03b7b692d213994cff42d1ff08125d1d60c74fcaf872", size = 36862073, upload-time = "2026-04-24T22:59:55.835Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/7d/fd87588cffbef8fbdb8436f14fa673ee3735cf8600a1a2a36ef78718cfd6/awscrt-0.36.0.tar.gz", hash = "sha256:ad2198461f3b2a2851f37891d75dcb9173bfe2474d8550ad6260bf9970b4064a", size = 37058473, upload-time = "2026-07-16T19:36:20.843Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/99/a6c712a2f638c766b0879da0eacd9fe5695c64deb89c0357bcc4f1f4df9b/awscrt-0.32.2-cp311-abi3-macosx_10_15_universal2.whl", hash = "sha256:32785f54d0786e07b6491b51f9c2f75ea9e17decd39bb6b66fdc60cd871a49ef", size = 3406247, upload-time = "2026-04-24T22:58:46.268Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/03/665c81f3b9d3c56fcdfb8f353c22501bc538d192c431cfaaf307f867d404/awscrt-0.32.2-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f8a586c52f41ff14c2f1b8afeb764e231ad3d66acfd42a6b9fb6c8afd8da8fe2", size = 3906890, upload-time = "2026-04-24T22:58:47.96Z" },
-    { url = "https://files.pythonhosted.org/packages/31/ad/5db0691a0c72d55a17c03c47149cf15d4602b83b470355c322c9a7f115e8/awscrt-0.32.2-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3ef1664588d35dcad2115377120667e689cd7a517da52a481373c9536811ed96", size = 4196631, upload-time = "2026-04-24T22:58:49.244Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/66/63a4654b2996158f33e88d74d79178a5812d94a7e0d6c94ec475115dff18/awscrt-0.32.2-cp311-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:7ed7c209136650fe25659436bb4150e5af6eb43d71a0bf294f0bf414428736ee", size = 3818090, upload-time = "2026-04-24T22:58:50.657Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/26/b8fee227918465830a0bbba48f54ebf0a5029c3a7d11d4fa973838a79262/awscrt-0.32.2-cp311-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:cfd437122d5a2ec7eb9fffaf2cd8b96543d4a0d7e906b9515b79672005a1607a", size = 4056453, upload-time = "2026-04-24T22:58:52.373Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/26/f5b9e9677bf90d1840d4db1513ba92e73601ef82e61a16e747a83493d35c/awscrt-0.32.2-cp311-abi3-win32.whl", hash = "sha256:5197d1e4e780d755632f79f8d32a09a30a9101cccb51ca1694fe25c711b2e801", size = 4066027, upload-time = "2026-04-24T22:58:53.752Z" },
-    { url = "https://files.pythonhosted.org/packages/57/0b/fd1798551ecdc8a28d61ecdeda248f99faa3457f83aefa10ab797f466889/awscrt-0.32.2-cp311-abi3-win_amd64.whl", hash = "sha256:80420aa19c074a4c0335f2bd0e4aee3381fa452328d937795a1e0c779f0c052d", size = 4221984, upload-time = "2026-04-24T22:58:55.115Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/a3/075e29b39945f398adfb5d5ee4d533e00d37c0f5c68d79b250a1bdb087ba/awscrt-0.32.2-cp313-abi3-macosx_10_15_universal2.whl", hash = "sha256:d2f7aee3bce261ab1ceba1fac404de4d496aa866237161d4257cef92bff9d828", size = 3404901, upload-time = "2026-04-24T22:58:56.492Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/41/1c4783b32bf4ec7383156787570ea1221c95c037c2c0f11cbc9e9529ba48/awscrt-0.32.2-cp313-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ff0fff9c2b613d7fabc298b0fd81f0d7056353f3d20271a852a719c5b2f7ccf4", size = 3897627, upload-time = "2026-04-24T22:58:58.144Z" },
-    { url = "https://files.pythonhosted.org/packages/af/2d/5736128847ff4a877d50720ea7a48d7e50a56b78741919e4b6ffabffb1ad/awscrt-0.32.2-cp313-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:79bb11d5d1dfdcfd867aac4a026bee11afbd2154279e12b66588442d8c14bdf7", size = 4189579, upload-time = "2026-04-24T22:58:59.56Z" },
-    { url = "https://files.pythonhosted.org/packages/90/f5/064b23d4c927e9b63725ee60c88edb75a1e8f5fd1e97d56d4d6a63fe954b/awscrt-0.32.2-cp313-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:47330f421948207a122092042f235cf82d48fa145c446ff4db12cc8cd3a418b6", size = 3809647, upload-time = "2026-04-24T22:59:00.884Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/36/f14ea531cccb6ff85c4d50c9e79e61030675520a393b4af23685d24ea018/awscrt-0.32.2-cp313-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:5ec4d8200eb0158b60e35fbb65faa96ef1eb7763f6ce1192827886ee24c6df99", size = 4051532, upload-time = "2026-04-24T22:59:02.593Z" },
-    { url = "https://files.pythonhosted.org/packages/64/aa/b12e721c8148a1bbc58a22cbd204d88d0a6263331049d40c057f9dcd3e11/awscrt-0.32.2-cp313-abi3-win32.whl", hash = "sha256:a81f30a501d2eb6ba52c769cd6ecb3f7005512fba4a533211dc717e1115b0d94", size = 4062484, upload-time = "2026-04-24T22:59:04.251Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/26/9f5f23647465a4fe1b28afce334e54a4264e23b69365024c28955f0c4119/awscrt-0.32.2-cp313-abi3-win_amd64.whl", hash = "sha256:8d731edda20dce5afc15a04731d91136a31779a244672d1f0a292a8b04aa0fd3", size = 4220425, upload-time = "2026-04-24T22:59:05.627Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/76/18077410c1d7b524a7a7486550bc969218f6575288f66e285157dc78e143/awscrt-0.32.2-cp313-cp313t-macosx_10_15_universal2.whl", hash = "sha256:f2a085d0dd4eef974f2ae5467ae3717d2fc08dd8cd508c4fd7a5acb658c68616", size = 3414715, upload-time = "2026-04-24T22:59:07.01Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/12/465d72ea6afffc7829f7f48f408a707d4dab9e3f2b694f4e0e63e011478a/awscrt-0.32.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d8a4e52f7312e5e435461119aa903f6424e9996d93a040101fb1eb7b9c4e58dc", size = 4028634, upload-time = "2026-04-24T22:59:08.303Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/ee/2e9d3716cf6a24f30b85af24691d473c913c119dc996bcd8c9b2b3fe2c17/awscrt-0.32.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6cb3c858e96ba023de691a3b6478bed9fb59085433042dff78c42e59eed19cf2", size = 4311846, upload-time = "2026-04-24T22:59:10.02Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/ce/aa08aad92e48929cfe243ed7da5cf039fbb137c391e84af79e88c848a37a/awscrt-0.32.2-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:7f92b8f40a104a2a87ea5f428b3799220666ec1450b3a90665867d3715749e91", size = 3952242, upload-time = "2026-04-24T22:59:11.632Z" },
-    { url = "https://files.pythonhosted.org/packages/42/e3/09ad98aa7dae9cd3ad578c7721b64e9da03f9a5ed444e518c63e82db05a9/awscrt-0.32.2-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:9fd2dbca02f4e22fb5c02d1505327e6e6e9320dbe8ca80fc033cbbb29ed8631a", size = 4187982, upload-time = "2026-04-24T22:59:14.477Z" },
-    { url = "https://files.pythonhosted.org/packages/26/be/897b1ad519d83a837d721f4e8a87d98e6f36e5b985fa697f3ffed512a8eb/awscrt-0.32.2-cp313-cp313t-win32.whl", hash = "sha256:023a2f4595804a0f1d61ab49b64dda5612be9bfbe9b13759331e8e31658dda3f", size = 4111958, upload-time = "2026-04-24T22:59:15.857Z" },
-    { url = "https://files.pythonhosted.org/packages/71/54/6cca298e8acb6769c8078b39bedbc507f17a3f7fe6ea768d8256d584d4ed/awscrt-0.32.2-cp313-cp313t-win_amd64.whl", hash = "sha256:a2f513f0fb3aafdf7cdf29d7f6f0c46bf4cc7880380c86e88635b7818565e76d", size = 4271679, upload-time = "2026-04-24T22:59:17.425Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/09/51fca333d42b53ddb04881f53e3cc0f4462872ac81426fbb34f5d0b1d1fb/awscrt-0.32.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:7404cb551046bbe7cd454ea75f88b4a1b26f018d1b9bea83dbe46c174789d835", size = 3414716, upload-time = "2026-04-24T22:59:18.918Z" },
-    { url = "https://files.pythonhosted.org/packages/39/3a/0ae52a8dfb0e3c37f0129232d79307c65e6ee1ea13a3cbdcf301aaad0a6a/awscrt-0.32.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:51d6132e9d70de40da07dfad5f17780a652dd4b351c35ca97c79d0fa0186d645", size = 4028980, upload-time = "2026-04-24T22:59:20.316Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/7f/7f52020bfcf29122cad77e936d82abaa1f6857a5a70453e8cc734119f0e2/awscrt-0.32.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:193cc3ecf03a1dd6f989853b6c21549a0a9750c855520fedc8c3c8fbcd32e1bc", size = 4312564, upload-time = "2026-04-24T22:59:21.851Z" },
-    { url = "https://files.pythonhosted.org/packages/25/86/2c9b5479e08b8198459d2a781df5524e45d4d0f9c6329bad26979a4d1e85/awscrt-0.32.2-cp314-cp314t-win32.whl", hash = "sha256:25c7e7e6535cb2d2a4d22fd6264f621672d3903491318364dbc59066b63c7186", size = 4195784, upload-time = "2026-04-24T22:59:23.769Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/85/a12515514de8969b9e7fa40bb782501a336a8a985cc3093309120a80b627/awscrt-0.32.2-cp314-cp314t-win_amd64.whl", hash = "sha256:a6782c19a00f354c7b232b675f09cde94d1ca37bcf29009b8779b3f6395b27b4", size = 4366435, upload-time = "2026-04-24T22:59:25.53Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/37/1dd6a63dc5325bdb36f082490fd770aec1fd6565d1aaacb3ff9fd9c2bad7/awscrt-0.36.0-cp311-abi3-macosx_10_15_universal2.whl", hash = "sha256:1f6dbe7fd755d981c6492f6ad08775060e86e9ccb7d84f6725e4444cee14bf5c", size = 5148128, upload-time = "2026-07-16T19:35:17.537Z" },
+    { url = "https://files.pythonhosted.org/packages/78/e6/3ecfa5ad2023bc7e897ccd9f09e6d30d34448c9fddbdb2f7549f7964784e/awscrt-0.36.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:900eb2cf518a3f1c7e9c4ebc320f5a3fac891208992b9428da76e3f0fb0300a5", size = 3972156, upload-time = "2026-07-16T19:35:19.025Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/94/a5fc3f83e4178f20f4e75fbecfaefc1c8d5a1d848eeba100c46226bf966e/awscrt-0.36.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bf8bafef584f9d5fead3a88f3b86e0aea957c85ecab5243d0c47858ea3d9b39a", size = 4264588, upload-time = "2026-07-16T19:35:20.437Z" },
+    { url = "https://files.pythonhosted.org/packages/42/8d/0c3d1ea026a20be02a0586dd31c41018a98ec7e52701b1ff68c408e79d09/awscrt-0.36.0-cp311-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:1608b45260678aeb4aabdf5f0c69799cb801304b50d065891f96a474e053f908", size = 3880158, upload-time = "2026-07-16T19:35:21.971Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/58/870c1a5adc6d0675e8a4cbb39ea7070ec2860a82b4fa71416bc18cc2f805/awscrt-0.36.0-cp311-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:a950c3b4082a687f7e76accc01f937113c6febe13a790856381314323e6a8d03", size = 4121252, upload-time = "2026-07-16T19:35:23.442Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/85/a06708ee6caf8d0281a9a7c5f73ec36d5471dda37ccd0b630933c869fa4e/awscrt-0.36.0-cp311-abi3-win32.whl", hash = "sha256:b195103c3b87f02a2c2f278281a64e35dfe57d03d92017097adeb31332731459", size = 4167298, upload-time = "2026-07-16T19:35:24.86Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/0a/3fa90ed5283aba9c41f3ea657a4bc71addf6eda0fe85d05aff338f159a53/awscrt-0.36.0-cp311-abi3-win_amd64.whl", hash = "sha256:d4b391736d15f44d452bef0372997c418af44c83d0a11953d0e18a5fd937ba0f", size = 4337077, upload-time = "2026-07-16T19:35:26.236Z" },
+    { url = "https://files.pythonhosted.org/packages/69/68/355a9c06805f14ac4e1ac1bdf81c8e50d1308dd8c1ea73ae8b3ff35a09ac/awscrt-0.36.0-cp313-abi3-macosx_10_15_universal2.whl", hash = "sha256:0ef852c7bd977402f2c82959d9b6c68e39c74bca885d4578cec86e6a3b60c864", size = 5146650, upload-time = "2026-07-16T19:35:27.565Z" },
+    { url = "https://files.pythonhosted.org/packages/93/fb/982bb2798550c469e1fe8ff3b368dbc458f82187a82c38ce6b61456a7a94/awscrt-0.36.0-cp313-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:01a55a4de4d3d915714590bd50cd3cc430e8f5bce78a4c6b6308c6a7f513ca12", size = 3962528, upload-time = "2026-07-16T19:35:29.166Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/91/a607e1c70a56bc33008b4a2829334e1b319cf9056419784aaed24dbad9c9/awscrt-0.36.0-cp313-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6dba4e0ec0aeec18ecf534081c02357794b89d8a7e12d83f6c970f9d90b1ff0a", size = 4258010, upload-time = "2026-07-16T19:35:30.606Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/ed/57655a46f64a7a5d384248a16ad624d2aac076b8a0e759f3e820a30543d0/awscrt-0.36.0-cp313-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:63b726ee7165c5f13ffdd8c57402538a59d01dbc1eeec4eaef75790dbb4ce4d9", size = 3872506, upload-time = "2026-07-16T19:35:32.017Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c7/7963d182695a1a13597d8c1df36364595475eaba26af176a5d892e8199a6/awscrt-0.36.0-cp313-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:74e8419f3ab6770082a5a7af267508c72af10b7352bae17b284800ba8e6ec13b", size = 4116622, upload-time = "2026-07-16T19:35:33.477Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/2f/dbefbf49c797a4fc0698f9f5ef51ec6725cc46755e8ce8ecadad07efe64a/awscrt-0.36.0-cp313-abi3-win32.whl", hash = "sha256:ef8e655ffaf245a2d4a5c6ca9a1da12fe72cf43c70457dd07f6e0b162ffed164", size = 4163785, upload-time = "2026-07-16T19:35:35.006Z" },
+    { url = "https://files.pythonhosted.org/packages/54/b4/710ec9200b10bb3a39eb3308723fb7ee86622e57a2a8b18532e37c191b7a/awscrt-0.36.0-cp313-abi3-win_amd64.whl", hash = "sha256:e1329d9e6b4e1051bf094130fc40d9790cd6986b529bbe8a8bf65ae4fb559d30", size = 4333718, upload-time = "2026-07-16T19:35:36.431Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/15/d4754f15a54206ea2fe4bb8b2343dc86cf1ae163a413aeb23280feffe129/awscrt-0.36.0-cp313-cp313t-macosx_10_15_universal2.whl", hash = "sha256:6f0044e3fdc3acb7287dc8285fb0710370b94ffd5d69ee1e01a0f161b5ea0376", size = 5155749, upload-time = "2026-07-16T19:35:37.904Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/b2/64590179bc367832edb16a56ff88d86a73f8bfe070311325851c404331c1/awscrt-0.36.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:93ece6a57527cb6124cda94345adc797bee99ae34bb013c7edcd4bbe09493778", size = 4013555, upload-time = "2026-07-16T19:35:39.569Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/5f/eba58de79c2e63758805de1d355cbe68a17053cd460f1040c98f7baa9211/awscrt-0.36.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:6231b3940c261ac3c6e2128d9ea3fcaabdeec6f5737c19e4310f98b1c5ea2b8d", size = 4254426, upload-time = "2026-07-16T19:35:41.103Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/a9/49839240e66c8373fe266c9d16218cbce06f31c6e706939e53976c197631/awscrt-0.36.0-cp313-cp313t-win32.whl", hash = "sha256:62d8938540dfa84e754621bcbf9dfdab19a39a4ae2d3a6f350f3d615b1ff4767", size = 4219945, upload-time = "2026-07-16T19:35:42.604Z" },
+    { url = "https://files.pythonhosted.org/packages/71/c6/926f66a4f17d874d60fc60578fe6be58f5a91e64cd8836a94f87d1803bf7/awscrt-0.36.0-cp313-cp313t-win_amd64.whl", hash = "sha256:3c822bb7c98c306484c70564d798400110928a0ea5c9c1b2091b74a5026b4561", size = 4380060, upload-time = "2026-07-16T19:35:44.211Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/43/98fa9bd741ce4e46e9701ee2247635aa5ccfb9fbcf0e5922ab14ff91306d/awscrt-0.36.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:4c1a10d5f33a6c3fb1e39474242c6761b9f607c048e688b344acf95354053d65", size = 5155758, upload-time = "2026-07-16T19:35:45.687Z" },
+    { url = "https://files.pythonhosted.org/packages/df/da/b21fff2240b8185afcced69912db6231ff62545e428bc70248c196f73f48/awscrt-0.36.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b76cb47f2ed5c0bf989541ee80ab8f35d9a392d30b5de1e24b17d655e2f63da5", size = 4094173, upload-time = "2026-07-16T19:35:47.317Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9c/b4ecc77494e5930f0bca50ba9b8c9f973ac477e0233c83126cfb81c85327/awscrt-0.36.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bfc4039bc8ee9924d9dfc1558d073305d5d1f0046e87d7773826901d0f0f0792", size = 4384153, upload-time = "2026-07-16T19:35:48.931Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/48/ed0f2b0cb2cb5b7fbb89f14574c7b4bb5f7584072054523c3d4424be693e/awscrt-0.36.0-cp314-cp314t-win32.whl", hash = "sha256:2c8ebe57a6d8a329b57b480357767da1ae3af49d243727e826c3317da09397a5", size = 4301556, upload-time = "2026-07-16T19:35:50.48Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a3/9f36da2b735b896c4eb5455d858c4bca80eeadcf6bbfdfafd189de46830f/awscrt-0.36.0-cp314-cp314t-win_amd64.whl", hash = "sha256:edc9814c5ddf4b49e9b4dc5f424b7172afc07a2f7b655338a25d6c87620d2b89", size = 4479687, upload-time = "2026-07-16T19:35:52.014Z" },
 ]
 
 [[package]]
@@ -293,7 +291,7 @@ wheels = [
 
 [[package]]
 name = "bedrock-agentcore"
-version = "1.6.4"
+version = "1.18.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
@@ -305,37 +303,37 @@ dependencies = [
     { name = "uvicorn" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/54/6d/6dfd3e9f05fb3fff256312cf7a9cee11d849281dfd4d32fa7aaf3cea87e9/bedrock_agentcore-1.6.4.tar.gz", hash = "sha256:7b3e12361ca432ab1cada5e191e6f3cfa9536cd5cedafc37058f670b263bdabf", size = 521801, upload-time = "2026-04-23T20:08:25.401Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/e8/8149bb168ef3825884685eb98ef868f5bb5f796e4ea58eb98e8df3248937/bedrock_agentcore-1.18.1.tar.gz", hash = "sha256:ed4aa8822e39aa5846b9d68d1461afee19f2f795c1f6d71a61bc650ecc00ee31", size = 1030729, upload-time = "2026-07-17T19:55:21.354Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/cc/298426f7601172fab91a7c4fe6c0f7a07ecbdaeb2413f1e8dc5d79aacbd7/bedrock_agentcore-1.6.4-py3-none-any.whl", hash = "sha256:a20f76f23cf08f4c081704eeb85c1899340163066b1612458c93963055a5e3dd", size = 168734, upload-time = "2026-04-23T20:08:23.467Z" },
+    { url = "https://files.pythonhosted.org/packages/45/fe/26cc0a66920035d2740c062bd46df252b15708b7723e13ccae0ab7b334db/bedrock_agentcore-1.18.1-py3-none-any.whl", hash = "sha256:6d8001f09cdfca0a20650ea691426149f521037d8d56917057fc191c00801086", size = 450684, upload-time = "2026-07-17T19:55:19.334Z" },
 ]
 
 [[package]]
 name = "boto3"
-version = "1.43.30"
+version = "1.43.52"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/47/2db3e7c1317019d800a1b4181059656842b8aec69ad578ac01a73eba3b89/boto3-1.43.30.tar.gz", hash = "sha256:6b1ee360f363a457f67a8f5702f522043d8a32d67a97c362ad12075d8b5b531e", size = 113154, upload-time = "2026-06-15T20:32:58.123Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/93/5f98e422ced57a359e3b7827ab79b359d67456abb9c5840b0c5eb7b90e6b/boto3-1.43.52.tar.gz", hash = "sha256:3da09a393c050906d407023bee5fb5b5fb333378513af1a1a51159db870b572f", size = 112680, upload-time = "2026-07-20T19:31:28.396Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/61/4031fd64c458ab7e01879e6ac8b42e256e37139df551315beafe04e74b57/boto3-1.43.30-py3-none-any.whl", hash = "sha256:89e982463d94773136ccf69be77cccd54ff1ce351a6aadd1d3437fcb693681b5", size = 140534, upload-time = "2026-06-15T20:32:55.646Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/57/31e6f45c3e236273f9f83f047ae579a90c4be8c6dc1b8366d63a6dcd9841/boto3-1.43.52-py3-none-any.whl", hash = "sha256:1af1950c2b2400267c93d971d588367fc73554e02b4f435a50a5e930a7c93526", size = 140026, upload-time = "2026-07-20T19:31:26.247Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.43.30"
+version = "1.43.52"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/dd/6df8586de6cc036eec2e491b1a65c489c43d9722929aef407c20b7323329/botocore-1.43.30.tar.gz", hash = "sha256:19ed560cb35ae43bf010d37da429a553c07063bf7efea0f2cb53be8a78d3e3d5", size = 15520608, upload-time = "2026-06-15T20:32:45.439Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/18/f6f02b1acea9a7c42571813ad4c3e19460206e67ca99af402b7ae3d7584d/botocore-1.43.52.tar.gz", hash = "sha256:3c25e11796ae6e295f1cc3a7760e808c26c432cd580d6a608f32da24715c389b", size = 15717429, upload-time = "2026-07-20T19:31:17.296Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/b0/9343b5007ad24363c63455facfb0859e9765cf245eebffee8233056b9696/botocore-1.43.30-py3-none-any.whl", hash = "sha256:26b1dded84d89b396180916f56900bd2ab1c0d545a66d1d2c3eeb40f772935b2", size = 15205423, upload-time = "2026-06-15T20:32:40.827Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e8/99f83445500c565e1850b20d510821d1eb635283171573340aa310d478b5/botocore-1.43.52-py3-none-any.whl", hash = "sha256:43715e971b306f86d5918b3b728ec62aae3f4be49e1606058ef1f0b87dcbad9e", size = 15402564, upload-time = "2026-07-20T19:31:13.936Z" },
 ]
 
 [package.optional-dependencies]
@@ -2707,14 +2705,14 @@ wheels = [
 
 [[package]]
 name = "s3transfer"
-version = "0.18.0"
+version = "0.19.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/1f/12417f7f493fc45e1f9fd5d4a9b6c125cf8d2cf3f8ddbdfab3e76406e9d6/s3transfer-0.18.0.tar.gz", hash = "sha256:3760b8b7ec1315da54048b2d626276732bee4300d054d492d4e1d43e20d4ecbd", size = 160560, upload-time = "2026-05-28T19:39:09.124Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/da/4bef7ce7bb989b222aa4785a413896dbec53306dfc59c6ce7d16a7ffbd6a/s3transfer-0.19.1.tar.gz", hash = "sha256:d3d6371dc3f1e5c5427b2b457bcf13bcf87bec334c95aed18642eae61f6926f3", size = 165354, upload-time = "2026-07-10T19:32:04.849Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/58/a58fc997655386daa2e25784e30c288aa3e3819e401f77029ee4899fb55a/s3transfer-0.18.0-py3-none-any.whl", hash = "sha256:239c13b09e65ad0346e1be7348b8a202dcad44ac7ea7c6eb858fc881dce739b6", size = 88572, upload-time = "2026-05-28T19:39:07.999Z" },
+    { url = "https://files.pythonhosted.org/packages/24/23/e84c64ad0e8bc59cd1b2ef98def848deff0ef3456c542afe74d51e9e8c85/s3transfer-0.19.1-py3-none-any.whl", hash = "sha256:d5fd7005ee39307455ad5f310b5ea67f4b1960d7fed5b3671ee50c249de675de", size = 90072, upload-time = "2026-07-10T19:32:03.673Z" },
 ]
 
 [[package]]

--- a/src/agent-core/docker-swarm/pyproject.toml
+++ b/src/agent-core/docker-swarm/pyproject.toml
@@ -17,6 +17,3 @@ dependencies = [
 
 [tool.uv]
 package = false
-# Wait 7 days before resolving newly published package versions — newly
-# published packages can be malicious or unstable (supply-chain hardening).
-exclude-newer = "7 days"

--- a/src/agent-core/docker-swarm/pyproject.toml
+++ b/src/agent-core/docker-swarm/pyproject.toml
@@ -17,3 +17,6 @@ dependencies = [
 
 [tool.uv]
 package = false
+# Wait 7 days before resolving newly published package versions — newly
+# published packages can be malicious or unstable (supply-chain hardening).
+exclude-newer = "7 days"

--- a/src/agent-core/docker-swarm/pyproject.toml
+++ b/src/agent-core/docker-swarm/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.13"
 dependencies = [
     "strands-agents==1.41.0",
     "strands-agents-evals==0.1.2",
-    "bedrock-agentcore==1.6.4",
+    "bedrock-agentcore>=1.8",
     "mcp-proxy-for-aws==1.2.0",
     "pydantic==2.12.3",
     "boto3>=1.42.86",

--- a/src/agent-core/docker-swarm/src/data_source.py
+++ b/src/agent-core/docker-swarm/src/data_source.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING
 
-from boto3.dynamodb.conditions import Key
 from botocore.exceptions import ClientError
 from shared.base_data_source import BaseConfigurationLoader
 from shared.utils import deserialize
@@ -39,22 +38,19 @@ class SwarmConfigurationLoader(BaseConfigurationLoader):
             logger (Logger): Logger instance for recording operations
         """
         super().__init__(logger)
-        self._agents_table = None
         self._summary_table = None
-
-    def _get_agents_table(self):
-        """Get the DynamoDB agents table with lazy initialization."""
-        return self._get_lazy_table("agentsTableName", "_agents_table")
 
     def _get_summary_table(self):
         """Get the DynamoDB summary table with lazy initialization."""
         return self._get_lazy_table("agentsSummaryTableName", "_summary_table")
 
     def _load_agent_config(self, ref: AgentReference) -> SwarmAgentDefinition:
-        """Load an agent configuration from DynamoDB by endpoint name.
+        """Load a referenced sub-agent's configuration from its bundle.
 
-        Resolves the endpoint name to a version via the summary table's
-        QualifierToVersion mapping, then fetches the config for that version.
+        Resolves the endpoint name to a bundle versionId via the summary table's
+        QualifierToVersion mapping, then fetches that sub-agent's config from its
+        own configuration bundle via the control plane (ADR-0001). The component
+        is keyed by the sub-agent's stable agent id (ADR-0002).
 
         Args:
             ref (AgentReference): Reference containing agentName and endpointName
@@ -63,11 +59,10 @@ class SwarmConfigurationLoader(BaseConfigurationLoader):
             SwarmAgentDefinition: The agent definition for use in the swarm
 
         Raises:
-            ValueError: If agent/endpoint not found or has no configuration
-            ClientError: If DynamoDB query fails
+            ValueError: If agent/endpoint/bundle not found or has no configuration
+            ClientError: If DynamoDB query or the control-plane fetch fails
         """
         summary_table = self._get_summary_table()
-        agents_table = self._get_agents_table()
 
         try:
             response = summary_table.query(
@@ -85,43 +80,35 @@ class SwarmConfigurationLoader(BaseConfigurationLoader):
         if not items:
             raise ValueError(f"Agent '{ref.agentName}' not found in summary table")
 
-        qualifier_to_version = items[0].get("QualifierToVersion", {})
+        row = items[0]
+        qualifier_to_version = row.get("QualifierToVersion", {})
         if ref.endpointName not in qualifier_to_version:
             raise ValueError(
                 f"Agent '{ref.agentName}' has no endpoint '{ref.endpointName}'. "
                 f"Available endpoints: {list(qualifier_to_version.keys())}"
             )
 
-        version = str(qualifier_to_version[ref.endpointName])
+        # QualifierToVersion now stores the bundle versionId for each endpoint.
+        version_id = str(qualifier_to_version[ref.endpointName])
+        bundle_id = row.get("BundleId")
+        if not bundle_id:
+            raise ValueError(
+                f"Agent '{ref.agentName}' has no BundleId in the summary table"
+            )
 
         self._logger.info(
             f"Loading config for agent '{ref.agentName}' "
-            f"endpoint '{ref.endpointName}' (version {version})",
+            f"endpoint '{ref.endpointName}' (bundle {bundle_id} version {version_id})",
         )
 
-        try:
-            response = agents_table.query(
-                IndexName="byAgentNameAndVersion",
-                KeyConditionExpression=Key("AgentName").eq(ref.agentName)
-                & Key("AgentRuntimeVersion").eq(version),
-            )
-        except ClientError as err:
-            self._logger.error(
-                f"Error querying agent '{ref.agentName}' from DynamoDB",
-                extra={"rawErrorMessage": str(err)},
-            )
-            raise
-
-        items = response.get("Items", [])
-        if not items:
-            raise ValueError(
-                f"Agent '{ref.agentName}' endpoint '{ref.endpointName}' "
-                f"(version {version}) not found in agents table"
-            )
-
-        config_str = items[0].get("ConfigurationValue")
-        if config_str is None:
-            raise ValueError(f"Agent '{ref.agentName}' has no configuration")
+        # Fetch the sub-agent's ConfigurationValue from its own bundle; the
+        # component is keyed by the sub-agent's stable agent id (ADR-0002).
+        config_str = self._fetch_config_from_bundle(
+            bundle_id=bundle_id,
+            bundle_version=version_id,
+            component_key=ref.agentName,
+            entity_type="sub-agent",
+        )
 
         config_data = json.loads(config_str)
 

--- a/src/agent-core/docker-swarm/src/data_source.py
+++ b/src/agent-core/docker-swarm/src/data_source.py
@@ -144,19 +144,21 @@ class SwarmConfigurationLoader(BaseConfigurationLoader):
         return agent_def
 
     def parse_configuration(self) -> SwarmConfiguration:
-        """Parse swarm configuration from DynamoDB.
+        """Parse swarm configuration sourced from the config bundle.
 
-        If the configuration uses agentReferences, this method will load
-        each referenced agent's configuration and populate the agents list.
+        Fetches the top-level swarm ConfigurationValue via _fetch_config_from_bundle
+        (control plane). If the configuration uses agentReferences, this method
+        still resolves each referenced agent via the summary/agents tables and
+        populates the agents list (unchanged).
 
         Returns:
             SwarmConfiguration: Parsed swarm configuration with agents populated
 
         Raises:
-            ClientError: If DynamoDB read fails
+            ClientError: If the control-plane fetch or DynamoDB read fails
             ValueError: If configuration not found or invalid
         """
-        configuration_str = self._fetch_item_from_dynamodb(entity_type="swarm")
+        configuration_str = self._fetch_config_from_bundle(entity_type="swarm")
 
         parsed_cfg: SwarmConfiguration = deserialize(
             configuration_str, SwarmConfiguration
@@ -193,7 +195,7 @@ class SwarmConfigurationLoader(BaseConfigurationLoader):
 
 
 def parse_configuration(logger: Logger) -> SwarmConfiguration:
-    """Parse swarm configuration from DynamoDB.
+    """Parse swarm configuration from the config bundle.
 
     If the configuration uses agentReferences, this function will load
     each referenced agent's configuration and populate the agents list.
@@ -205,7 +207,7 @@ def parse_configuration(logger: Logger) -> SwarmConfiguration:
         SwarmConfiguration: Parsed swarm configuration with agents populated
 
     Raises:
-        ClientError: If DynamoDB read fails
+        ClientError: If the control-plane fetch or DynamoDB read fails
         ValueError: If configuration not found or invalid
     """
     loader = SwarmConfigurationLoader(logger)

--- a/src/agent-core/docker-swarm/tests/test_data_source.py
+++ b/src/agent-core/docker-swarm/tests/test_data_source.py
@@ -1,0 +1,68 @@
+# ---------------------------------------------------------------------------- #
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# SPDX-License-Identifier: MIT-0
+# ---------------------------------------------------------------------------- #
+"""Tests for the swarm config loader sourcing the top-level config from a bundle (T2).
+
+Sub-agent resolution (summary/agents tables) is unchanged and covered elsewhere;
+these tests only assert the top-level swarm config is fetched from the bundle and
+that fetch failures propagate.
+
+Run with:
+    pytest tests/test_data_source.py -v
+"""
+
+import json
+import logging
+from unittest.mock import patch
+
+import pytest
+from botocore.exceptions import ClientError
+from src.data_source import SwarmConfigurationLoader
+
+# Inline agents so parse_configuration does not trigger table-based resolution.
+VALID_CONFIG = {
+    "agents": [
+        {
+            "name": "researcher",
+            "instructions": "You research things.",
+            "modelInferenceParameters": {
+                "modelId": "us.anthropic.claude-sonnet-4-6",
+                "parameters": {"maxTokens": 4096, "temperature": 0.7},
+            },
+        }
+    ],
+    "entryAgent": "researcher",
+}
+
+
+def _make_loader() -> SwarmConfigurationLoader:
+    loader = SwarmConfigurationLoader.__new__(SwarmConfigurationLoader)
+    loader._logger = logging.getLogger("test")
+    loader._agents_table = None
+    loader._summary_table = None
+    return loader
+
+
+def test_parse_configuration_from_bundle():
+    loader = _make_loader()
+    with patch.object(
+        loader, "_fetch_config_from_bundle", return_value=json.dumps(VALID_CONFIG)
+    ) as fetch:
+        cfg = loader.parse_configuration()
+
+    fetch.assert_called_once_with(entity_type="swarm")
+    assert cfg.entryAgent == "researcher"
+    assert [a.name for a in cfg.agents] == ["researcher"]
+
+
+def test_parse_configuration_propagates_fetch_error():
+    loader = _make_loader()
+    err = ClientError(
+        {"Error": {"Code": "ResourceNotFoundException", "Message": "nope"}},
+        "GetConfigurationBundleVersion",
+    )
+    with patch.object(loader, "_fetch_config_from_bundle", side_effect=err):
+        with pytest.raises(ClientError):
+            loader.parse_configuration()

--- a/src/agent-core/docker-swarm/tests/test_data_source.py
+++ b/src/agent-core/docker-swarm/tests/test_data_source.py
@@ -3,11 +3,13 @@
 #
 # SPDX-License-Identifier: MIT-0
 # ---------------------------------------------------------------------------- #
-"""Tests for the swarm config loader sourcing the top-level config from a bundle (T2).
+"""Tests for the swarm config loader sourcing config from bundles (T2 + T8).
 
-Sub-agent resolution (summary/agents tables) is unchanged and covered elsewhere;
-these tests only assert the top-level swarm config is fetched from the bundle and
-that fetch failures propagate.
+Covers the top-level swarm config fetch from the bundle, fetch-failure
+propagation, and the T8 change to sub-agent (agentReference) resolution: each
+referenced sub-agent's config is read from its own bundle (summary row →
+BundleId + QualifierToVersion versionId → get_configuration_bundle_version),
+not from the removed runtime config table.
 
 Run with:
     pytest tests/test_data_source.py -v
@@ -15,11 +17,12 @@ Run with:
 
 import json
 import logging
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from botocore.exceptions import ClientError
 from src.data_source import SwarmConfigurationLoader
+from src.types import AgentReference
 
 # Inline agents so parse_configuration does not trigger table-based resolution.
 VALID_CONFIG = {
@@ -37,10 +40,21 @@ VALID_CONFIG = {
 }
 
 
+SUB_AGENT_CONFIG = {
+    "instructions": "You advocate for serverless.",
+    "modelInferenceParameters": {
+        "modelId": "us.anthropic.claude-sonnet-4-6",
+        "parameters": {"maxTokens": 4096, "temperature": 0.7},
+    },
+    "tools": ["calculator"],
+    "toolParameters": {},
+    "mcpServers": [],
+}
+
+
 def _make_loader() -> SwarmConfigurationLoader:
     loader = SwarmConfigurationLoader.__new__(SwarmConfigurationLoader)
     loader._logger = logging.getLogger("test")
-    loader._agents_table = None
     loader._summary_table = None
     return loader
 
@@ -66,3 +80,72 @@ def test_parse_configuration_propagates_fetch_error():
     with patch.object(loader, "_fetch_config_from_bundle", side_effect=err):
         with pytest.raises(ClientError):
             loader.parse_configuration()
+
+
+def test_load_agent_config_resolves_sub_agent_from_bundle():
+    """A referenced sub-agent is resolved via summary row → its own bundle."""
+    loader = _make_loader()
+    summary_table = MagicMock()
+    summary_table.query.return_value = {
+        "Items": [
+            {
+                "AgentName": "serverless_advocate",
+                "BundleId": "serverless_advocate-abc123",
+                "QualifierToVersion": {"DEFAULT": "ver-42"},
+            }
+        ]
+    }
+    loader._summary_table = summary_table
+    ref = AgentReference(agentName="serverless_advocate", endpointName="DEFAULT")
+
+    with patch.object(
+        loader, "_fetch_config_from_bundle", return_value=json.dumps(SUB_AGENT_CONFIG)
+    ) as fetch:
+        agent_def = loader._load_agent_config(ref)
+
+    # Fetched from the sub-agent's OWN bundle/version, keyed by its agent id.
+    fetch.assert_called_once_with(
+        bundle_id="serverless_advocate-abc123",
+        bundle_version="ver-42",
+        component_key="serverless_advocate",
+        entity_type="sub-agent",
+    )
+    assert agent_def.name == "serverless_advocate"
+    assert agent_def.tools == ["calculator"]
+
+
+def test_load_agent_config_missing_bundle_id_raises():
+    loader = _make_loader()
+    summary_table = MagicMock()
+    summary_table.query.return_value = {
+        "Items": [
+            {
+                "AgentName": "serverless_advocate",
+                "QualifierToVersion": {"DEFAULT": "ver-42"},
+            }
+        ]
+    }
+    loader._summary_table = summary_table
+    ref = AgentReference(agentName="serverless_advocate", endpointName="DEFAULT")
+
+    with pytest.raises(ValueError, match="no BundleId"):
+        loader._load_agent_config(ref)
+
+
+def test_load_agent_config_unknown_endpoint_raises():
+    loader = _make_loader()
+    summary_table = MagicMock()
+    summary_table.query.return_value = {
+        "Items": [
+            {
+                "AgentName": "serverless_advocate",
+                "BundleId": "serverless_advocate-abc123",
+                "QualifierToVersion": {"DEFAULT": "ver-42"},
+            }
+        ]
+    }
+    loader._summary_table = summary_table
+    ref = AgentReference(agentName="serverless_advocate", endpointName="PROD")
+
+    with pytest.raises(ValueError, match="no endpoint 'PROD'"):
+        loader._load_agent_config(ref)

--- a/src/agent-core/docker-swarm/uv.lock
+++ b/src/agent-core/docker-swarm/uv.lock
@@ -21,7 +21,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "aws-opentelemetry-distro", specifier = "==0.10.1" },
-    { name = "bedrock-agentcore", specifier = "==1.6.4" },
+    { name = "bedrock-agentcore", specifier = ">=1.8" },
     { name = "boto3", specifier = ">=1.42.86" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "mcp-proxy-for-aws", specifier = "==1.2.0" },
@@ -286,36 +286,34 @@ wheels = [
 
 [[package]]
 name = "awscrt"
-version = "0.32.2"
+version = "0.36.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/92/cb/980fe60c4209af71d036276217f8b9f372f958e290c15d2849a3de4dcd23/awscrt-0.32.2.tar.gz", hash = "sha256:a4f48805e8a66237923f03b7b692d213994cff42d1ff08125d1d60c74fcaf872", size = 36862073, upload-time = "2026-04-24T22:59:55.835Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/7d/fd87588cffbef8fbdb8436f14fa673ee3735cf8600a1a2a36ef78718cfd6/awscrt-0.36.0.tar.gz", hash = "sha256:ad2198461f3b2a2851f37891d75dcb9173bfe2474d8550ad6260bf9970b4064a", size = 37058473, upload-time = "2026-07-16T19:36:20.843Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/99/a6c712a2f638c766b0879da0eacd9fe5695c64deb89c0357bcc4f1f4df9b/awscrt-0.32.2-cp311-abi3-macosx_10_15_universal2.whl", hash = "sha256:32785f54d0786e07b6491b51f9c2f75ea9e17decd39bb6b66fdc60cd871a49ef", size = 3406247, upload-time = "2026-04-24T22:58:46.268Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/03/665c81f3b9d3c56fcdfb8f353c22501bc538d192c431cfaaf307f867d404/awscrt-0.32.2-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f8a586c52f41ff14c2f1b8afeb764e231ad3d66acfd42a6b9fb6c8afd8da8fe2", size = 3906890, upload-time = "2026-04-24T22:58:47.96Z" },
-    { url = "https://files.pythonhosted.org/packages/31/ad/5db0691a0c72d55a17c03c47149cf15d4602b83b470355c322c9a7f115e8/awscrt-0.32.2-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3ef1664588d35dcad2115377120667e689cd7a517da52a481373c9536811ed96", size = 4196631, upload-time = "2026-04-24T22:58:49.244Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/66/63a4654b2996158f33e88d74d79178a5812d94a7e0d6c94ec475115dff18/awscrt-0.32.2-cp311-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:7ed7c209136650fe25659436bb4150e5af6eb43d71a0bf294f0bf414428736ee", size = 3818090, upload-time = "2026-04-24T22:58:50.657Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/26/b8fee227918465830a0bbba48f54ebf0a5029c3a7d11d4fa973838a79262/awscrt-0.32.2-cp311-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:cfd437122d5a2ec7eb9fffaf2cd8b96543d4a0d7e906b9515b79672005a1607a", size = 4056453, upload-time = "2026-04-24T22:58:52.373Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/26/f5b9e9677bf90d1840d4db1513ba92e73601ef82e61a16e747a83493d35c/awscrt-0.32.2-cp311-abi3-win32.whl", hash = "sha256:5197d1e4e780d755632f79f8d32a09a30a9101cccb51ca1694fe25c711b2e801", size = 4066027, upload-time = "2026-04-24T22:58:53.752Z" },
-    { url = "https://files.pythonhosted.org/packages/57/0b/fd1798551ecdc8a28d61ecdeda248f99faa3457f83aefa10ab797f466889/awscrt-0.32.2-cp311-abi3-win_amd64.whl", hash = "sha256:80420aa19c074a4c0335f2bd0e4aee3381fa452328d937795a1e0c779f0c052d", size = 4221984, upload-time = "2026-04-24T22:58:55.115Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/a3/075e29b39945f398adfb5d5ee4d533e00d37c0f5c68d79b250a1bdb087ba/awscrt-0.32.2-cp313-abi3-macosx_10_15_universal2.whl", hash = "sha256:d2f7aee3bce261ab1ceba1fac404de4d496aa866237161d4257cef92bff9d828", size = 3404901, upload-time = "2026-04-24T22:58:56.492Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/41/1c4783b32bf4ec7383156787570ea1221c95c037c2c0f11cbc9e9529ba48/awscrt-0.32.2-cp313-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ff0fff9c2b613d7fabc298b0fd81f0d7056353f3d20271a852a719c5b2f7ccf4", size = 3897627, upload-time = "2026-04-24T22:58:58.144Z" },
-    { url = "https://files.pythonhosted.org/packages/af/2d/5736128847ff4a877d50720ea7a48d7e50a56b78741919e4b6ffabffb1ad/awscrt-0.32.2-cp313-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:79bb11d5d1dfdcfd867aac4a026bee11afbd2154279e12b66588442d8c14bdf7", size = 4189579, upload-time = "2026-04-24T22:58:59.56Z" },
-    { url = "https://files.pythonhosted.org/packages/90/f5/064b23d4c927e9b63725ee60c88edb75a1e8f5fd1e97d56d4d6a63fe954b/awscrt-0.32.2-cp313-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:47330f421948207a122092042f235cf82d48fa145c446ff4db12cc8cd3a418b6", size = 3809647, upload-time = "2026-04-24T22:59:00.884Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/36/f14ea531cccb6ff85c4d50c9e79e61030675520a393b4af23685d24ea018/awscrt-0.32.2-cp313-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:5ec4d8200eb0158b60e35fbb65faa96ef1eb7763f6ce1192827886ee24c6df99", size = 4051532, upload-time = "2026-04-24T22:59:02.593Z" },
-    { url = "https://files.pythonhosted.org/packages/64/aa/b12e721c8148a1bbc58a22cbd204d88d0a6263331049d40c057f9dcd3e11/awscrt-0.32.2-cp313-abi3-win32.whl", hash = "sha256:a81f30a501d2eb6ba52c769cd6ecb3f7005512fba4a533211dc717e1115b0d94", size = 4062484, upload-time = "2026-04-24T22:59:04.251Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/26/9f5f23647465a4fe1b28afce334e54a4264e23b69365024c28955f0c4119/awscrt-0.32.2-cp313-abi3-win_amd64.whl", hash = "sha256:8d731edda20dce5afc15a04731d91136a31779a244672d1f0a292a8b04aa0fd3", size = 4220425, upload-time = "2026-04-24T22:59:05.627Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/76/18077410c1d7b524a7a7486550bc969218f6575288f66e285157dc78e143/awscrt-0.32.2-cp313-cp313t-macosx_10_15_universal2.whl", hash = "sha256:f2a085d0dd4eef974f2ae5467ae3717d2fc08dd8cd508c4fd7a5acb658c68616", size = 3414715, upload-time = "2026-04-24T22:59:07.01Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/12/465d72ea6afffc7829f7f48f408a707d4dab9e3f2b694f4e0e63e011478a/awscrt-0.32.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d8a4e52f7312e5e435461119aa903f6424e9996d93a040101fb1eb7b9c4e58dc", size = 4028634, upload-time = "2026-04-24T22:59:08.303Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/ee/2e9d3716cf6a24f30b85af24691d473c913c119dc996bcd8c9b2b3fe2c17/awscrt-0.32.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6cb3c858e96ba023de691a3b6478bed9fb59085433042dff78c42e59eed19cf2", size = 4311846, upload-time = "2026-04-24T22:59:10.02Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/ce/aa08aad92e48929cfe243ed7da5cf039fbb137c391e84af79e88c848a37a/awscrt-0.32.2-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:7f92b8f40a104a2a87ea5f428b3799220666ec1450b3a90665867d3715749e91", size = 3952242, upload-time = "2026-04-24T22:59:11.632Z" },
-    { url = "https://files.pythonhosted.org/packages/42/e3/09ad98aa7dae9cd3ad578c7721b64e9da03f9a5ed444e518c63e82db05a9/awscrt-0.32.2-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:9fd2dbca02f4e22fb5c02d1505327e6e6e9320dbe8ca80fc033cbbb29ed8631a", size = 4187982, upload-time = "2026-04-24T22:59:14.477Z" },
-    { url = "https://files.pythonhosted.org/packages/26/be/897b1ad519d83a837d721f4e8a87d98e6f36e5b985fa697f3ffed512a8eb/awscrt-0.32.2-cp313-cp313t-win32.whl", hash = "sha256:023a2f4595804a0f1d61ab49b64dda5612be9bfbe9b13759331e8e31658dda3f", size = 4111958, upload-time = "2026-04-24T22:59:15.857Z" },
-    { url = "https://files.pythonhosted.org/packages/71/54/6cca298e8acb6769c8078b39bedbc507f17a3f7fe6ea768d8256d584d4ed/awscrt-0.32.2-cp313-cp313t-win_amd64.whl", hash = "sha256:a2f513f0fb3aafdf7cdf29d7f6f0c46bf4cc7880380c86e88635b7818565e76d", size = 4271679, upload-time = "2026-04-24T22:59:17.425Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/09/51fca333d42b53ddb04881f53e3cc0f4462872ac81426fbb34f5d0b1d1fb/awscrt-0.32.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:7404cb551046bbe7cd454ea75f88b4a1b26f018d1b9bea83dbe46c174789d835", size = 3414716, upload-time = "2026-04-24T22:59:18.918Z" },
-    { url = "https://files.pythonhosted.org/packages/39/3a/0ae52a8dfb0e3c37f0129232d79307c65e6ee1ea13a3cbdcf301aaad0a6a/awscrt-0.32.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:51d6132e9d70de40da07dfad5f17780a652dd4b351c35ca97c79d0fa0186d645", size = 4028980, upload-time = "2026-04-24T22:59:20.316Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/7f/7f52020bfcf29122cad77e936d82abaa1f6857a5a70453e8cc734119f0e2/awscrt-0.32.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:193cc3ecf03a1dd6f989853b6c21549a0a9750c855520fedc8c3c8fbcd32e1bc", size = 4312564, upload-time = "2026-04-24T22:59:21.851Z" },
-    { url = "https://files.pythonhosted.org/packages/25/86/2c9b5479e08b8198459d2a781df5524e45d4d0f9c6329bad26979a4d1e85/awscrt-0.32.2-cp314-cp314t-win32.whl", hash = "sha256:25c7e7e6535cb2d2a4d22fd6264f621672d3903491318364dbc59066b63c7186", size = 4195784, upload-time = "2026-04-24T22:59:23.769Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/85/a12515514de8969b9e7fa40bb782501a336a8a985cc3093309120a80b627/awscrt-0.32.2-cp314-cp314t-win_amd64.whl", hash = "sha256:a6782c19a00f354c7b232b675f09cde94d1ca37bcf29009b8779b3f6395b27b4", size = 4366435, upload-time = "2026-04-24T22:59:25.53Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/37/1dd6a63dc5325bdb36f082490fd770aec1fd6565d1aaacb3ff9fd9c2bad7/awscrt-0.36.0-cp311-abi3-macosx_10_15_universal2.whl", hash = "sha256:1f6dbe7fd755d981c6492f6ad08775060e86e9ccb7d84f6725e4444cee14bf5c", size = 5148128, upload-time = "2026-07-16T19:35:17.537Z" },
+    { url = "https://files.pythonhosted.org/packages/78/e6/3ecfa5ad2023bc7e897ccd9f09e6d30d34448c9fddbdb2f7549f7964784e/awscrt-0.36.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:900eb2cf518a3f1c7e9c4ebc320f5a3fac891208992b9428da76e3f0fb0300a5", size = 3972156, upload-time = "2026-07-16T19:35:19.025Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/94/a5fc3f83e4178f20f4e75fbecfaefc1c8d5a1d848eeba100c46226bf966e/awscrt-0.36.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bf8bafef584f9d5fead3a88f3b86e0aea957c85ecab5243d0c47858ea3d9b39a", size = 4264588, upload-time = "2026-07-16T19:35:20.437Z" },
+    { url = "https://files.pythonhosted.org/packages/42/8d/0c3d1ea026a20be02a0586dd31c41018a98ec7e52701b1ff68c408e79d09/awscrt-0.36.0-cp311-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:1608b45260678aeb4aabdf5f0c69799cb801304b50d065891f96a474e053f908", size = 3880158, upload-time = "2026-07-16T19:35:21.971Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/58/870c1a5adc6d0675e8a4cbb39ea7070ec2860a82b4fa71416bc18cc2f805/awscrt-0.36.0-cp311-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:a950c3b4082a687f7e76accc01f937113c6febe13a790856381314323e6a8d03", size = 4121252, upload-time = "2026-07-16T19:35:23.442Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/85/a06708ee6caf8d0281a9a7c5f73ec36d5471dda37ccd0b630933c869fa4e/awscrt-0.36.0-cp311-abi3-win32.whl", hash = "sha256:b195103c3b87f02a2c2f278281a64e35dfe57d03d92017097adeb31332731459", size = 4167298, upload-time = "2026-07-16T19:35:24.86Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/0a/3fa90ed5283aba9c41f3ea657a4bc71addf6eda0fe85d05aff338f159a53/awscrt-0.36.0-cp311-abi3-win_amd64.whl", hash = "sha256:d4b391736d15f44d452bef0372997c418af44c83d0a11953d0e18a5fd937ba0f", size = 4337077, upload-time = "2026-07-16T19:35:26.236Z" },
+    { url = "https://files.pythonhosted.org/packages/69/68/355a9c06805f14ac4e1ac1bdf81c8e50d1308dd8c1ea73ae8b3ff35a09ac/awscrt-0.36.0-cp313-abi3-macosx_10_15_universal2.whl", hash = "sha256:0ef852c7bd977402f2c82959d9b6c68e39c74bca885d4578cec86e6a3b60c864", size = 5146650, upload-time = "2026-07-16T19:35:27.565Z" },
+    { url = "https://files.pythonhosted.org/packages/93/fb/982bb2798550c469e1fe8ff3b368dbc458f82187a82c38ce6b61456a7a94/awscrt-0.36.0-cp313-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:01a55a4de4d3d915714590bd50cd3cc430e8f5bce78a4c6b6308c6a7f513ca12", size = 3962528, upload-time = "2026-07-16T19:35:29.166Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/91/a607e1c70a56bc33008b4a2829334e1b319cf9056419784aaed24dbad9c9/awscrt-0.36.0-cp313-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6dba4e0ec0aeec18ecf534081c02357794b89d8a7e12d83f6c970f9d90b1ff0a", size = 4258010, upload-time = "2026-07-16T19:35:30.606Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/ed/57655a46f64a7a5d384248a16ad624d2aac076b8a0e759f3e820a30543d0/awscrt-0.36.0-cp313-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:63b726ee7165c5f13ffdd8c57402538a59d01dbc1eeec4eaef75790dbb4ce4d9", size = 3872506, upload-time = "2026-07-16T19:35:32.017Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c7/7963d182695a1a13597d8c1df36364595475eaba26af176a5d892e8199a6/awscrt-0.36.0-cp313-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:74e8419f3ab6770082a5a7af267508c72af10b7352bae17b284800ba8e6ec13b", size = 4116622, upload-time = "2026-07-16T19:35:33.477Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/2f/dbefbf49c797a4fc0698f9f5ef51ec6725cc46755e8ce8ecadad07efe64a/awscrt-0.36.0-cp313-abi3-win32.whl", hash = "sha256:ef8e655ffaf245a2d4a5c6ca9a1da12fe72cf43c70457dd07f6e0b162ffed164", size = 4163785, upload-time = "2026-07-16T19:35:35.006Z" },
+    { url = "https://files.pythonhosted.org/packages/54/b4/710ec9200b10bb3a39eb3308723fb7ee86622e57a2a8b18532e37c191b7a/awscrt-0.36.0-cp313-abi3-win_amd64.whl", hash = "sha256:e1329d9e6b4e1051bf094130fc40d9790cd6986b529bbe8a8bf65ae4fb559d30", size = 4333718, upload-time = "2026-07-16T19:35:36.431Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/15/d4754f15a54206ea2fe4bb8b2343dc86cf1ae163a413aeb23280feffe129/awscrt-0.36.0-cp313-cp313t-macosx_10_15_universal2.whl", hash = "sha256:6f0044e3fdc3acb7287dc8285fb0710370b94ffd5d69ee1e01a0f161b5ea0376", size = 5155749, upload-time = "2026-07-16T19:35:37.904Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/b2/64590179bc367832edb16a56ff88d86a73f8bfe070311325851c404331c1/awscrt-0.36.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:93ece6a57527cb6124cda94345adc797bee99ae34bb013c7edcd4bbe09493778", size = 4013555, upload-time = "2026-07-16T19:35:39.569Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/5f/eba58de79c2e63758805de1d355cbe68a17053cd460f1040c98f7baa9211/awscrt-0.36.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:6231b3940c261ac3c6e2128d9ea3fcaabdeec6f5737c19e4310f98b1c5ea2b8d", size = 4254426, upload-time = "2026-07-16T19:35:41.103Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/a9/49839240e66c8373fe266c9d16218cbce06f31c6e706939e53976c197631/awscrt-0.36.0-cp313-cp313t-win32.whl", hash = "sha256:62d8938540dfa84e754621bcbf9dfdab19a39a4ae2d3a6f350f3d615b1ff4767", size = 4219945, upload-time = "2026-07-16T19:35:42.604Z" },
+    { url = "https://files.pythonhosted.org/packages/71/c6/926f66a4f17d874d60fc60578fe6be58f5a91e64cd8836a94f87d1803bf7/awscrt-0.36.0-cp313-cp313t-win_amd64.whl", hash = "sha256:3c822bb7c98c306484c70564d798400110928a0ea5c9c1b2091b74a5026b4561", size = 4380060, upload-time = "2026-07-16T19:35:44.211Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/43/98fa9bd741ce4e46e9701ee2247635aa5ccfb9fbcf0e5922ab14ff91306d/awscrt-0.36.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:4c1a10d5f33a6c3fb1e39474242c6761b9f607c048e688b344acf95354053d65", size = 5155758, upload-time = "2026-07-16T19:35:45.687Z" },
+    { url = "https://files.pythonhosted.org/packages/df/da/b21fff2240b8185afcced69912db6231ff62545e428bc70248c196f73f48/awscrt-0.36.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b76cb47f2ed5c0bf989541ee80ab8f35d9a392d30b5de1e24b17d655e2f63da5", size = 4094173, upload-time = "2026-07-16T19:35:47.317Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9c/b4ecc77494e5930f0bca50ba9b8c9f973ac477e0233c83126cfb81c85327/awscrt-0.36.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bfc4039bc8ee9924d9dfc1558d073305d5d1f0046e87d7773826901d0f0f0792", size = 4384153, upload-time = "2026-07-16T19:35:48.931Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/48/ed0f2b0cb2cb5b7fbb89f14574c7b4bb5f7584072054523c3d4424be693e/awscrt-0.36.0-cp314-cp314t-win32.whl", hash = "sha256:2c8ebe57a6d8a329b57b480357767da1ae3af49d243727e826c3317da09397a5", size = 4301556, upload-time = "2026-07-16T19:35:50.48Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a3/9f36da2b735b896c4eb5455d858c4bca80eeadcf6bbfdfafd189de46830f/awscrt-0.36.0-cp314-cp314t-win_amd64.whl", hash = "sha256:edc9814c5ddf4b49e9b4dc5f424b7172afc07a2f7b655338a25d6c87620d2b89", size = 4479687, upload-time = "2026-07-16T19:35:52.014Z" },
 ]
 
 [[package]]
@@ -342,7 +340,7 @@ wheels = [
 
 [[package]]
 name = "bedrock-agentcore"
-version = "1.6.4"
+version = "1.18.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
@@ -354,37 +352,37 @@ dependencies = [
     { name = "uvicorn" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/54/6d/6dfd3e9f05fb3fff256312cf7a9cee11d849281dfd4d32fa7aaf3cea87e9/bedrock_agentcore-1.6.4.tar.gz", hash = "sha256:7b3e12361ca432ab1cada5e191e6f3cfa9536cd5cedafc37058f670b263bdabf", size = 521801, upload-time = "2026-04-23T20:08:25.401Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/e8/8149bb168ef3825884685eb98ef868f5bb5f796e4ea58eb98e8df3248937/bedrock_agentcore-1.18.1.tar.gz", hash = "sha256:ed4aa8822e39aa5846b9d68d1461afee19f2f795c1f6d71a61bc650ecc00ee31", size = 1030729, upload-time = "2026-07-17T19:55:21.354Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/cc/298426f7601172fab91a7c4fe6c0f7a07ecbdaeb2413f1e8dc5d79aacbd7/bedrock_agentcore-1.6.4-py3-none-any.whl", hash = "sha256:a20f76f23cf08f4c081704eeb85c1899340163066b1612458c93963055a5e3dd", size = 168734, upload-time = "2026-04-23T20:08:23.467Z" },
+    { url = "https://files.pythonhosted.org/packages/45/fe/26cc0a66920035d2740c062bd46df252b15708b7723e13ccae0ab7b334db/bedrock_agentcore-1.18.1-py3-none-any.whl", hash = "sha256:6d8001f09cdfca0a20650ea691426149f521037d8d56917057fc191c00801086", size = 450684, upload-time = "2026-07-17T19:55:19.334Z" },
 ]
 
 [[package]]
 name = "boto3"
-version = "1.43.30"
+version = "1.43.52"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/47/2db3e7c1317019d800a1b4181059656842b8aec69ad578ac01a73eba3b89/boto3-1.43.30.tar.gz", hash = "sha256:6b1ee360f363a457f67a8f5702f522043d8a32d67a97c362ad12075d8b5b531e", size = 113154, upload-time = "2026-06-15T20:32:58.123Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/93/5f98e422ced57a359e3b7827ab79b359d67456abb9c5840b0c5eb7b90e6b/boto3-1.43.52.tar.gz", hash = "sha256:3da09a393c050906d407023bee5fb5b5fb333378513af1a1a51159db870b572f", size = 112680, upload-time = "2026-07-20T19:31:28.396Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/61/4031fd64c458ab7e01879e6ac8b42e256e37139df551315beafe04e74b57/boto3-1.43.30-py3-none-any.whl", hash = "sha256:89e982463d94773136ccf69be77cccd54ff1ce351a6aadd1d3437fcb693681b5", size = 140534, upload-time = "2026-06-15T20:32:55.646Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/57/31e6f45c3e236273f9f83f047ae579a90c4be8c6dc1b8366d63a6dcd9841/boto3-1.43.52-py3-none-any.whl", hash = "sha256:1af1950c2b2400267c93d971d588367fc73554e02b4f435a50a5e930a7c93526", size = 140026, upload-time = "2026-07-20T19:31:26.247Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.43.30"
+version = "1.43.52"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/dd/6df8586de6cc036eec2e491b1a65c489c43d9722929aef407c20b7323329/botocore-1.43.30.tar.gz", hash = "sha256:19ed560cb35ae43bf010d37da429a553c07063bf7efea0f2cb53be8a78d3e3d5", size = 15520608, upload-time = "2026-06-15T20:32:45.439Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/18/f6f02b1acea9a7c42571813ad4c3e19460206e67ca99af402b7ae3d7584d/botocore-1.43.52.tar.gz", hash = "sha256:3c25e11796ae6e295f1cc3a7760e808c26c432cd580d6a608f32da24715c389b", size = 15717429, upload-time = "2026-07-20T19:31:17.296Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/b0/9343b5007ad24363c63455facfb0859e9765cf245eebffee8233056b9696/botocore-1.43.30-py3-none-any.whl", hash = "sha256:26b1dded84d89b396180916f56900bd2ab1c0d545a66d1d2c3eeb40f772935b2", size = 15205423, upload-time = "2026-06-15T20:32:40.827Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e8/99f83445500c565e1850b20d510821d1eb635283171573340aa310d478b5/botocore-1.43.52-py3-none-any.whl", hash = "sha256:43715e971b306f86d5918b3b728ec62aae3f4be49e1606058ef1f0b87dcbad9e", size = 15402564, upload-time = "2026-07-20T19:31:13.936Z" },
 ]
 
 [package.optional-dependencies]
@@ -2736,14 +2734,14 @@ wheels = [
 
 [[package]]
 name = "s3transfer"
-version = "0.18.0"
+version = "0.19.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/1f/12417f7f493fc45e1f9fd5d4a9b6c125cf8d2cf3f8ddbdfab3e76406e9d6/s3transfer-0.18.0.tar.gz", hash = "sha256:3760b8b7ec1315da54048b2d626276732bee4300d054d492d4e1d43e20d4ecbd", size = 160560, upload-time = "2026-05-28T19:39:09.124Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/da/4bef7ce7bb989b222aa4785a413896dbec53306dfc59c6ce7d16a7ffbd6a/s3transfer-0.19.1.tar.gz", hash = "sha256:d3d6371dc3f1e5c5427b2b457bcf13bcf87bec334c95aed18642eae61f6926f3", size = 165354, upload-time = "2026-07-10T19:32:04.849Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/58/a58fc997655386daa2e25784e30c288aa3e3819e401f77029ee4899fb55a/s3transfer-0.18.0-py3-none-any.whl", hash = "sha256:239c13b09e65ad0346e1be7348b8a202dcad44ac7ea7c6eb858fc881dce739b6", size = 88572, upload-time = "2026-05-28T19:39:07.999Z" },
+    { url = "https://files.pythonhosted.org/packages/24/23/e84c64ad0e8bc59cd1b2ef98def848deff0ef3456c542afe74d51e9e8c85/s3transfer-0.19.1-py3-none-any.whl", hash = "sha256:d5fd7005ee39307455ad5f310b5ea67f4b1960d7fed5b3671ee50c249de675de", size = 90072, upload-time = "2026-07-10T19:32:03.673Z" },
 ]
 
 [[package]]

--- a/src/agent-core/docker/pyproject.toml
+++ b/src/agent-core/docker/pyproject.toml
@@ -22,4 +22,8 @@ prerelease = "allow"
 # between mcp-proxy-for-aws (needs awscrt==0.31.2 via botocore[crt])
 # and strands-agents[bidi] (needs awscrt~=0.28.2 via aws-sdk-bedrock-runtime).
 # CRT is a performance optimization, not required for correctness.
-override-dependencies = ["botocore>=1.42.86"]
+# Floor must track boto3: boto3/botocore are lockstep-coupled (boto3 1.43.x
+# imports symbols like DocumentModifiedShape from the matching botocore). A
+# lower floor let botocore lock to 1.43.30 while boto3 advanced to 1.43.52,
+# crashing `import boto3` at container startup.
+override-dependencies = ["botocore>=1.43.52"]

--- a/src/agent-core/docker/pyproject.toml
+++ b/src/agent-core/docker/pyproject.toml
@@ -18,6 +18,9 @@ dependencies = [
 [tool.uv]
 package = false
 prerelease = "allow"
+# Wait 7 days before resolving newly published package versions — newly
+# published packages can be malicious or unstable (supply-chain hardening).
+exclude-newer = "7 days"
 # Override: install botocore WITHOUT [crt] extra to avoid awscrt version conflict
 # between mcp-proxy-for-aws (needs awscrt==0.31.2 via botocore[crt])
 # and strands-agents[bidi] (needs awscrt~=0.28.2 via aws-sdk-bedrock-runtime).

--- a/src/agent-core/docker/pyproject.toml
+++ b/src/agent-core/docker/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.13"
 dependencies = [
     "strands-agents[bidi,a2a]==1.41.0",
     "strands-agents-evals==0.1.2",
-    "bedrock-agentcore==1.6.4",
+    "bedrock-agentcore>=1.8",
     "mcp-proxy-for-aws==1.2.0",
     "pydantic==2.12.3",
     "boto3>=1.42.86",

--- a/src/agent-core/docker/pyproject.toml
+++ b/src/agent-core/docker/pyproject.toml
@@ -18,9 +18,6 @@ dependencies = [
 [tool.uv]
 package = false
 prerelease = "allow"
-# Wait 7 days before resolving newly published package versions — newly
-# published packages can be malicious or unstable (supply-chain hardening).
-exclude-newer = "7 days"
 # Override: install botocore WITHOUT [crt] extra to avoid awscrt version conflict
 # between mcp-proxy-for-aws (needs awscrt==0.31.2 via botocore[crt])
 # and strands-agents[bidi] (needs awscrt~=0.28.2 via aws-sdk-bedrock-runtime).

--- a/src/agent-core/docker/src/data_source.py
+++ b/src/agent-core/docker/src/data_source.py
@@ -17,19 +17,22 @@ if TYPE_CHECKING:
 
 
 class AgentConfigurationLoader(BaseConfigurationLoader):
-    """Loader for agent configurations from DynamoDB."""
+    """Loader for agent configurations from a configuration bundle."""
 
     def parse_configuration(self) -> AgentConfiguration:
-        """Parse and return the agent configuration.
+        """Parse the agent configuration sourced from the config bundle.
+
+        Fetches ConfigurationValue via _fetch_config_from_bundle (control plane)
+        and deserializes to AgentConfiguration.
 
         Returns:
             AgentConfiguration: Parsed agent configuration
 
         Raises:
-            ClientError: If DynamoDB query fails
+            ClientError: If the control-plane fetch fails
             ValueError: If configuration not found or invalid
         """
-        configuration_str = self._fetch_item_from_dynamodb(entity_type="agent")
+        configuration_str = self._fetch_config_from_bundle(entity_type="agent")
 
         parsed_cfg = deserialize(configuration_str, AgentConfiguration)
 
@@ -41,7 +44,7 @@ class AgentConfigurationLoader(BaseConfigurationLoader):
 
 
 def parse_configuration(logger: Logger) -> AgentConfiguration:
-    """Parse agent configuration from DynamoDB.
+    """Parse agent configuration from the config bundle.
 
     Args:
         logger (Logger): Logger instance for logging events
@@ -50,7 +53,7 @@ def parse_configuration(logger: Logger) -> AgentConfiguration:
         AgentConfiguration: Parsed agent configuration
 
     Raises:
-        ClientError: If DynamoDB read fails
+        ClientError: If the control-plane fetch fails
         ValueError: If configuration not found or invalid
     """
     loader = AgentConfigurationLoader(logger)

--- a/src/agent-core/docker/tests/conftest.py
+++ b/src/agent-core/docker/tests/conftest.py
@@ -1,0 +1,13 @@
+# ---------------------------------------------------------------------------- #
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# SPDX-License-Identifier: MIT-0
+# ---------------------------------------------------------------------------- #
+"""Pytest configuration for single-agent (docker) tests."""
+
+import sys
+from pathlib import Path
+
+# Add the image root to sys.path so `import src.*` resolves the same way the
+# container does (src/ is copied to the image root).
+sys.path.insert(0, str(Path(__file__).parent.parent))

--- a/src/agent-core/docker/tests/test_data_source.py
+++ b/src/agent-core/docker/tests/test_data_source.py
@@ -1,0 +1,58 @@
+# ---------------------------------------------------------------------------- #
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# SPDX-License-Identifier: MIT-0
+# ---------------------------------------------------------------------------- #
+"""Tests for the single-agent config loader sourcing from a bundle (T2).
+
+Run with:
+    pytest tests/test_data_source.py -v
+"""
+
+import json
+import logging
+from unittest.mock import patch
+
+import pytest
+from botocore.exceptions import ClientError
+from src.data_source import AgentConfigurationLoader
+
+VALID_CONFIG = {
+    "modelInferenceParameters": {
+        "modelId": "us.anthropic.claude-sonnet-4-6",
+        "parameters": {"maxTokens": 4096, "temperature": 0.7},
+    },
+    "instructions": "You are a helpful assistant.",
+    "tools": [],
+    "toolParameters": {},
+    "mcpServers": [],
+}
+
+
+def _make_loader() -> AgentConfigurationLoader:
+    loader = AgentConfigurationLoader.__new__(AgentConfigurationLoader)
+    loader._logger = logging.getLogger("test")
+    return loader
+
+
+def test_parse_configuration_from_bundle():
+    loader = _make_loader()
+    with patch.object(
+        loader, "_fetch_config_from_bundle", return_value=json.dumps(VALID_CONFIG)
+    ) as fetch:
+        cfg = loader.parse_configuration()
+
+    fetch.assert_called_once_with(entity_type="agent")
+    assert cfg.instructions == "You are a helpful assistant."
+    assert cfg.modelInferenceParameters.modelId == "us.anthropic.claude-sonnet-4-6"
+
+
+def test_parse_configuration_propagates_fetch_error():
+    loader = _make_loader()
+    err = ClientError(
+        {"Error": {"Code": "ResourceNotFoundException", "Message": "nope"}},
+        "GetConfigurationBundleVersion",
+    )
+    with patch.object(loader, "_fetch_config_from_bundle", side_effect=err):
+        with pytest.raises(ClientError):
+            loader.parse_configuration()

--- a/src/agent-core/docker/uv.lock
+++ b/src/agent-core/docker/uv.lock
@@ -48,7 +48,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "aws-opentelemetry-distro", specifier = "==0.14.1" },
-    { name = "bedrock-agentcore", specifier = "==1.6.4" },
+    { name = "bedrock-agentcore", specifier = ">=1.8" },
     { name = "boto3", specifier = ">=1.42.86" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "mcp-proxy-for-aws", specifier = "==1.2.0" },
@@ -447,7 +447,7 @@ wheels = [
 
 [[package]]
 name = "bedrock-agentcore"
-version = "1.6.4"
+version = "1.18.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
@@ -459,23 +459,23 @@ dependencies = [
     { name = "uvicorn" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/54/6d/6dfd3e9f05fb3fff256312cf7a9cee11d849281dfd4d32fa7aaf3cea87e9/bedrock_agentcore-1.6.4.tar.gz", hash = "sha256:7b3e12361ca432ab1cada5e191e6f3cfa9536cd5cedafc37058f670b263bdabf", size = 521801, upload-time = "2026-04-23T20:08:25.401Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/e8/8149bb168ef3825884685eb98ef868f5bb5f796e4ea58eb98e8df3248937/bedrock_agentcore-1.18.1.tar.gz", hash = "sha256:ed4aa8822e39aa5846b9d68d1461afee19f2f795c1f6d71a61bc650ecc00ee31", size = 1030729, upload-time = "2026-07-17T19:55:21.354Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/cc/298426f7601172fab91a7c4fe6c0f7a07ecbdaeb2413f1e8dc5d79aacbd7/bedrock_agentcore-1.6.4-py3-none-any.whl", hash = "sha256:a20f76f23cf08f4c081704eeb85c1899340163066b1612458c93963055a5e3dd", size = 168734, upload-time = "2026-04-23T20:08:23.467Z" },
+    { url = "https://files.pythonhosted.org/packages/45/fe/26cc0a66920035d2740c062bd46df252b15708b7723e13ccae0ab7b334db/bedrock_agentcore-1.18.1-py3-none-any.whl", hash = "sha256:6d8001f09cdfca0a20650ea691426149f521037d8d56917057fc191c00801086", size = 450684, upload-time = "2026-07-17T19:55:19.334Z" },
 ]
 
 [[package]]
 name = "boto3"
-version = "1.43.30"
+version = "1.43.52"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/47/2db3e7c1317019d800a1b4181059656842b8aec69ad578ac01a73eba3b89/boto3-1.43.30.tar.gz", hash = "sha256:6b1ee360f363a457f67a8f5702f522043d8a32d67a97c362ad12075d8b5b531e", size = 113154, upload-time = "2026-06-15T20:32:58.123Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/93/5f98e422ced57a359e3b7827ab79b359d67456abb9c5840b0c5eb7b90e6b/boto3-1.43.52.tar.gz", hash = "sha256:3da09a393c050906d407023bee5fb5b5fb333378513af1a1a51159db870b572f", size = 112680, upload-time = "2026-07-20T19:31:28.396Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/61/4031fd64c458ab7e01879e6ac8b42e256e37139df551315beafe04e74b57/boto3-1.43.30-py3-none-any.whl", hash = "sha256:89e982463d94773136ccf69be77cccd54ff1ce351a6aadd1d3437fcb693681b5", size = 140534, upload-time = "2026-06-15T20:32:55.646Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/57/31e6f45c3e236273f9f83f047ae579a90c4be8c6dc1b8366d63a6dcd9841/boto3-1.43.52-py3-none-any.whl", hash = "sha256:1af1950c2b2400267c93d971d588367fc73554e02b4f435a50a5e930a7c93526", size = 140026, upload-time = "2026-07-20T19:31:26.247Z" },
 ]
 
 [[package]]
@@ -3016,14 +3016,14 @@ wheels = [
 
 [[package]]
 name = "s3transfer"
-version = "0.18.0"
+version = "0.19.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/1f/12417f7f493fc45e1f9fd5d4a9b6c125cf8d2cf3f8ddbdfab3e76406e9d6/s3transfer-0.18.0.tar.gz", hash = "sha256:3760b8b7ec1315da54048b2d626276732bee4300d054d492d4e1d43e20d4ecbd", size = 160560, upload-time = "2026-05-28T19:39:09.124Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/da/4bef7ce7bb989b222aa4785a413896dbec53306dfc59c6ce7d16a7ffbd6a/s3transfer-0.19.1.tar.gz", hash = "sha256:d3d6371dc3f1e5c5427b2b457bcf13bcf87bec334c95aed18642eae61f6926f3", size = 165354, upload-time = "2026-07-10T19:32:04.849Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/58/a58fc997655386daa2e25784e30c288aa3e3819e401f77029ee4899fb55a/s3transfer-0.18.0-py3-none-any.whl", hash = "sha256:239c13b09e65ad0346e1be7348b8a202dcad44ac7ea7c6eb858fc881dce739b6", size = 88572, upload-time = "2026-05-28T19:39:07.999Z" },
+    { url = "https://files.pythonhosted.org/packages/24/23/e84c64ad0e8bc59cd1b2ef98def848deff0ef3456c542afe74d51e9e8c85/s3transfer-0.19.1-py3-none-any.whl", hash = "sha256:d5fd7005ee39307455ad5f310b5ea67f4b1960d7fed5b3671ee50c249de675de", size = 90072, upload-time = "2026-07-10T19:32:03.673Z" },
 ]
 
 [[package]]

--- a/src/agent-core/docker/uv.lock
+++ b/src/agent-core/docker/uv.lock
@@ -6,7 +6,7 @@ requires-python = ">=3.13"
 prerelease-mode = "allow"
 
 [manifest]
-overrides = [{ name = "botocore", specifier = ">=1.42.86" }]
+overrides = [{ name = "botocore", specifier = ">=1.43.52" }]
 
 [[package]]
 name = "a2a-sdk"
@@ -480,16 +480,16 @@ wheels = [
 
 [[package]]
 name = "botocore"
-version = "1.43.30"
+version = "1.43.53"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/dd/6df8586de6cc036eec2e491b1a65c489c43d9722929aef407c20b7323329/botocore-1.43.30.tar.gz", hash = "sha256:19ed560cb35ae43bf010d37da429a553c07063bf7efea0f2cb53be8a78d3e3d5", size = 15520608, upload-time = "2026-06-15T20:32:45.439Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/6b/ebcefacc4de3cd4f1c449540d86877f76c2f5e586a620831012decbb2b2c/botocore-1.43.53.tar.gz", hash = "sha256:36d93dd8db68ee75f6b61ca9f775161b8168844e4601698701530e6efdded141", size = 15720336, upload-time = "2026-07-21T19:28:41.547Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/b0/9343b5007ad24363c63455facfb0859e9765cf245eebffee8233056b9696/botocore-1.43.30-py3-none-any.whl", hash = "sha256:26b1dded84d89b396180916f56900bd2ab1c0d545a66d1d2c3eeb40f772935b2", size = 15205423, upload-time = "2026-06-15T20:32:40.827Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/e5/1b60e394f0fff97ee70dd16913382b7dffda85b98e639c0c9e8ff56cfaa7/botocore-1.43.53-py3-none-any.whl", hash = "sha256:b7ee9a70d187e5348883c820990ccd9436ab14e2bd6622741fc96fe561e816b8", size = 15404628, upload-time = "2026-07-21T19:28:37.475Z" },
 ]
 
 [[package]]

--- a/src/agent-core/functions/seeder/index.py
+++ b/src/agent-core/functions/seeder/index.py
@@ -6,7 +6,9 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING
+import re
+import uuid
+from typing import TYPE_CHECKING, Optional
 
 import boto3
 from aws_lambda_powertools import Logger, Tracer
@@ -22,14 +24,17 @@ logger = Logger(service="agentcore-seeder")
 # ---------------------------------------------------------- #
 
 # -------------------- Env Variables ----------------------- #
-CFG_TABLE_NAME = os.environ["CFG_TABLE_NAME"]
 DASHBOARD_TABLE_NAME = os.environ["DASHBOARD_TABLE_NAME"]
 # ---------------------------------------------------------- #
 
 # --------------- Boto3 Clients/Resource ------------------- #
-CFG_TABLE = boto3.resource("dynamodb").Table(CFG_TABLE_NAME)  # type: ignore
 DASHBOARD_TABLE = boto3.resource("dynamodb").Table(DASHBOARD_TABLE_NAME)  # type: ignore
+BAC_CLIENT = boto3.client("bedrock-agentcore-control")
 # ---------------------------------------------------------- #
+
+# Bundle names must match ^[a-zA-Z][a-zA-Z0-9_]{0,99}$ before AWS appends its
+# random suffix — so the sanitized prefix is capped at 100 chars.
+BUNDLE_NAME_MAX = 100
 
 
 class ItemValues(BaseModel):
@@ -81,21 +86,60 @@ def handler(event: dict, _: LambdaContext) -> dict:
 
     if request_type in ["Create", "Update"]:
         try:
-            CFG_TABLE.put_item(Item=item.model_dump())
+            existing = DASHBOARD_TABLE.get_item(Key={"AgentName": item.AgentName}).get(
+                "Item"
+            )
+
+            # Idempotency: CloudFormation only re-invokes the seeder when the
+            # CustomResource properties change (createdAt is derived from the
+            # config hash), so an unchanged config normally never reaches here.
+            # Guard anyway — if the stored ConfigHash matches, skip creating a
+            # redundant bundle version.
+            if existing and existing.get("ConfigHash") == props.configHash:
+                logger.info(
+                    "Config hash unchanged - skipping bundle version",
+                    extra={
+                        "agentName": item.AgentName,
+                        "configHash": props.configHash,
+                    },
+                )
+                return _response(physical_id, item)
+
+            # Version an existing bundle, or create a new one (ADR-0002).
+            bundle_id = existing.get("BundleId") if existing else None
+            parent_version_id = (
+                existing.get("QualifierToVersion", {}).get("DEFAULT")
+                if existing
+                else None
+            )
+            new_bundle_id, bundle_arn, version_id = _put_config_bundle(
+                item.AgentName,
+                item.ConfigurationValue,
+                bundle_id,
+                parent_version_id,
+            )
             logger.info(
-                "Successfully seeded agent configuration",
-                extra={"agentName": item.AgentName, "createdAt": item.CreatedAt},
+                "Successfully seeded agent configuration bundle",
+                extra={
+                    "agentName": item.AgentName,
+                    "bundleId": new_bundle_id,
+                    "versionId": version_id,
+                },
             )
             _update_dashboard(
                 item.AgentName,
-                item.AgentRuntimeVersion,
+                version_id,
                 item.AgentRuntimeId,
                 item.AgentRuntimeArn,
+                new_bundle_id,
+                bundle_arn,
+                props.configHash,
+                existing is not None,
             )
         except ClientError as err:
             logger.error(
                 "Failed to seed agent configuration",
-                extra={"error": str(err), "item": item},
+                extra={"error": str(err), "agentName": item.AgentName},
             )
             raise
 
@@ -107,6 +151,10 @@ def handler(event: dict, _: LambdaContext) -> dict:
             extra={"agentName": item.AgentName},
         )
 
+    return _response(physical_id, item)
+
+
+def _response(physical_id: str, item: ItemValues) -> dict:
     return {
         "PhysicalResourceId": physical_id,
         "Data": {
@@ -116,23 +164,90 @@ def handler(event: dict, _: LambdaContext) -> dict:
     }
 
 
-def _update_dashboard(agent_name: str, version: str, runtime_id: str, runtime_arn: str):
-    existing = DASHBOARD_TABLE.get_item(Key={"AgentName": agent_name})
-    if "Item" in existing:
+def sanitize_bundle_name(agent_name: str) -> str:
+    """Map an agent name to a valid bundle-name prefix: ``[a-zA-Z][a-zA-Z0-9_]{0,99}``.
+
+    Mirrors ``put-config-bundle`` (T4) — see ``src/api/functions/put-config-bundle``.
+    Kept as a local copy because the seeder and that Lambda are separate
+    deployment packages with no shared import path.
+    """
+    sanitized = re.sub(r"[^a-zA-Z0-9_]", "_", agent_name)
+    if not sanitized or not sanitized[0].isalpha():
+        sanitized = f"a_{sanitized}"
+    return sanitized[:BUNDLE_NAME_MAX]
+
+
+def _put_config_bundle(
+    agent_name: str,
+    configuration_value: str,
+    bundle_id: Optional[str],
+    parent_version_id: Optional[str],
+) -> tuple[str, str, str]:
+    """Create-or-version the default agent's configuration bundle.
+
+    Mirrors the ``put-config-bundle`` Lambda (T4): create when ``bundle_id`` is
+    None, else update with ``parentVersionIds=[parent_version_id]``. Returns
+    ``(bundleId, bundleArn, versionId)``.
+    """
+    components = {
+        agent_name: {"configuration": {"ConfigurationValue": configuration_value}}
+    }
+    api_args = {
+        "components": components,
+        "clientToken": str(uuid.uuid4()),  # idempotency for at-least-once retries
+        "commitMessage": "Seeded by CDK deploy",
+    }
+    if bundle_id:
+        api_args["bundleId"] = bundle_id
+        if parent_version_id:
+            api_args["parentVersionIds"] = [parent_version_id]
+        response = BAC_CLIENT.update_configuration_bundle(**api_args)
+    else:
+        api_args["bundleName"] = sanitize_bundle_name(agent_name)
+        response = BAC_CLIENT.create_configuration_bundle(**api_args)
+
+    return response["bundleId"], response["bundleArn"], response["versionId"]
+
+
+def _update_dashboard(
+    agent_name: str,
+    version_id: str,
+    runtime_id: str,
+    runtime_arn: str,
+    bundle_id: str,
+    bundle_arn: str,
+    config_hash: str,
+    exists: bool,
+):
+    """Write the summary row with bundle identity. No runtime-config-table write."""
+    if exists:
         DASHBOARD_TABLE.update_item(
             Key={"AgentName": agent_name},
-            UpdateExpression="ADD NumberOfVersions :inc SET QualifierToVersion.#default = :ver",
+            UpdateExpression=(
+                "ADD NumberOfVersions :inc "
+                "SET QualifierToVersion.#default = :ver, "
+                "BundleId = :bid, BundleArn = :barn, ConfigHash = :hash"
+            ),
             ExpressionAttributeNames={"#default": "DEFAULT"},
-            ExpressionAttributeValues={":inc": 1, ":ver": version},
+            ExpressionAttributeValues={
+                ":inc": 1,
+                ":ver": version_id,
+                ":bid": bundle_id,
+                ":barn": bundle_arn,
+                ":hash": config_hash,
+            },
         )
     else:
         DASHBOARD_TABLE.put_item(
             Item={
                 "AgentName": agent_name,
                 "NumberOfVersions": 1,
-                "QualifierToVersion": {"DEFAULT": version},
+                "QualifierToVersion": {"DEFAULT": version_id},
                 "AgentRuntimeArn": runtime_arn,
                 "AgentRuntimeId": runtime_id,
+                "BundleId": bundle_id,
+                "BundleArn": bundle_arn,
+                "ConfigHash": config_hash,
                 "Status": "Ready",
             }
         )

--- a/src/agent-core/functions/seeder/tests/conftest.py
+++ b/src/agent-core/functions/seeder/tests/conftest.py
@@ -1,0 +1,23 @@
+# ---------------------------------------------------------------------------- #
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# SPDX-License-Identifier: MIT-0
+# ---------------------------------------------------------------------------- #
+"""Pytest configuration for the agentcore seeder tests."""
+
+import os
+import sys
+from pathlib import Path
+
+# Disable Powertools tracing so tests don't require the aws_xray_sdk provider,
+# which is present in the Lambda runtime but not the local dev env.
+os.environ.setdefault("POWERTOOLS_TRACE_DISABLED", "1")
+
+# Env vars the seeder reads at import time. Set before `import index` so the
+# module loads (and builds its boto3 resources) without a KeyError.
+os.environ.setdefault("DASHBOARD_TABLE_NAME", "dashboard-table")
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+
+# Add the function root so `import index` resolves the module under test the
+# same way the Lambda runtime does (handler = index.handler).
+sys.path.insert(0, str(Path(__file__).parent.parent))

--- a/src/agent-core/functions/seeder/tests/test_index.py
+++ b/src/agent-core/functions/seeder/tests/test_index.py
@@ -1,0 +1,146 @@
+# ---------------------------------------------------------------------------- #
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# SPDX-License-Identifier: MIT-0
+# ---------------------------------------------------------------------------- #
+"""Unit tests for the agentcore seeder config-bundle write path."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import index
+import pytest
+
+CONFIG_JSON = '{"systemPrompt": "hi", "modelId": "anthropic.claude-x"}'
+
+# Minimal Lambda context for @logger.inject_lambda_context.
+LAMBDA_CTX = SimpleNamespace(
+    function_name="seeder",
+    memory_limit_in_mb=128,
+    invoked_function_arn="arn:aws:lambda:us-east-1:1:function:seeder",
+    aws_request_id="req-1",
+)
+
+
+def _event(request_type: str = "Create", config_hash: str = "hash-1") -> dict:
+    return {
+        "RequestType": request_type,
+        "ResourceProperties": {
+            "item": json.dumps(
+                {
+                    "AgentName": "default-agent",
+                    "CreatedAt": 123,
+                    "AgentRuntimeArn": "arn:aws:bedrock-agentcore:us-east-1:1:runtime/r",
+                    "AgentRuntimeId": "r-1",
+                    "AgentRuntimeVersion": "1",
+                    "ConfigurationValue": CONFIG_JSON,
+                }
+            ),
+            "configHash": config_hash,
+        },
+    }
+
+
+@pytest.fixture
+def clients(monkeypatch):
+    """Replace the module-level DynamoDB table and control-plane client."""
+    table = MagicMock()
+    bac = MagicMock()
+    monkeypatch.setattr(index, "DASHBOARD_TABLE", table)
+    monkeypatch.setattr(index, "BAC_CLIENT", bac)
+    return table, bac
+
+
+def test_create_path_new_agent(clients):
+    table, bac = clients
+    # No prior summary row → create a new bundle.
+    table.get_item.return_value = {}
+    bac.create_configuration_bundle.return_value = {
+        "bundleId": "bundle-1",
+        "bundleArn": "arn:aws:bedrock-agentcore:us-east-1:1:bundle/bundle-1",
+        "versionId": "v1",
+    }
+
+    index.handler(_event(), LAMBDA_CTX)
+
+    bac.create_configuration_bundle.assert_called_once()
+    bac.update_configuration_bundle.assert_not_called()
+    kwargs = bac.create_configuration_bundle.call_args.kwargs
+    assert kwargs["bundleName"] == "default_agent"  # hyphen -> underscore
+    assert kwargs["components"] == {
+        "default-agent": {"configuration": {"ConfigurationValue": CONFIG_JSON}}
+    }
+
+    # New agent → put_item with bundle fields, no runtime-config-table write.
+    table.put_item.assert_called_once()
+    item = table.put_item.call_args.kwargs["Item"]
+    assert item["BundleId"] == "bundle-1"
+    assert item["BundleArn"] == "arn:aws:bedrock-agentcore:us-east-1:1:bundle/bundle-1"
+    assert item["QualifierToVersion"] == {"DEFAULT": "v1"}
+    assert item["ConfigHash"] == "hash-1"
+
+
+def test_update_path_existing_agent_versions_bundle(clients):
+    table, bac = clients
+    # Prior row exists with a different hash and an existing bundle.
+    table.get_item.return_value = {
+        "Item": {
+            "BundleId": "bundle-1",
+            "QualifierToVersion": {"DEFAULT": "v1"},
+            "ConfigHash": "old-hash",
+        }
+    }
+    bac.update_configuration_bundle.return_value = {
+        "bundleId": "bundle-1",
+        "bundleArn": "arn:aws:bedrock-agentcore:us-east-1:1:bundle/bundle-1",
+        "versionId": "v2",
+    }
+
+    index.handler(_event(request_type="Update", config_hash="new-hash"), LAMBDA_CTX)
+
+    bac.update_configuration_bundle.assert_called_once()
+    bac.create_configuration_bundle.assert_not_called()
+    kwargs = bac.update_configuration_bundle.call_args.kwargs
+    assert kwargs["bundleId"] == "bundle-1"
+    assert kwargs["parentVersionIds"] == ["v1"]  # parent chained
+
+    # Existing agent → update_item advancing QualifierToVersion + bundle fields.
+    table.update_item.assert_called_once()
+    values = table.update_item.call_args.kwargs["ExpressionAttributeValues"]
+    assert values[":ver"] == "v2"
+    assert values[":bid"] == "bundle-1"
+    assert values[":hash"] == "new-hash"
+
+
+def test_idempotent_unchanged_hash_skips_bundle(clients):
+    table, bac = clients
+    # Prior row with the SAME hash as the incoming event → no-op.
+    table.get_item.return_value = {"Item": {"ConfigHash": "hash-1", "BundleId": "b1"}}
+
+    index.handler(_event(config_hash="hash-1"), LAMBDA_CTX)
+
+    bac.create_configuration_bundle.assert_not_called()
+    bac.update_configuration_bundle.assert_not_called()
+    table.put_item.assert_not_called()
+    table.update_item.assert_not_called()
+
+
+def test_delete_is_noop(clients):
+    table, bac = clients
+    index.handler(_event(request_type="Delete"), LAMBDA_CTX)
+    bac.create_configuration_bundle.assert_not_called()
+    bac.update_configuration_bundle.assert_not_called()
+    table.get_item.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("default-agent", "default_agent"),
+        ("123agent", "a_123agent"),
+        ("valid_Name1", "valid_Name1"),
+    ],
+)
+def test_sanitize_bundle_name(raw, expected):
+    assert index.sanitize_bundle_name(raw) == expected

--- a/src/agent-core/shared/base_data_source.py
+++ b/src/agent-core/shared/base_data_source.py
@@ -143,6 +143,88 @@ class BaseConfigurationLoader:
 
         return configuration_str
 
+    def _fetch_config_from_bundle(
+        self,
+        bundle_id: str | None = None,
+        bundle_version: str | None = None,
+        component_key: str | None = None,
+        entity_type: str = "agent",
+    ) -> str:
+        """Fetch the ConfigurationValue JSON string from a configuration bundle version.
+
+        Reads via the control plane (no Gateway/baggage — see ADR-0001):
+        `bedrock-agentcore-control.get_configuration_bundle_version(bundleId, versionId)`,
+        then returns `components[component_key]["configuration"]["ConfigurationValue"]`.
+
+        Args:
+            bundle_id (str | None): Bundle id. If None, reads the `BUNDLE_ID` env var.
+            bundle_version (str | None): Immutable version id. If None, reads the
+                `BUNDLE_VERSION` env var.
+            component_key (str | None): Stable component key (agent id). If None, reads
+                the `agentName` env var (ADR-0002).
+            entity_type (str): Type of entity being loaded (for error messages).
+                Defaults to "agent".
+
+        Returns:
+            str: The ConfigurationValue JSON string (same shape as the old DynamoDB field).
+
+        Raises:
+            ClientError: If the control-plane call fails.
+            ValueError: If the component/key is missing or has no ConfigurationValue.
+        """
+        if bundle_id is None:
+            bundle_id = os.environ["BUNDLE_ID"]
+        if bundle_version is None:
+            bundle_version = os.environ["BUNDLE_VERSION"]
+        if component_key is None:
+            component_key = os.environ["agentName"]
+
+        self._logger.info(
+            f"Fetching {entity_type} configuration value from configuration bundle",
+            extra={
+                "bundleId": bundle_id,
+                "bundleVersion": bundle_version,
+                "componentKey": component_key,
+            },
+        )
+
+        client = boto3.client(
+            "bedrock-agentcore-control", region_name=os.environ.get("AWS_REGION")
+        )
+
+        try:
+            response = client.get_configuration_bundle_version(
+                bundleId=bundle_id,
+                versionId=bundle_version,
+            )
+        except ClientError as err:
+            self._logger.error(
+                "Error reading configuration bundle version",
+                extra={"rawErrorMessage": str(err)},
+            )
+            raise
+
+        components = response.get("components") or {}
+        component = components.get(component_key)
+        if component is None:
+            err_message = (
+                f"Configuration bundle {bundle_id} version {bundle_version} has no "
+                f"component for {entity_type} {component_key}"
+            )
+            self._logger.error(err_message)
+            raise ValueError(err_message)
+
+        configuration_str = component.get("configuration", {}).get("ConfigurationValue")
+        if configuration_str is None:
+            err_message = (
+                f"Component {component_key} in bundle {bundle_id} version "
+                f"{bundle_version} has no ConfigurationValue"
+            )
+            self._logger.error(err_message)
+            raise ValueError(err_message)
+
+        return configuration_str
+
     def parse_configuration(self) -> Any:
         """Parse and return the configuration object.
 

--- a/src/agent-core/shared/base_data_source.py
+++ b/src/agent-core/shared/base_data_source.py
@@ -20,44 +20,31 @@ T = TypeVar("T")
 
 
 class BaseConfigurationLoader:
-    """Base class for loading agent/swarm configurations from DynamoDB.
+    """Base class for loading agent/swarm configurations.
 
-    This class provides common functionality for fetching configuration data
-    from DynamoDB tables, including table initialization, error handling,
-    and validation. Subclasses should override parse_configuration() to
-    deserialize to their specific configuration type.
+    Provides the control-plane bundle-fetch path (``_fetch_config_from_bundle``)
+    shared by all container loaders (ADR-0001), plus a lazy DynamoDB table
+    helper (``_get_lazy_table``) for subclasses that still need an auxiliary
+    table (e.g. the swarm summary table). Subclasses override
+    parse_configuration() to deserialize to their specific configuration type.
 
     Attributes:
         _logger (Logger): Logger instance for recording operations
-        _table (Table): DynamoDB table resource for configuration storage
     """
 
-    def __init__(self, logger: Logger, table_name_env_var: str = "tableName"):
+    def __init__(self, logger: Logger):
         """Initialize the configuration loader.
+
+        Agent config is now read from AgentCore configuration bundles via the
+        control plane (see ADR-0001), so the loader no longer eagerly binds a
+        DynamoDB config table at construction. Subclasses that still need a
+        DynamoDB table for auxiliary lookups (e.g. the swarm summary table) do
+        so lazily via ``_get_lazy_table``.
 
         Args:
             logger (Logger): Logger instance for recording operations
-            table_name_env_var (str): Environment variable containing the table name.
-                Defaults to "tableName".
         """
         self._logger = logger
-        self._table = self._get_table(table_name_env_var)
-
-    def _get_table(self, table_name_env_var: str):
-        """Get DynamoDB table resource.
-
-        Args:
-            table_name_env_var (str): Environment variable containing table name
-
-        Returns:
-            Table: DynamoDB table resource
-
-        Raises:
-            KeyError: If environment variable not found
-        """
-        table_name = os.environ[table_name_env_var]
-        dynamodb = boto3.resource("dynamodb", region_name=os.environ.get("AWS_REGION"))
-        return dynamodb.Table(table_name)  # type: ignore
 
     def _get_lazy_table(self, table_name_env_var: str, cache_attr: str):
         """Get DynamoDB table with lazy initialization and caching.
@@ -83,65 +70,6 @@ class BaseConfigurationLoader:
             )
             setattr(self, cache_attr, dynamodb.Table(table_name))  # type: ignore
         return getattr(self, cache_attr)
-
-    def _fetch_item_from_dynamodb(
-        self,
-        agent_name: str | None = None,
-        created_at: int | None = None,
-        entity_type: str = "agent",
-    ) -> str:
-        """Fetch configuration string from DynamoDB.
-
-        Args:
-            agent_name (str | None): Agent name. If None, reads from 'agentName' env var.
-            created_at (int | None): Creation timestamp. If None, reads from 'createdAt' env var.
-            entity_type (str): Type of entity being loaded (for error messages). Defaults to "agent".
-
-        Returns:
-            str: The configuration string from ConfigurationValue field
-
-        Raises:
-            ClientError: If DynamoDB query fails
-            ValueError: If item not found or has no configuration
-        """
-        if agent_name is None:
-            agent_name = os.environ["agentName"]
-        if created_at is None:
-            created_at = int(os.environ["createdAt"])
-
-        self._logger.info(
-            f"Fetching {entity_type} configuration value from DynamoDb",
-            extra={"compositeKey": {"AgentName": agent_name, "CreatedAt": created_at}},
-        )
-
-        try:
-            response = self._table.get_item(
-                Key={
-                    "AgentName": agent_name,
-                    "CreatedAt": created_at,
-                }
-            )
-        except ClientError as err:
-            self._logger.error(
-                "Error reading from dynamoDB table", extra={"rawErrorMessage": str(err)}
-            )
-            raise
-
-        if "Item" not in response:
-            err_message = f"Did not find a match for {entity_type} {agent_name} created at {created_at}"
-            self._logger.error(err_message)
-            raise ValueError(err_message)
-
-        item = response["Item"]
-        configuration_str = item.get("ConfigurationValue")
-
-        if configuration_str is None:
-            err_message = (
-                f"The item {agent_name} created at {created_at} has no configuration"
-            )
-            raise ValueError(err_message)
-
-        return configuration_str
 
     def _fetch_config_from_bundle(
         self,

--- a/src/agent-core/shared/tests/test_base_data_source.py
+++ b/src/agent-core/shared/tests/test_base_data_source.py
@@ -1,0 +1,119 @@
+# ---------------------------------------------------------------------------- #
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# SPDX-License-Identifier: MIT-0
+# ---------------------------------------------------------------------------- #
+"""Tests for the shared BaseConfigurationLoader bundle-fetch path (T1).
+
+Run with:
+    pytest shared/tests/test_base_data_source.py -v
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+from shared.base_data_source import BaseConfigurationLoader
+
+
+def _make_loader() -> BaseConfigurationLoader:
+    """Build a loader without touching DynamoDB in __init__."""
+    loader = BaseConfigurationLoader.__new__(BaseConfigurationLoader)
+    loader._logger = logging.getLogger("test")
+    return loader
+
+
+def _bundle_response(config_value: str) -> dict:
+    return {
+        "bundleId": "agent-abc123",
+        "versionId": "v1",
+        "components": {
+            "my-agent": {"configuration": {"ConfigurationValue": config_value}}
+        },
+    }
+
+
+def test_fetch_config_from_bundle_returns_configuration_value():
+    client = MagicMock()
+    client.get_configuration_bundle_version.return_value = _bundle_response('{"k": 1}')
+
+    loader = _make_loader()
+    with patch("shared.base_data_source.boto3.client", return_value=client):
+        result = loader._fetch_config_from_bundle(
+            bundle_id="agent-abc123",
+            bundle_version="v1",
+            component_key="my-agent",
+        )
+
+    assert result == '{"k": 1}'
+    client.get_configuration_bundle_version.assert_called_once_with(
+        bundleId="agent-abc123", versionId="v1"
+    )
+
+
+def test_fetch_config_from_bundle_reads_env_vars(monkeypatch):
+    monkeypatch.setenv("BUNDLE_ID", "agent-abc123")
+    monkeypatch.setenv("BUNDLE_VERSION", "v1")
+    monkeypatch.setenv("agentName", "my-agent")
+
+    client = MagicMock()
+    client.get_configuration_bundle_version.return_value = _bundle_response('{"k": 2}')
+
+    loader = _make_loader()
+    with patch("shared.base_data_source.boto3.client", return_value=client):
+        result = loader._fetch_config_from_bundle()
+
+    assert result == '{"k": 2}'
+    client.get_configuration_bundle_version.assert_called_once_with(
+        bundleId="agent-abc123", versionId="v1"
+    )
+
+
+def test_fetch_config_from_bundle_missing_component_raises():
+    client = MagicMock()
+    client.get_configuration_bundle_version.return_value = _bundle_response('{"k": 1}')
+
+    loader = _make_loader()
+    with patch("shared.base_data_source.boto3.client", return_value=client):
+        with pytest.raises(ValueError, match="has no component"):
+            loader._fetch_config_from_bundle(
+                bundle_id="agent-abc123",
+                bundle_version="v1",
+                component_key="does-not-exist",
+            )
+
+
+def test_fetch_config_from_bundle_missing_configuration_value_raises():
+    client = MagicMock()
+    client.get_configuration_bundle_version.return_value = {
+        "components": {"my-agent": {"configuration": {}}}
+    }
+
+    loader = _make_loader()
+    with patch("shared.base_data_source.boto3.client", return_value=client):
+        with pytest.raises(ValueError, match="no ConfigurationValue"):
+            loader._fetch_config_from_bundle(
+                bundle_id="agent-abc123",
+                bundle_version="v1",
+                component_key="my-agent",
+            )
+
+
+def test_fetch_config_from_bundle_propagates_client_error():
+    client = MagicMock()
+    client.get_configuration_bundle_version.side_effect = ClientError(
+        {"Error": {"Code": "ResourceNotFoundException", "Message": "nope"}},
+        "GetConfigurationBundleVersion",
+    )
+
+    loader = _make_loader()
+    with patch("shared.base_data_source.boto3.client", return_value=client):
+        with pytest.raises(ClientError):
+            loader._fetch_config_from_bundle(
+                bundle_id="agent-abc123",
+                bundle_version="v1",
+                component_key="my-agent",
+            )

--- a/src/api/functions/agent-factory-resolver/index.py
+++ b/src/api/functions/agent-factory-resolver/index.py
@@ -272,14 +272,13 @@ def _fetch_config_from_bundle(agent_name: str, bundle_id: str, version_id: str) 
 
 @app.resolver(type_name="Query", field_name="getRuntimeConfigurationByVersion")
 def get_runtime_cfg_by_version(agentName: str, agentVersion: str) -> str:
-    """Retrieves agent runtime configuration for a specific version.
+    """Retrieves agent runtime configuration for a specific bundle version.
 
     Config now lives in AgentCore configuration bundles (the runtime config table
-    was removed in the bundles migration). Only the version currently mapped by a
-    qualifier in the summary row is resolvable — the summary's QualifierToVersion
-    stores bundle versionIds, so we serve `agentVersion` only if it matches a
-    mapped versionId. Historical (pre-bundle) versions are not available and
-    return "".
+    was removed in the bundles migration). `agentVersion` is a bundle versionId;
+    any version of the agent's own bundle is resolvable (list them with
+    `listAgentBundleVersions`), so the UI can inspect historical config, not only
+    the qualifier-mapped current version.
 
     Args:
         agentName (str): Name of the agent
@@ -307,14 +306,11 @@ def get_runtime_cfg_by_version(agentName: str, agentVersion: str) -> str:
     if not bundle_id:
         logger.error(f"Agent {agentName} has no BundleId")
         return ""
-    # Serve only if the requested version is a known bundle version for this agent
-    # (the mapped DEFAULT/qualifier versionIds). Guards against arbitrary lookups.
-    known_versions = set((row.get("QualifierToVersion") or {}).values())
-    if agentVersion not in known_versions:
-        logger.error(
-            f"Version {agentVersion} is not a mapped bundle version for {agentName}"
-        )
-        return ""
+    # The bundleId comes from this agent's own summary row, so every version of
+    # that bundle belongs to this agent — serving any of them (not just the
+    # qualifier-mapped ones) lets the UI inspect historical config while staying
+    # scoped to the agent. A wrong/foreign versionId simply 404s at the control
+    # plane and returns "".
     return _fetch_config_from_bundle(agentName, bundle_id, agentVersion)
 
 
@@ -436,6 +432,80 @@ def list_agent_versions(agentRuntimeId: str) -> list[str]:
         BAC_CLIENT.list_agent_runtime_versions,
         root_key="agentRuntimes",
     )
+
+
+@app.resolver(type_name="Query", field_name="listAgentBundleVersions")
+def list_agent_bundle_versions(agentName: str) -> list[dict]:
+    """Lists every version of an agent's configuration bundle, newest first.
+
+    Reads the agent's BundleId + current QualifierToVersion from the summary row,
+    then enumerates the bundle's immutable version history via the control plane
+    (`list_configuration_bundle_versions`). Each entry is annotated with the
+    qualifiers (DEFAULT, BACKUP, …) currently pointing at it, so the UI can label
+    versions meaningfully instead of showing bare UUIDs. Returns [] on any miss.
+
+    Args:
+        agentName (str): Name of the agent.
+
+    Returns:
+        list[dict]: BundleVersion dicts (versionId, createdAt, commitMessage,
+        qualifiers), sorted newest-first.
+    """
+    try:
+        response = SUMMARY_TABLE.query(
+            KeyConditionExpression="AgentName = :agent",
+            ExpressionAttributeValues={":agent": agentName},
+        )
+    except ClientError as err:
+        logger.error(
+            "Failed to query summary table", extra={"rawErrorMessage": str(err)}
+        )
+        return []
+    items = response.get("Items", [])
+    if not items:
+        logger.error(f"Agent {agentName} not found")
+        return []
+    row = items[0]
+    bundle_id = row.get("BundleId")
+    if not bundle_id:
+        logger.error(f"Agent {agentName} has no BundleId")
+        return []
+
+    # Invert QualifierToVersion so each versionId knows which qualifiers point at it.
+    version_to_qualifiers: dict[str, list[str]] = {}
+    for qualifier, version_id in (row.get("QualifierToVersion") or {}).items():
+        version_to_qualifiers.setdefault(version_id, []).append(qualifier)
+
+    versions: list[dict] = []
+    try:
+        paginator = BAC_CLIENT.get_paginator("list_configuration_bundle_versions")
+        for page in paginator.paginate(bundleId=bundle_id):
+            for v in page.get("versions", []):
+                version_id = v.get("versionId")
+                if not version_id:
+                    continue
+                created_at = v.get("versionCreatedAt")
+                lineage = v.get("lineageMetadata") or {}
+                versions.append(
+                    {
+                        "versionId": version_id,
+                        "createdAt": created_at.isoformat()
+                        if hasattr(created_at, "isoformat")
+                        else (str(created_at) if created_at else None),
+                        "commitMessage": lineage.get("commitMessage"),
+                        "qualifiers": version_to_qualifiers.get(version_id, []),
+                    }
+                )
+    except ClientError as err:
+        logger.error(
+            "Failed to list configuration bundle versions",
+            extra={"rawErrorMessage": str(err), "bundleId": bundle_id},
+        )
+        return []
+
+    # Newest first — createdAt is ISO-8601 so lexical sort matches chronological.
+    versions.sort(key=lambda v: v.get("createdAt") or "", reverse=True)
+    return versions
 
 
 @app.resolver(type_name="Query", field_name="listAgentEndpoints")

--- a/src/api/functions/agent-factory-resolver/index.py
+++ b/src/api/functions/agent-factory-resolver/index.py
@@ -13,7 +13,6 @@ import boto3
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import AppSyncResolver
 from aws_lambda_powertools.logging import correlation_paths
-from boto3.dynamodb.conditions import Key
 from botocore.exceptions import ClientError
 from genai_core.api_helper.types import (
     AgentConfiguration,
@@ -40,7 +39,6 @@ CONTAINER_URI = os.environ["CONTAINER_URI"]
 AGENT_CORE_RUNTIME_ROLE_ARN = os.environ["AGENT_CORE_RUNTIME_ROLE_ARN"]
 ENVIRONMENT_TAG = os.environ.get("ENVIRONMENT_TAG")
 STACK_TAG = os.environ.get("STACK_TAG", "aca")
-AGENT_CORE_RUNTIME_TABLE = os.environ["AGENT_CORE_RUNTIME_TABLE"]
 AGENT_CORE_SUMMARY_TABLE = os.environ["AGENT_CORE_SUMMARY_TABLE"]
 TOOL_REGISTRY_TABLE = os.environ["TOOL_REGISTRY_TABLE"]
 MCP_SERVER_REGISTRY_TABLE = os.environ["MCP_SERVER_REGISTRY_TABLE"]
@@ -51,7 +49,6 @@ EVENT_EXPIRE_DAYS = int(os.environ.get("EVENT_EXPIRE_DAYS", "90"))
 # --------------- Boto3 Clients/Resource ------------------- #
 BAC_CLIENT = boto3.client("bedrock-agentcore-control")
 SFN_CLIENT = boto3.client("stepfunctions")
-TABLE = boto3.resource("dynamodb").Table(AGENT_CORE_RUNTIME_TABLE)  # type: ignore
 SUMMARY_TABLE = boto3.resource("dynamodb").Table(AGENT_CORE_SUMMARY_TABLE)  # type: ignore
 # ---------------------------------------------------------- #
 
@@ -247,30 +244,78 @@ def list_runtime_agents() -> list[dict]:
     ]
 
 
+def _fetch_config_from_bundle(agent_name: str, bundle_id: str, version_id: str) -> str:
+    """Fetch a component's ConfigurationValue JSON from a configuration bundle version.
+
+    Reads via the control plane (ADR-0001):
+    `get_configuration_bundle_version(bundleId, versionId)`, then returns
+    `components[<agentName>].configuration.ConfigurationValue` — the component is
+    keyed by the stable agent id (ADR-0002). Mirrors the container-side loader
+    (`src/agent-core/shared/base_data_source.py::_fetch_config_from_bundle`).
+
+    Returns "" (not an error) when the bundle/component/value is missing, so the
+    GraphQL config-read queries degrade gracefully in the UI.
+    """
+    try:
+        response = BAC_CLIENT.get_configuration_bundle_version(
+            bundleId=bundle_id, versionId=version_id
+        )
+    except ClientError as err:
+        logger.error(
+            "Failed to read configuration bundle version",
+            extra={"rawErrorMessage": str(err), "bundleId": bundle_id},
+        )
+        return ""
+    component = (response.get("components") or {}).get(agent_name) or {}
+    return component.get("configuration", {}).get("ConfigurationValue", "") or ""
+
+
 @app.resolver(type_name="Query", field_name="getRuntimeConfigurationByVersion")
 def get_runtime_cfg_by_version(agentName: str, agentVersion: str) -> str:
     """Retrieves agent runtime configuration for a specific version.
 
+    Config now lives in AgentCore configuration bundles (the runtime config table
+    was removed in the bundles migration). Only the version currently mapped by a
+    qualifier in the summary row is resolvable — the summary's QualifierToVersion
+    stores bundle versionIds, so we serve `agentVersion` only if it matches a
+    mapped versionId. Historical (pre-bundle) versions are not available and
+    return "".
+
     Args:
         agentName (str): Name of the agent
-        agentVersion (str): Version of the agent runtime
+        agentVersion (str): Bundle versionId of the configuration
 
     Returns:
-        str: JSON configuration string for the specified agent version, empty string if not found
+        str: JSON configuration string, or "" if not found/available.
     """
     try:
-        response = TABLE.query(
-            IndexName="byAgentNameAndVersion",
-            KeyConditionExpression=Key("AgentName").eq(agentName)
-            & Key("AgentRuntimeVersion").eq(agentVersion),
+        response = SUMMARY_TABLE.query(
+            KeyConditionExpression="AgentName = :agent",
+            ExpressionAttributeValues={":agent": agentName},
         )
-        items = response.get("Items", [])
-        return items[0].get("ConfigurationValue", "") if items else ""
     except ClientError as err:
         logger.error(
-            "Failed to query runtime configuration", extra={"rawErrorMessage": str(err)}
+            "Failed to query summary table", extra={"rawErrorMessage": str(err)}
         )
         return ""
+    items = response.get("Items", [])
+    if not items:
+        logger.error(f"Agent {agentName} not found")
+        return ""
+    row = items[0]
+    bundle_id = row.get("BundleId")
+    if not bundle_id:
+        logger.error(f"Agent {agentName} has no BundleId")
+        return ""
+    # Serve only if the requested version is a known bundle version for this agent
+    # (the mapped DEFAULT/qualifier versionIds). Guards against arbitrary lookups.
+    known_versions = set((row.get("QualifierToVersion") or {}).values())
+    if agentVersion not in known_versions:
+        logger.error(
+            f"Version {agentVersion} is not a mapped bundle version for {agentName}"
+        )
+        return ""
+    return _fetch_config_from_bundle(agentName, bundle_id, agentVersion)
 
 
 @app.resolver(type_name="Query", field_name="getRuntimeConfigurationByQualifier")
@@ -531,7 +576,8 @@ def _get_runtime_cfg_by_qualifier_impl(agentName: str, qualifier: str) -> str:
         if not items:
             logger.error(f"Agent {agentName} not found")
             return ""
-        qualifier_to_version = items[0].get("QualifierToVersion", {})
+        row = items[0]
+        qualifier_to_version = row.get("QualifierToVersion", {})
 
         logger.info(
             "Retrieved object that map qualifiers to versions",
@@ -542,13 +588,15 @@ def _get_runtime_cfg_by_qualifier_impl(agentName: str, qualifier: str) -> str:
             logger.error(f"Agent {agentName} has no qualifier {qualifier}")
             return ""
 
-        response = TABLE.query(
-            IndexName="byAgentNameAndVersion",
-            KeyConditionExpression=Key("AgentName").eq(agentName)
-            & Key("AgentRuntimeVersion").eq(str(qualifier_to_version[qualifier])),
-        )
-        items = response.get("Items", [])
-        return items[0].get("ConfigurationValue", "") if items else ""
+        bundle_id = row.get("BundleId")
+        if not bundle_id:
+            logger.error(f"Agent {agentName} has no BundleId")
+            return ""
+
+        # QualifierToVersion now stores the bundle versionId for each qualifier;
+        # fetch that version's config from the bundle (control plane, ADR-0001).
+        version_id = str(qualifier_to_version[qualifier])
+        return _fetch_config_from_bundle(agentName, bundle_id, version_id)
     except ClientError as err:
         logger.error(
             "Failed to query runtime configuration", extra={"rawErrorMessage": str(err)}

--- a/src/api/functions/create-runtime-version/index.py
+++ b/src/api/functions/create-runtime-version/index.py
@@ -29,11 +29,9 @@ SWARM_CONTAINER_URI = os.environ.get("SWARM_CONTAINER_URI", "")
 GRAPH_CONTAINER_URI = os.environ.get("GRAPH_CONTAINER_URI", "")
 AGENTS_AS_TOOLS_CONTAINER_URI = os.environ.get("AGENTS_AS_TOOLS_CONTAINER_URI", "")
 AGENT_CORE_RUNTIME_ROLE_ARN = os.environ["AGENT_CORE_RUNTIME_ROLE_ARN"]
-AGENT_CORE_RUNTIME_TABLE = os.environ["AGENT_CORE_RUNTIME_TABLE"]
 TOOL_REGISTRY_TABLE = os.environ["TOOL_REGISTRY_TABLE"]
 MCP_SERVER_REGISTRY_TABLE = os.environ["MCP_SERVER_REGISTRY_TABLE"]
 ACCOUNT_ID = os.environ["ACCOUNT_ID"]
-AGENTS_TABLE_NAME = os.environ.get("AGENTS_TABLE_NAME", "")
 AGENTS_SUMMARY_TABLE_NAME = os.environ.get("AGENTS_SUMMARY_TABLE_NAME", "")
 BEDROCK_ACCESS_ROLE_ARN = os.environ.get("BEDROCK_ACCESS_ROLE_ARN", "")
 SKILLS_BUCKET_NAME = os.environ.get("SKILLS_BUCKET_NAME", "")
@@ -249,7 +247,6 @@ def handler(event: InputModel, _) -> dict:
         "networkConfiguration": {"networkMode": "PUBLIC"},
         "roleArn": AGENT_CORE_RUNTIME_ROLE_ARN,
         "environmentVariables": {
-            "tableName": AGENT_CORE_RUNTIME_TABLE,
             "toolRegistry": TOOL_REGISTRY_TABLE,
             "mcpServerRegistry": MCP_SERVER_REGISTRY_TABLE,
             # `agentName` keeps the user-facing name even on the A2A twin so
@@ -272,12 +269,15 @@ def handler(event: InputModel, _) -> dict:
         api_args["protocolConfiguration"] = {"serverProtocol": SERVER_PROTOCOL_A2A}
 
     if is_swarm or is_graph or is_agents_as_tools:
-        if not AGENTS_TABLE_NAME or not AGENTS_SUMMARY_TABLE_NAME:
+        # Orchestrators resolve referenced sub-agents via the summary table
+        # (QualifierToVersion → bundle versionId + the A2A twin ARN); each
+        # sub-agent's config is then read from its own bundle. The old
+        # per-version config table (agentsTableName) is gone.
+        if not AGENTS_SUMMARY_TABLE_NAME:
             arch_type = event.architectureType
-            err_msg = f"AGENTS_TABLE_NAME and AGENTS_SUMMARY_TABLE_NAME environment variables must be set for {arch_type} architecture"
+            err_msg = f"AGENTS_SUMMARY_TABLE_NAME environment variable must be set for {arch_type} architecture"
             logger.error(err_msg)
             raise ValueError(err_msg)
-        api_args["environmentVariables"]["agentsTableName"] = AGENTS_TABLE_NAME
         api_args["environmentVariables"][
             "agentsSummaryTableName"
         ] = AGENTS_SUMMARY_TABLE_NAME

--- a/src/api/functions/create-runtime-version/index.py
+++ b/src/api/functions/create-runtime-version/index.py
@@ -62,11 +62,17 @@ class InputModel(BaseModel):
     protocol: str = SERVER_PROTOCOL_HTTP
     # Caller-supplied creation timestamp. The SFN mints this once before the
     # parallel HTTP/A2A branch and passes it into both Lambda invocations so
-    # both containers inject the same `createdAt` env var — matching the
-    # partition key under which the agent config row is saved. Without this,
-    # each branch called `int(time.time())` independently and drifted by a
-    # few seconds, leaving the A2A twin unable to load its config at startup.
+    # both twins share a single version timestamp; it is still returned in the
+    # response Body (summary bookkeeping) but is no longer injected as a
+    # container env var — config is now keyed by the bundle, not by createdAt.
     createdAt: Optional[int] = None
+    # Configuration-bundle pointers (ADR-0002). The SFN creates/versions the
+    # bundle before runtime creation and passes these so the container reads
+    # its config via get_configuration_bundle_version(BUNDLE_ID, BUNDLE_VERSION).
+    # Both the HTTP runtime and the A2A twin get the same values — they read
+    # the same component.
+    bundleId: str
+    versionId: str
 
 
 class Body(BaseModel):
@@ -248,9 +254,14 @@ def handler(event: InputModel, _) -> dict:
             "mcpServerRegistry": MCP_SERVER_REGISTRY_TABLE,
             # `agentName` keeps the user-facing name even on the A2A twin so
             # observability (logs / SNS tool events) attributes work to the
-            # logical agent rather than the synthetic twin name.
+            # logical agent rather than the synthetic twin name. It is also the
+            # bundle component key (ADR-0002), so the container reads the same
+            # component on both the HTTP runtime and the A2A twin.
             "agentName": event.agentName,
-            "createdAt": str(created_at),
+            # Read-path pointers: the container fetches its config via
+            # get_configuration_bundle_version(BUNDLE_ID, BUNDLE_VERSION).
+            "BUNDLE_ID": event.bundleId,
+            "BUNDLE_VERSION": event.versionId,
             "accountId": ACCOUNT_ID,
             "sessionsTableName": os.environ.get("SESSIONS_TABLE_NAME", ""),
             "agentcoreServerProtocol": event.protocol,

--- a/src/api/functions/create-runtime-version/tests/conftest.py
+++ b/src/api/functions/create-runtime-version/tests/conftest.py
@@ -1,0 +1,35 @@
+# ---------------------------------------------------------------------------- #
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# SPDX-License-Identifier: MIT-0
+# ---------------------------------------------------------------------------- #
+"""Pytest configuration for the create-runtime-version Lambda tests."""
+
+import os
+import sys
+from pathlib import Path
+
+# Disable Powertools tracing so tests don't require the aws_xray_sdk provider,
+# which is present in the Lambda runtime but not the local dev env.
+os.environ.setdefault("POWERTOOLS_TRACE_DISABLED", "1")
+
+# Module-level env vars the Lambda reads at import time. Set them before
+# `import index` so the module loads without a KeyError.
+os.environ.setdefault(
+    "CONTAINER_URI", "123.dkr.ecr.us-east-1.amazonaws.com/single:latest"
+)
+os.environ.setdefault(
+    "AGENT_CORE_RUNTIME_ROLE_ARN", "arn:aws:iam::123456789012:role/runtime"
+)
+os.environ.setdefault("AGENT_CORE_RUNTIME_TABLE", "runtime-table")
+os.environ.setdefault("TOOL_REGISTRY_TABLE", "tool-registry")
+os.environ.setdefault("MCP_SERVER_REGISTRY_TABLE", "mcp-registry")
+os.environ.setdefault("ACCOUNT_ID", "123456789012")
+
+_FUNCTION_ROOT = Path(__file__).parent.parent
+# Add the function root so `import index` resolves the module under test the
+# same way the Lambda runtime does (handler = index.handler).
+sys.path.insert(0, str(_FUNCTION_ROOT))
+# The genai_core package is vendored into the function dir at build time (empty
+# in the repo); point at the shared python-sdk layer so imports resolve locally.
+sys.path.insert(0, str(_FUNCTION_ROOT.parents[2] / "shared" / "layers" / "python-sdk"))

--- a/src/api/functions/create-runtime-version/tests/conftest.py
+++ b/src/api/functions/create-runtime-version/tests/conftest.py
@@ -21,7 +21,6 @@ os.environ.setdefault(
 os.environ.setdefault(
     "AGENT_CORE_RUNTIME_ROLE_ARN", "arn:aws:iam::123456789012:role/runtime"
 )
-os.environ.setdefault("AGENT_CORE_RUNTIME_TABLE", "runtime-table")
 os.environ.setdefault("TOOL_REGISTRY_TABLE", "tool-registry")
 os.environ.setdefault("MCP_SERVER_REGISTRY_TABLE", "mcp-registry")
 os.environ.setdefault("ACCOUNT_ID", "123456789012")

--- a/src/api/functions/create-runtime-version/tests/test_index.py
+++ b/src/api/functions/create-runtime-version/tests/test_index.py
@@ -1,0 +1,77 @@
+# ---------------------------------------------------------------------------- #
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# SPDX-License-Identifier: MIT-0
+# ---------------------------------------------------------------------------- #
+"""Unit tests for the create-runtime-version Lambda config-bundle env wiring."""
+
+from unittest.mock import MagicMock
+
+import index
+import pytest
+
+BASE_EVENT = {
+    "agentName": "my-agent",
+    "agentCfg": {"systemPrompt": "hi", "useMemory": False},
+    "bundleId": "bundle-123",
+    "versionId": "v1",
+}
+
+
+@pytest.fixture
+def bac_client(monkeypatch):
+    """Replace the module-level control-plane client with a MagicMock.
+
+    A brand-new runtime is simulated: list returns no match (create path), and
+    create returns version '1'.
+    """
+    client = MagicMock()
+    client.list_agent_runtimes.return_value = {"agentRuntimes": [], "nextToken": None}
+    client.create_agent_runtime.return_value = {
+        "agentRuntimeArn": "arn:aws:bedrock-agentcore:us-east-1:123:runtime/r-1",
+        "agentRuntimeId": "r-1",
+        "agentRuntimeVersion": "1",
+    }
+    monkeypatch.setattr(index, "BAC_CLIENT", client)
+    return client
+
+
+def _env_of_last_create(client) -> dict:
+    """Return the environmentVariables map from the create call."""
+    return client.create_agent_runtime.call_args.kwargs["environmentVariables"]
+
+
+def test_http_env_has_bundle_pointers(bac_client):
+    index.handler({**BASE_EVENT, "protocol": "HTTP"}, None)
+
+    env = _env_of_last_create(bac_client)
+    assert env["BUNDLE_ID"] == "bundle-123"
+    assert env["BUNDLE_VERSION"] == "v1"
+    # agentName stays — it is the bundle component key (ADR-0002).
+    assert env["agentName"] == "my-agent"
+    # createdAt is no longer a container env var (config keyed by bundle).
+    assert "createdAt" not in env
+
+
+def test_a2a_env_has_bundle_pointers(bac_client):
+    index.handler({**BASE_EVENT, "protocol": "A2A"}, None)
+
+    env = _env_of_last_create(bac_client)
+    assert env["BUNDLE_ID"] == "bundle-123"
+    assert env["BUNDLE_VERSION"] == "v1"
+    assert env["agentName"] == "my-agent"
+    assert "createdAt" not in env
+
+
+def test_created_at_still_returned_in_body(bac_client):
+    """createdAt is dropped from container env but still surfaced for the SFN."""
+    result = index.handler({**BASE_EVENT, "protocol": "HTTP", "createdAt": 42}, None)
+    assert result["body"]["createdAt"] == 42
+
+
+def test_bundle_id_is_required(bac_client):
+    """The input model now requires bundleId/versionId (supplied by the SFN)."""
+    with pytest.raises(Exception):
+        index.handler(
+            {"agentName": "my-agent", "agentCfg": {}, "protocol": "HTTP"}, None
+        )

--- a/src/api/functions/delete-agent-runtime-references/index.py
+++ b/src/api/functions/delete-agent-runtime-references/index.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: MIT-0
 # ---------------------------------------------------------------------------- #
-import os
+from typing import Optional
 
 import boto3
 from aws_lambda_powertools import Logger, Tracer
@@ -11,24 +11,26 @@ from aws_lambda_powertools.utilities.parser import BaseModel, event_parser
 from botocore.exceptions import ClientError
 
 # ------------------- Lambda Powertools -------------------- #
-tracer = Tracer(service="deleteAgentVersions")
-logger = Logger(service="deleteAgentVersions")
+tracer = Tracer(service="deleteAgentBundle")
+logger = Logger(service="deleteAgentBundle")
 # ---------------------------------------------------------- #
 
 # --------------- Boto3 Clients/Resource ------------------- #
-DYNAMODB = boto3.resource("dynamodb")
-VERSIONS_TABLE_NAME = os.environ["VERSIONS_TABLE_NAME"]
-VERSIONS_TABLE = DYNAMODB.Table(VERSIONS_TABLE_NAME)  # type: ignore
+BAC_CLIENT = boto3.client("bedrock-agentcore-control")
 # ---------------------------------------------------------- #
 
 
 class InputModel(BaseModel):
     agentName: str
+    # Supplied by the delete SFN, read from the summary row *before* it is
+    # deleted (the summary row is gone by the time this Lambda runs). Optional
+    # so pre-bundles agents (no BundleId recorded) resolve to a clean no-op.
+    bundleId: Optional[str] = None
 
 
 class Body(BaseModel):
     message: str
-    deletedCount: int = 0
+    deletedBundleId: Optional[str] = None
 
 
 class OutputModel(BaseModel):
@@ -39,67 +41,64 @@ class OutputModel(BaseModel):
 @event_parser(model=InputModel)
 @tracer.capture_lambda_handler
 def handler(event: InputModel, _) -> dict:
-    """Delete all version items for a given AgentName from DynamoDB.
+    """Delete the agent's AgentCore configuration bundle by its stored bundleId.
 
-    This function queries the versions table for all items with the specified
-    AgentName (partition key) and deletes them in batches.
+    The delete state machine reads ``BundleId`` from the summary row and passes
+    it in, then deletes the summary row itself; this Lambda calls
+    ``bedrock-agentcore-control.delete_configuration_bundle`` which removes the
+    bundle and all its (immutable) versions. An already-absent bundle is treated
+    as success so retries and partial-failure re-runs are idempotent.
 
     Args:
-        event: InputModel containing agentName
-        _: Lambda context (unused)
+        event: InputModel containing agentName and (optionally) bundleId.
+        _: Lambda context (unused).
 
     Returns:
-        dict: Response with status code, message, and count of deleted items
+        dict: Response with status code, message, and the deleted bundleId.
     """
+    if not event.bundleId:
+        # Nothing recorded (e.g. an agent created before config bundles) — no
+        # bundle to orphan, so this is a successful no-op.
+        msg = f"No bundleId for agent {event.agentName}; nothing to delete"
+        logger.info(msg)
+        output = OutputModel(status=200, body=Body(message=msg))
+        return output.model_dump()
+
     try:
-        # Query all items with the specified AgentName
-        response = VERSIONS_TABLE.query(
-            KeyConditionExpression="AgentName = :agent_name",
-            ExpressionAttributeValues={":agent_name": event.agentName},
-            ProjectionExpression="AgentName, CreatedAt",
+        BAC_CLIENT.delete_configuration_bundle(bundleId=event.bundleId)
+        msg = (
+            f"Deleted configuration bundle {event.bundleId} "
+            f"for agent {event.agentName}"
         )
-
-        items = response.get("Items", [])
-        deleted_count = 0
-
-        # Handle pagination if there are more items
-        while "LastEvaluatedKey" in response:
-            response = VERSIONS_TABLE.query(
-                KeyConditionExpression="AgentName = :agent_name",
-                ExpressionAttributeValues={":agent_name": event.agentName},
-                ProjectionExpression="AgentName, CreatedAt",
-                ExclusiveStartKey=response["LastEvaluatedKey"],
-            )
-            items.extend(response.get("Items", []))
-
-        logger.info(
-            f"Found {len(items)} version items to delete for agent {event.agentName}"
-        )
-
-        # Batch delete items (DynamoDB allows up to 25 items per batch)
-        if items:
-            with VERSIONS_TABLE.batch_writer() as batch:
-                for item in items:
-                    batch.delete_item(
-                        Key={
-                            "AgentName": item["AgentName"],
-                            "CreatedAt": item["CreatedAt"],
-                        }
-                    )
-                    deleted_count += 1
-
-        msg = f"Successfully deleted {deleted_count} version items for agent {event.agentName}"
         logger.info(msg)
         output = OutputModel(
-            status=200, body=Body(message=msg, deletedCount=deleted_count)
+            status=200, body=Body(message=msg, deletedBundleId=event.bundleId)
         )
 
     except ClientError as err:
-        msg = f"Failed to delete version items for agent {event.agentName}"
-        output = OutputModel(status=400, body=Body(message=msg))
-        logger.error(msg, extra={"rawErrorMessage": str(err)})
+        error_code = err.response.get("Error", {}).get("Code", "")
+        if error_code == "ResourceNotFoundException":
+            # Already gone — idempotent success.
+            msg = (
+                f"Configuration bundle {event.bundleId} already absent "
+                f"for agent {event.agentName}; treating as deleted"
+            )
+            logger.info(msg)
+            output = OutputModel(
+                status=200, body=Body(message=msg, deletedBundleId=event.bundleId)
+            )
+        else:
+            msg = (
+                f"Failed to delete configuration bundle {event.bundleId} "
+                f"for agent {event.agentName}"
+            )
+            output = OutputModel(status=400, body=Body(message=msg))
+            logger.error(msg, extra={"rawErrorMessage": str(err)})
     except Exception as err:
-        msg = f"Unexpected error deleting version items for agent {event.agentName}"
+        msg = (
+            f"Unexpected error deleting configuration bundle "
+            f"for agent {event.agentName}"
+        )
         output = OutputModel(status=500, body=Body(message=msg))
         logger.error(msg, extra={"rawErrorMessage": str(err)})
 

--- a/src/api/functions/delete-agent-runtime-references/tests/conftest.py
+++ b/src/api/functions/delete-agent-runtime-references/tests/conftest.py
@@ -1,0 +1,18 @@
+# ---------------------------------------------------------------------------- #
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# SPDX-License-Identifier: MIT-0
+# ---------------------------------------------------------------------------- #
+"""Pytest configuration for the delete-agent-runtime-references Lambda tests."""
+
+import os
+import sys
+from pathlib import Path
+
+# Disable Powertools tracing so tests don't require the aws_xray_sdk provider,
+# which is present in the Lambda runtime but not the local dev env.
+os.environ.setdefault("POWERTOOLS_TRACE_DISABLED", "1")
+
+# Add the function root to sys.path so `import index` resolves the module under
+# test the same way the Lambda runtime does (handler = index.handler).
+sys.path.insert(0, str(Path(__file__).parent.parent))

--- a/src/api/functions/delete-agent-runtime-references/tests/test_index.py
+++ b/src/api/functions/delete-agent-runtime-references/tests/test_index.py
@@ -1,0 +1,82 @@
+# ---------------------------------------------------------------------------- #
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# SPDX-License-Identifier: MIT-0
+# ---------------------------------------------------------------------------- #
+"""Unit tests for the delete-agent-runtime-references config-bundle delete path."""
+
+from unittest.mock import MagicMock
+
+import index
+import pytest
+from botocore.exceptions import ClientError
+
+
+@pytest.fixture
+def bac(monkeypatch):
+    """Replace the module-level control-plane client with a mock."""
+    mock = MagicMock()
+    monkeypatch.setattr(index, "BAC_CLIENT", mock)
+    return mock
+
+
+def test_deletes_bundle_by_id(bac):
+    bac.delete_configuration_bundle.return_value = {
+        "bundleId": "bundle-1",
+        "status": "DELETING",
+    }
+
+    result = index.handler({"agentName": "my-agent", "bundleId": "bundle-1"}, None)
+
+    bac.delete_configuration_bundle.assert_called_once_with(bundleId="bundle-1")
+    assert result["status"] == 200
+    assert result["body"]["deletedBundleId"] == "bundle-1"
+
+
+def test_missing_bundle_is_idempotent_success(bac):
+    bac.delete_configuration_bundle.side_effect = ClientError(
+        {"Error": {"Code": "ResourceNotFoundException", "Message": "gone"}},
+        "DeleteConfigurationBundle",
+    )
+
+    result = index.handler({"agentName": "my-agent", "bundleId": "bundle-1"}, None)
+
+    bac.delete_configuration_bundle.assert_called_once_with(bundleId="bundle-1")
+    assert result["status"] == 200
+    assert result["body"]["deletedBundleId"] == "bundle-1"
+
+
+def test_no_bundle_id_is_noop(bac):
+    result = index.handler({"agentName": "legacy-agent"}, None)
+
+    bac.delete_configuration_bundle.assert_not_called()
+    assert result["status"] == 200
+    assert result["body"]["deletedBundleId"] is None
+
+
+def test_empty_bundle_id_is_noop(bac):
+    # The SFN passes '' when the summary row carries no BundleId.
+    result = index.handler({"agentName": "legacy-agent", "bundleId": ""}, None)
+
+    bac.delete_configuration_bundle.assert_not_called()
+    assert result["status"] == 200
+
+
+def test_other_client_error_returns_400(bac):
+    bac.delete_configuration_bundle.side_effect = ClientError(
+        {"Error": {"Code": "ConflictException", "Message": "busy"}},
+        "DeleteConfigurationBundle",
+    )
+
+    result = index.handler({"agentName": "my-agent", "bundleId": "bundle-1"}, None)
+
+    assert result["status"] == 400
+    assert result["body"]["deletedBundleId"] is None
+
+
+def test_unexpected_error_returns_500(bac):
+    bac.delete_configuration_bundle.side_effect = RuntimeError("boom")
+
+    result = index.handler({"agentName": "my-agent", "bundleId": "bundle-1"}, None)
+
+    assert result["status"] == 500

--- a/src/api/functions/put-config-bundle/index.py
+++ b/src/api/functions/put-config-bundle/index.py
@@ -1,0 +1,143 @@
+# ---------------------------------------------------------------------------- #
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# SPDX-License-Identifier: MIT-0
+# ---------------------------------------------------------------------------- #
+"""Single write-path primitive for AgentCore configuration bundles.
+
+Given an agent id and its full ``AgentConfiguration`` JSON, this Lambda either
+creates a new bundle (first version) or appends an immutable version to an
+existing bundle (chained via ``parentVersionIds``). It returns the identifiers
+the caller (SFN in T5, seeder in T7) persists into ``agentCoreSummaryTable`` —
+this handler is pure control-plane and never writes DynamoDB.
+
+Keying uses a single stable component id — the agent name, not the runtime ARN —
+because the ARN does not exist yet when the bundle is first created (ADR-0002).
+"""
+
+import re
+import uuid
+from typing import Optional
+
+import boto3
+from aws_lambda_powertools import Logger, Tracer
+from aws_lambda_powertools.utilities.parser import BaseModel, event_parser
+from botocore.exceptions import ClientError
+
+# ------------------- Lambda Powertools -------------------- #
+tracer = Tracer(service="graphQL-putConfigBundle")
+logger = Logger(service="graphQL-putConfigBundle")
+# ---------------------------------------------------------- #
+
+# --------------- Boto3 Clients/Resource ------------------- #
+BAC_CLIENT = boto3.client("bedrock-agentcore-control")
+# ---------------------------------------------------------- #
+
+# Bundle names must match ^[a-zA-Z][a-zA-Z0-9_]{0,99}$ before AWS appends its
+# random suffix — so the sanitized prefix is capped at 100 chars.
+BUNDLE_NAME_MAX = 100
+
+
+class PutConfigBundleInput(BaseModel):
+    """Input to create-or-version a bundle for one agent."""
+
+    agentName: str  # stable component key + name-prefix source (ADR-0002)
+    configurationValue: str  # full AgentConfiguration JSON, single-blob (design §6)
+    bundleId: Optional[str] = None  # None -> create new bundle; set -> add a version
+    parentVersionId: Optional[str] = None  # required when bundleId set
+    commitMessage: Optional[str] = None
+
+
+class PutConfigBundleOutput(BaseModel):
+    """Identifiers persisted by the caller into agentCoreSummaryTable."""
+
+    bundleId: str
+    bundleArn: str
+    versionId: str  # new immutable version -> QualifierToVersion[DEFAULT]
+
+
+def sanitize_bundle_name(agent_name: str) -> str:
+    """Map an agent name to a valid bundle-name prefix: ``[a-zA-Z][a-zA-Z0-9_]{0,99}``.
+
+    Hyphens (and any other disallowed char) become underscores, a leading letter
+    is guaranteed, and the result is truncated to the max length. AWS appends a
+    random suffix, so this prefix need not be globally unique (ADR-0002).
+    """
+    # Collapse every disallowed character to an underscore.
+    sanitized = re.sub(r"[^a-zA-Z0-9_]", "_", agent_name)
+    # Bundle names must start with a letter — prefix one when they don't.
+    if not sanitized or not sanitized[0].isalpha():
+        sanitized = f"a_{sanitized}"
+    return sanitized[:BUNDLE_NAME_MAX]
+
+
+@event_parser(model=PutConfigBundleInput)
+@tracer.capture_lambda_handler
+def handler(event: PutConfigBundleInput, _) -> dict:
+    """Create a bundle (no ``bundleId``) or a new version (``bundleId`` + parent).
+
+    The entire ``AgentConfiguration`` JSON is stored single-blob under one
+    ``ConfigurationValue`` key, matching the container-side read path (T1).
+
+    Args:
+        event: Parsed :class:`PutConfigBundleInput`.
+        _: Lambda context (unused).
+
+    Raises:
+        ValueError: If ``bundleId`` is set without ``parentVersionId``.
+        ClientError: If the control-plane call fails.
+
+    Returns:
+        dict: A :class:`PutConfigBundleOutput` dump with the new bundle/version ids.
+    """
+    components = {
+        event.agentName: {
+            "configuration": {"ConfigurationValue": event.configurationValue}
+        }
+    }
+
+    api_args = {
+        "components": components,
+        "clientToken": str(uuid.uuid4()),  # idempotency for at-least-once retries
+    }
+    if event.commitMessage:
+        api_args["commitMessage"] = event.commitMessage
+
+    if event.bundleId:
+        # Update path: chain a new immutable version onto the existing bundle.
+        if not event.parentVersionId:
+            err_msg = "parentVersionId is required when bundleId is set"
+            logger.error(err_msg)
+            raise ValueError(err_msg)
+        api_args["bundleId"] = event.bundleId
+        api_args["parentVersionIds"] = [event.parentVersionId]
+        api_func = BAC_CLIENT.update_configuration_bundle
+        logger.info(
+            "Adding a new version to configuration bundle",
+            extra={"bundleId": event.bundleId, "agentName": event.agentName},
+        )
+    else:
+        # Create path: first version of a brand-new bundle.
+        api_args["bundleName"] = sanitize_bundle_name(event.agentName)
+        api_func = BAC_CLIENT.create_configuration_bundle
+        logger.info(
+            "Creating a new configuration bundle",
+            extra={"bundleName": api_args["bundleName"], "agentName": event.agentName},
+        )
+
+    try:
+        response = api_func(**api_args)
+    except ClientError as err:
+        logger.error(
+            "Failed to put configuration bundle", extra={"rawErrorMessage": str(err)}
+        )
+        logger.exception(err)
+        raise err
+
+    output = PutConfigBundleOutput(
+        bundleId=response["bundleId"],
+        bundleArn=response["bundleArn"],
+        versionId=response["versionId"],
+    )
+    logger.info("Configuration bundle written", extra={"metadata": output.model_dump()})
+    return output.model_dump()

--- a/src/api/functions/put-config-bundle/index.py
+++ b/src/api/functions/put-config-bundle/index.py
@@ -111,6 +111,12 @@ def handler(event: PutConfigBundleInput, _) -> dict:
             raise ValueError(err_msg)
         api_args["bundleId"] = event.bundleId
         api_args["parentVersionIds"] = [event.parentVersionId]
+        # UpdateConfigurationBundle rejects component updates without a
+        # commitMessage; the create SFN doesn't supply one, so default it here
+        # rather than fail every agent re-submit/modify.
+        api_args.setdefault(
+            "commitMessage", f"Update configuration for agent {event.agentName}"
+        )
         api_func = BAC_CLIENT.update_configuration_bundle
         logger.info(
             "Adding a new version to configuration bundle",

--- a/src/api/functions/put-config-bundle/tests/conftest.py
+++ b/src/api/functions/put-config-bundle/tests/conftest.py
@@ -1,0 +1,18 @@
+# ---------------------------------------------------------------------------- #
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# SPDX-License-Identifier: MIT-0
+# ---------------------------------------------------------------------------- #
+"""Pytest configuration for the put-config-bundle Lambda tests."""
+
+import os
+import sys
+from pathlib import Path
+
+# Disable Powertools tracing so tests don't require the aws_xray_sdk provider,
+# which is present in the Lambda runtime but not the local dev env.
+os.environ.setdefault("POWERTOOLS_TRACE_DISABLED", "1")
+
+# Add the function root to sys.path so `import index` resolves the module under
+# test the same way the Lambda runtime does (handler = index.handler).
+sys.path.insert(0, str(Path(__file__).parent.parent))

--- a/src/api/functions/put-config-bundle/tests/test_index.py
+++ b/src/api/functions/put-config-bundle/tests/test_index.py
@@ -83,6 +83,32 @@ def test_update_path_passes_parent_version_ids(bac_client):
     assert "bundleName" not in kwargs
 
 
+def test_update_path_defaults_commit_message_when_absent(bac_client):
+    # UpdateConfigurationBundle rejects component updates without a
+    # commitMessage; the create SFN doesn't pass one, so the handler must
+    # default it rather than let the update fail.
+    bac_client.update_configuration_bundle.return_value = {
+        "bundleId": "bundle-123",
+        "bundleArn": "arn:aws:bedrock-agentcore:us-east-1:1234:bundle/bundle-123",
+        "versionId": "v2",
+        "updatedAt": "2026-07-21T00:00:00Z",
+    }
+
+    index.handler(
+        {
+            "agentName": "my-agent",
+            "configurationValue": CONFIG_JSON,
+            "bundleId": "bundle-123",
+            "parentVersionId": "v1",
+        },
+        None,
+    )
+
+    kwargs = bac_client.update_configuration_bundle.call_args.kwargs
+    assert kwargs["commitMessage"]  # non-empty default supplied
+    assert "my-agent" in kwargs["commitMessage"]
+
+
 def test_update_without_parent_version_raises(bac_client):
     with pytest.raises(ValueError, match="parentVersionId is required"):
         index.handler(

--- a/src/api/functions/put-config-bundle/tests/test_index.py
+++ b/src/api/functions/put-config-bundle/tests/test_index.py
@@ -1,0 +1,127 @@
+# ---------------------------------------------------------------------------- #
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# SPDX-License-Identifier: MIT-0
+# ---------------------------------------------------------------------------- #
+"""Unit tests for the put-config-bundle Lambda (mocked control plane)."""
+
+from unittest.mock import MagicMock
+
+import index
+import pytest
+from botocore.exceptions import ClientError
+
+CONFIG_JSON = '{"systemPrompt": "hi", "modelId": "anthropic.claude-x"}'
+
+
+@pytest.fixture
+def bac_client(monkeypatch):
+    """Replace the module-level control-plane client with a MagicMock."""
+    client = MagicMock()
+    monkeypatch.setattr(index, "BAC_CLIENT", client)
+    return client
+
+
+def test_create_path_returns_new_bundle_ids(bac_client):
+    bac_client.create_configuration_bundle.return_value = {
+        "bundleId": "bundle-123",
+        "bundleArn": "arn:aws:bedrock-agentcore:us-east-1:1234:bundle/bundle-123",
+        "versionId": "v1",
+        "createdAt": "2026-07-21T00:00:00Z",
+    }
+
+    result = index.handler(
+        {"agentName": "my-agent", "configurationValue": CONFIG_JSON}, None
+    )
+
+    assert result == {
+        "bundleId": "bundle-123",
+        "bundleArn": "arn:aws:bedrock-agentcore:us-east-1:1234:bundle/bundle-123",
+        "versionId": "v1",
+    }
+    # Create is used (no bundleId), update is not.
+    bac_client.create_configuration_bundle.assert_called_once()
+    bac_client.update_configuration_bundle.assert_not_called()
+
+    kwargs = bac_client.create_configuration_bundle.call_args.kwargs
+    # Sanitized name (hyphen -> underscore) and single-blob component.
+    assert kwargs["bundleName"] == "my_agent"
+    assert kwargs["components"] == {
+        "my-agent": {"configuration": {"ConfigurationValue": CONFIG_JSON}}
+    }
+    assert "clientToken" in kwargs  # idempotency token present
+
+
+def test_update_path_passes_parent_version_ids(bac_client):
+    bac_client.update_configuration_bundle.return_value = {
+        "bundleId": "bundle-123",
+        "bundleArn": "arn:aws:bedrock-agentcore:us-east-1:1234:bundle/bundle-123",
+        "versionId": "v2",
+        "updatedAt": "2026-07-21T00:00:00Z",
+    }
+
+    result = index.handler(
+        {
+            "agentName": "my-agent",
+            "configurationValue": CONFIG_JSON,
+            "bundleId": "bundle-123",
+            "parentVersionId": "v1",
+            "commitMessage": "bump",
+        },
+        None,
+    )
+
+    assert result["versionId"] == "v2"
+    bac_client.update_configuration_bundle.assert_called_once()
+    bac_client.create_configuration_bundle.assert_not_called()
+
+    kwargs = bac_client.update_configuration_bundle.call_args.kwargs
+    assert kwargs["bundleId"] == "bundle-123"
+    assert kwargs["parentVersionIds"] == ["v1"]
+    assert kwargs["commitMessage"] == "bump"
+    # Update path must not send a bundleName.
+    assert "bundleName" not in kwargs
+
+
+def test_update_without_parent_version_raises(bac_client):
+    with pytest.raises(ValueError, match="parentVersionId is required"):
+        index.handler(
+            {
+                "agentName": "my-agent",
+                "configurationValue": CONFIG_JSON,
+                "bundleId": "bundle-123",
+            },
+            None,
+        )
+    bac_client.update_configuration_bundle.assert_not_called()
+
+
+def test_client_error_propagates(bac_client):
+    bac_client.create_configuration_bundle.side_effect = ClientError(
+        {"Error": {"Code": "ValidationException", "Message": "bad"}},
+        "CreateConfigurationBundle",
+    )
+    with pytest.raises(ClientError):
+        index.handler(
+            {"agentName": "my-agent", "configurationValue": CONFIG_JSON}, None
+        )
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("my-agent", "my_agent"),  # hyphen -> underscore
+        ("123agent", "a_123agent"),  # leading digit -> prefixed letter
+        ("_leading", "a__leading"),  # leading underscore -> prefixed letter
+        ("", "a_"),  # empty -> valid minimal name
+        ("valid_Name1", "valid_Name1"),  # already valid, unchanged
+        ("dots.and spaces!", "dots_and_spaces_"),  # arbitrary chars -> underscore
+    ],
+)
+def test_sanitize_bundle_name(raw, expected):
+    assert index.sanitize_bundle_name(raw) == expected
+
+
+def test_sanitize_bundle_name_truncates():
+    result = index.sanitize_bundle_name("a" * 200)
+    assert len(result) == index.BUNDLE_NAME_MAX

--- a/src/api/schema/schema.graphql
+++ b/src/api/schema/schema.graphql
@@ -141,6 +141,17 @@ type FavoriteRuntime @aws_cognito_user_pools {
     endpointName: String!
 }
 
+# One immutable version of an agent's AgentCore configuration bundle. Config now
+# lives in bundles (not the removed runtime-config table), so a "version" here is
+# a bundle versionId (opaque UUID) rather than a numeric runtime version.
+type BundleVersion @aws_cognito_user_pools {
+    versionId: String!
+    createdAt: String
+    commitMessage: String
+    # Qualifiers (DEFAULT, BACKUP, …) currently pointing at this version, if any.
+    qualifiers: [String!]
+}
+
 type Experiment @aws_cognito_user_pools {
     experimentId: String!
     userId: String!
@@ -441,6 +452,7 @@ type Query {
     getRuntimeConfigurationByQualifier(agentName: String!, qualifier: String!): String! @aws_cognito_user_pools
     getDefaultRuntimeConfiguration(agentName: String!): String! @aws_cognito_user_pools
     listAgentVersions(agentRuntimeId: String!): [String] @aws_cognito_user_pools
+    listAgentBundleVersions(agentName: String!): [BundleVersion!] @aws_cognito_user_pools
     listAgentEndpoints(agentRuntimeId: String!): [String] @aws_cognito_user_pools
     getFavoriteRuntime: FavoriteRuntime @aws_cognito_user_pools
     # Evaluators

--- a/src/api/state-machines/create-agentcore-runtime.json
+++ b/src/api/state-machines/create-agentcore-runtime.json
@@ -152,6 +152,60 @@
             "Assign": {
                 "createdAt": "{% $floor($millis() / 1000) %}"
             },
+            "Next": "Get Existing Bundle Info"
+        },
+        "Get Existing Bundle Info": {
+            "Type": "Task",
+            "Comment": "Read the summary row to decide whether Put Config Bundle creates a new bundle or versions an existing one. The row was created by 'Set Status to Creating'; BundleId is absent on first create.",
+            "Resource": "arn:aws:states:::dynamodb:getItem",
+            "Arguments": {
+                "TableName": "${summaryTableArn}",
+                "Key": {
+                    "AgentName": {
+                        "S": "{% $agentName %}"
+                    }
+                }
+            },
+            "Assign": {
+                "existingBundleId": "{% $exists($states.result.Item.BundleId) ? $states.result.Item.BundleId.S : null %}",
+                "existingBundleVersion": "{% $exists($states.result.Item.QualifierToVersion.M.DEFAULT) ? $states.result.Item.QualifierToVersion.M.DEFAULT.S : null %}"
+            },
+            "Catch": [
+                {
+                    "ErrorEquals": [
+                        "States.ALL"
+                    ],
+                    "Next": "Set Status to Failed"
+                }
+            ],
+            "Next": "Put Config Bundle"
+        },
+        "Put Config Bundle": {
+            "Type": "Task",
+            "Comment": "Create (no bundleId) or version (bundleId + parentVersionId) the agent's configuration bundle BEFORE runtime creation, so BUNDLE_ID/BUNDLE_VERSION can be injected as container env (ADR-0002).",
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "Arguments": {
+                "FunctionName": "${putConfigBundleFuncArn}",
+                "Payload": {
+                    "agentName": "{% $agentName %}",
+                    "configurationValue": "{% $string($agentCfg) %}",
+                    "bundleId": "{% $existingBundleId %}",
+                    "parentVersionId": "{% $existingBundleVersion %}"
+                }
+            },
+            "Assign": {
+                "bundleId": "{% $states.result.Payload.bundleId %}",
+                "bundleArn": "{% $states.result.Payload.bundleArn %}",
+                "bundleVersionId": "{% $states.result.Payload.versionId %}"
+            },
+            "Catch": [
+                {
+                    "ErrorEquals": [
+                        "States.ALL"
+                    ],
+                    "Next": "Set Status to Failed"
+                }
+            ],
             "Next": "Create Runtimes"
         },
         "Create Runtimes": {
@@ -172,7 +226,9 @@
                                     "memoryId": "{% $memoryId %}",
                                     "architectureType": "{% $architectureType %}",
                                     "protocol": "HTTP",
-                                    "createdAt": "{% $createdAt %}"
+                                    "createdAt": "{% $createdAt %}",
+                                    "bundleId": "{% $bundleId %}",
+                                    "versionId": "{% $bundleVersionId %}"
                                 }
                             },
                             "Assign": {
@@ -264,7 +320,9 @@
                                     "memoryId": "{% $memoryId %}",
                                     "architectureType": "{% $architectureType %}",
                                     "protocol": "A2A",
-                                    "createdAt": "{% $createdAt %}"
+                                    "createdAt": "{% $createdAt %}",
+                                    "bundleId": "{% $bundleId %}",
+                                    "versionId": "{% $bundleVersionId %}"
                                 }
                             },
                             "Assign": {
@@ -381,7 +439,7 @@
                         "S": "{% $agentName %}"
                     }
                 },
-                "UpdateExpression": "SET #status = :status, #id = :id, #arn = :arn, #arnA2A = :arnA2A, #nb = :nb, #qtv = :qtv, #at = :at",
+                "UpdateExpression": "SET #status = :status, #id = :id, #arn = :arn, #arnA2A = :arnA2A, #nb = :nb, #qtv = :qtv, #at = :at, #bid = :bid, #barn = :barn",
                 "ExpressionAttributeNames": {
                     "#status": "Status",
                     "#id": "AgentRuntimeId",
@@ -389,7 +447,9 @@
                     "#arnA2A": "AgentRuntimeArnA2A",
                     "#nb": "NumberOfVersions",
                     "#qtv": "QualifierToVersion",
-                    "#at": "ArchitectureType"
+                    "#at": "ArchitectureType",
+                    "#bid": "BundleId",
+                    "#barn": "BundleArn"
                 },
                 "ExpressionAttributeValues": {
                     ":id": {
@@ -410,16 +470,22 @@
                     ":qtv": {
                         "M": {
                             "DEFAULT": {
-                                "N": "1"
+                                "S": "{% $bundleVersionId %}"
                             }
                         }
                     },
                     ":at": {
                         "S": "{% $architectureType %}"
+                    },
+                    ":bid": {
+                        "S": "{% $bundleId %}"
+                    },
+                    ":barn": {
+                        "S": "{% $bundleArn %}"
                     }
                 }
             },
-            "Next": "Save Configuration"
+            "Next": "Wait Before Notify"
         },
         "Get Current Runtime Summary": {
             "Type": "Task",
@@ -447,17 +513,20 @@
                         "S": "{% $agentName %}"
                     }
                 },
-                "UpdateExpression": "SET #status = :status, QualifierToVersion.#default = :version, #nb = :count, #at = :at, #arnA2A = :arnA2A",
+                "UpdateExpression": "SET #status = :status, QualifierToVersion.#default = :version, #nb = :count, #at = :at, #arnA2A = :arnA2A, #arn = :arn, #bid = :bid, #barn = :barn",
                 "ExpressionAttributeNames": {
                     "#status": "Status",
                     "#default": "DEFAULT",
                     "#nb": "NumberOfVersions",
                     "#at": "ArchitectureType",
-                    "#arnA2A": "AgentRuntimeArnA2A"
+                    "#arnA2A": "AgentRuntimeArnA2A",
+                    "#arn": "AgentRuntimeArn",
+                    "#bid": "BundleId",
+                    "#barn": "BundleArn"
                 },
                 "ExpressionAttributeValues": {
                     ":version": {
-                        "S": "{% $agentRuntimeVersion %}"
+                        "S": "{% $bundleVersionId %}"
                     },
                     ":count": {
                         "N": "{% $string($currentNumberOfVersions + 1) %}"
@@ -470,34 +539,15 @@
                     },
                     ":arnA2A": {
                         "S": "{% $agentRuntimeArnA2A ? $agentRuntimeArnA2A : '' %}"
-                    }
-                }
-            },
-            "Next": "Save Configuration"
-        },
-        "Save Configuration": {
-            "Type": "Task",
-            "Resource": "arn:aws:states:::dynamodb:putItem",
-            "Arguments": {
-                "TableName": "${agentVersionTableArn}",
-                "Item": {
-                    "AgentName": {
-                        "S": "{% $agentName %}"
                     },
-                    "CreatedAt": {
-                        "N": "{% $string($createdAt) %}"
-                    },
-                    "AgentRuntimeArn": {
+                    ":arn": {
                         "S": "{% $agentRuntimeArn %}"
                     },
-                    "AgentRuntimeId": {
-                        "S": "{% $agentRuntimeId %}"
+                    ":bid": {
+                        "S": "{% $bundleId %}"
                     },
-                    "AgentRuntimeVersion": {
-                        "S": "{% $agentRuntimeVersion %}"
-                    },
-                    "ConfigurationValue": {
-                        "S": "{% $string($agentCfg) %}"
+                    ":barn": {
+                        "S": "{% $bundleArn %}"
                     }
                 }
             },

--- a/src/api/state-machines/delete-agentcore-runtime.json
+++ b/src/api/state-machines/delete-agentcore-runtime.json
@@ -24,7 +24,8 @@
                 }
             },
             "Assign": {
-                "agentRuntimeIdA2A": "{% ($arn := $exists($states.result.Item.AgentRuntimeArnA2A.S) ? $states.result.Item.AgentRuntimeArnA2A.S : ''; $arn != '' ? $substringAfter($arn, 'runtime/') : '') %}"
+                "agentRuntimeIdA2A": "{% ($arn := $exists($states.result.Item.AgentRuntimeArnA2A.S) ? $states.result.Item.AgentRuntimeArnA2A.S : ''; $arn != '' ? $substringAfter($arn, 'runtime/') : '') %}",
+                "bundleId": "{% $exists($states.result.Item.BundleId.S) ? $states.result.Item.BundleId.S : '' %}"
             },
             "Next": "Set Status to Deleting"
         },
@@ -317,7 +318,8 @@
                             "Arguments": {
                                 "FunctionName": "${removeRuntimeVersionsFunctionArn}",
                                 "Payload": {
-                                    "agentName": "{% $agentName %}"
+                                    "agentName": "{% $agentName %}",
+                                    "bundleId": "{% $bundleId %}"
                                 }
                             },
                             "Catch": [

--- a/src/shared/layers/boto3-latest/requirements.txt
+++ b/src/shared/layers/boto3-latest/requirements.txt
@@ -1,4 +1,7 @@
-boto3==1.40.53
+# boto3 must be >=1.43.0: the put-config-bundle Lambda calls
+# bedrock-agentcore-control.create_configuration_bundle, an API absent from
+# earlier releases (config-bundles migration).
+boto3==1.43.52
 requests==2.33.0
 opensearch-py==2.8.0
 retry==0.9.2

--- a/src/user-interface/react-app/src/API.ts
+++ b/src/user-interface/react-app/src/API.ts
@@ -328,6 +328,14 @@ export type RuntimeSummary = {
   architectureType?: ArchitectureType | null,
 };
 
+export type BundleVersion = {
+  __typename: "BundleVersion",
+  versionId: string,
+  createdAt?: string | null,
+  commitMessage?: string | null,
+  qualifiers?: Array< string > | null,
+};
+
 export type FavoriteRuntime = {
   __typename: "FavoriteRuntime",
   agentRuntimeId: string,
@@ -1349,6 +1357,20 @@ export type ListAgentVersionsQueryVariables = {
 
 export type ListAgentVersionsQuery = {
   listAgentVersions?: Array< string | null > | null,
+};
+
+export type ListAgentBundleVersionsQueryVariables = {
+  agentName: string,
+};
+
+export type ListAgentBundleVersionsQuery = {
+  listAgentBundleVersions?:  Array< {
+    __typename: "BundleVersion",
+    versionId: string,
+    createdAt?: string | null,
+    commitMessage?: string | null,
+    qualifiers?: Array< string > | null,
+  } > | null,
 };
 
 export type ListAgentEndpointsQueryVariables = {

--- a/src/user-interface/react-app/src/components/admin/agent-core-runtime-manager.tsx
+++ b/src/user-interface/react-app/src/components/admin/agent-core-runtime-manager.tsx
@@ -40,13 +40,14 @@ import {
 import {
     getFavoriteRuntime as getFavoriteRuntimeQuery,
     getRuntimeConfigurationByVersion as getRuntimeConfigurationByVersionQuery,
+    listAgentBundleVersions as listAgentBundleVersionsQuery,
     listAgentVersions as listAgentVersionsQuery,
     listRuntimeAgents as listRuntimeAgentsQuery,
 } from "../../graphql/queries";
 import { receiveUpdateNotification } from "../../graphql/subscriptions";
 import DeleteAgentModal from "./agent-core/delete-agent-modal";
 import TagVersionModal from "./agent-core/tag-version-modal";
-import ViewVersionModal from "./agent-core/view-version-modal";
+import ViewVersionModal, { VersionInfo } from "./agent-core/view-version-modal";
 
 export interface AgentManagerProps {
     readonly toolsOpen: boolean;
@@ -66,9 +67,7 @@ export default function AgentCoreEndpointManager(props: AgentManagerProps) {
     const [availableVersions, setAvailableVersions] = useState<string[]>([]);
     const [isTagging, setIsTagging] = useState(false);
     const [showViewModal, setShowViewModal] = useState(false);
-    const [viewVersions, setViewVersions] = useState<{ version: string; qualifiers: string[] }[]>(
-        [],
-    );
+    const [viewVersions, setViewVersions] = useState<VersionInfo[]>([]);
     const [showDeleteModal, setShowDeleteModal] = useState(false);
     const [isDeleting, setIsDeleting] = useState(false);
     const [showFavoriteModal, setShowFavoriteModal] = useState(false);
@@ -280,35 +279,24 @@ export default function AgentCoreEndpointManager(props: AgentManagerProps) {
                 // Refresh agent data to get latest qualifiers
                 await apiClient.graphql({ query: listRuntimeAgentsQuery });
 
-                // Get the updated agent data
-                const updatedAgent = agents.find((a) => a.agentRuntimeId === agent.agentRuntimeId);
-                if (!updatedAgent) return;
-
-                // Config now lives in AgentCore configuration bundles: the only
-                // versions the resolver can serve are the bundle versionIds mapped
-                // by a qualifier in QualifierToVersion (getRuntimeConfigurationByVersion
-                // rejects anything else). Build the version list from that map — NOT
-                // from listAgentVersions, which returns numeric runtime versions the
-                // bundle read path can't resolve.
-                let qualifierToVersion: Record<string, string> = {};
-                try {
-                    qualifierToVersion = JSON.parse(updatedAgent.qualifierToVersion || "{}");
-                } catch {
-                    qualifierToVersion = {};
-                }
-
-                const versionToQualifiers: Record<string, string[]> = {};
-                Object.entries(qualifierToVersion).forEach(([qualifier, version]) => {
-                    const v = version as string;
-                    if (!versionToQualifiers[v]) {
-                        versionToQualifiers[v] = [];
-                    }
-                    versionToQualifiers[v].push(qualifier);
+                // List the full history of the agent's configuration bundle. Config
+                // lives in bundles now, so a "version" is a bundle versionId; the
+                // resolver annotates each with the qualifiers pointing at it and its
+                // creation time, so the modal can list every historical version with
+                // a meaningful label — not just the qualifier-mapped current ones.
+                const result = await apiClient.graphql({
+                    query: listAgentBundleVersionsQuery,
+                    variables: { agentName: agent.agentName },
                 });
 
-                const versions = Object.entries(versionToQualifiers).map(
-                    ([version, qualifiers]) => ({ version, qualifiers }),
-                );
+                const versions = (result.data.listAgentBundleVersions || [])
+                    .filter((v): v is NonNullable<typeof v> => v !== null)
+                    .map((v) => ({
+                        version: v.versionId,
+                        qualifiers: (v.qualifiers ?? []).filter((q): q is string => q !== null),
+                        createdAt: v.createdAt,
+                        commitMessage: v.commitMessage,
+                    }));
 
                 setViewVersions(versions);
                 setShowViewModal(true);

--- a/src/user-interface/react-app/src/components/admin/agent-core-runtime-manager.tsx
+++ b/src/user-interface/react-app/src/components/admin/agent-core-runtime-manager.tsx
@@ -7,6 +7,7 @@
 
 import { useCollection } from "@cloudscape-design/collection-hooks";
 import {
+    Badge,
     Box,
     Button,
     CollectionPreferences,
@@ -283,28 +284,31 @@ export default function AgentCoreEndpointManager(props: AgentManagerProps) {
                 const updatedAgent = agents.find((a) => a.agentRuntimeId === agent.agentRuntimeId);
                 if (!updatedAgent) return;
 
-                const versionsResult = await apiClient.graphql({
-                    query: listAgentVersionsQuery,
-                    variables: { agentRuntimeId: agent.agentRuntimeId },
-                });
+                // Config now lives in AgentCore configuration bundles: the only
+                // versions the resolver can serve are the bundle versionIds mapped
+                // by a qualifier in QualifierToVersion (getRuntimeConfigurationByVersion
+                // rejects anything else). Build the version list from that map — NOT
+                // from listAgentVersions, which returns numeric runtime versions the
+                // bundle read path can't resolve.
+                let qualifierToVersion: Record<string, string> = {};
+                try {
+                    qualifierToVersion = JSON.parse(updatedAgent.qualifierToVersion || "{}");
+                } catch {
+                    qualifierToVersion = {};
+                }
 
-                const qualifierToVersion = JSON.parse(updatedAgent.qualifierToVersion);
                 const versionToQualifiers: Record<string, string[]> = {};
-
-                // Group qualifiers by version
                 Object.entries(qualifierToVersion).forEach(([qualifier, version]) => {
-                    if (!versionToQualifiers[version as string]) {
-                        versionToQualifiers[version as string] = [];
+                    const v = version as string;
+                    if (!versionToQualifiers[v]) {
+                        versionToQualifiers[v] = [];
                     }
-                    versionToQualifiers[version as string].push(qualifier);
+                    versionToQualifiers[v].push(qualifier);
                 });
 
-                const versions = (versionsResult.data.listAgentVersions || [])
-                    .filter((v): v is string => v !== null)
-                    .map((version) => ({
-                        version,
-                        qualifiers: versionToQualifiers[version] || [],
-                    }));
+                const versions = Object.entries(versionToQualifiers).map(
+                    ([version, qualifiers]) => ({ version, qualifiers }),
+                );
 
                 setViewVersions(versions);
                 setShowViewModal(true);
@@ -709,42 +713,59 @@ export default function AgentCoreEndpointManager(props: AgentManagerProps) {
                             id: "qualifierToVersion",
                             header: "Qualifiers",
                             cell: (item) => {
-                                const qualifierToVersion = JSON.parse(item.qualifierToVersion);
-                                const versionToQualifiers: Record<string, string[]> = {};
+                                // qualifierToVersion maps a qualifier name (DEFAULT,
+                                // BACKUP, …) to the bundle versionId it points at. The
+                                // versionId is an opaque UUID, so we surface the
+                                // qualifier name as the primary label and keep only a
+                                // short id prefix as a muted hint.
+                                let qualifierToVersion: Record<string, string> = {};
+                                try {
+                                    qualifierToVersion = JSON.parse(item.qualifierToVersion || "{}");
+                                } catch {
+                                    qualifierToVersion = {};
+                                }
 
-                                // Group qualifiers by version
-                                Object.entries(qualifierToVersion).forEach(
-                                    ([qualifier, version]) => {
-                                        if (!versionToQualifiers[version as string]) {
-                                            versionToQualifiers[version as string] = [];
-                                        }
-                                        versionToQualifiers[version as string].push(qualifier);
-                                    },
+                                const entries = Object.entries(qualifierToVersion).sort(
+                                    ([a], [b]) =>
+                                        a === "DEFAULT" ? -1 : b === "DEFAULT" ? 1 : a.localeCompare(b),
                                 );
 
+                                if (entries.length === 0) {
+                                    return (
+                                        <Box color="text-status-inactive" fontSize="body-s">
+                                            —
+                                        </Box>
+                                    );
+                                }
+
                                 return (
-                                    <SpaceBetween direction="vertical" size="xs">
-                                        {Object.entries(versionToQualifiers)
-                                            .sort(([a], [b]) => parseInt(b) - parseInt(a))
-                                            .map(([version, qualifiers]) => (
-                                                <Box key={version} fontSize="body-s">
-                                                    <strong>v{version}:</strong>{" "}
-                                                    {qualifiers.map((qualifier, index) => (
-                                                        <span key={qualifier}>
-                                                            {qualifier}
-                                                            {favoriteRuntime?.agentRuntimeId ===
-                                                                item.agentRuntimeId &&
-                                                            favoriteRuntime?.endpointName ===
-                                                                qualifier
-                                                                ? " ⭐"
-                                                                : ""}
-                                                            {index < qualifiers.length - 1
-                                                                ? ", "
-                                                                : ""}
-                                                        </span>
-                                                    ))}
-                                                </Box>
-                                            ))}
+                                    <SpaceBetween direction="vertical" size="xxs">
+                                        {entries.map(([qualifier, version]) => {
+                                            const isFavorite =
+                                                favoriteRuntime?.agentRuntimeId ===
+                                                    item.agentRuntimeId &&
+                                                favoriteRuntime?.endpointName === qualifier;
+                                            const shortId = String(version).slice(0, 8);
+                                            return (
+                                                <SpaceBetween
+                                                    key={qualifier}
+                                                    direction="horizontal"
+                                                    size="xs"
+                                                    alignItems="center"
+                                                >
+                                                    <Badge color={isFavorite ? "green" : "blue"}>
+                                                        {isFavorite ? `★ ${qualifier}` : qualifier}
+                                                    </Badge>
+                                                    <Box
+                                                        color="text-status-inactive"
+                                                        fontSize="body-s"
+                                                        display="inline"
+                                                    >
+                                                        {shortId}
+                                                    </Box>
+                                                </SpaceBetween>
+                                            );
+                                        })}
                                     </SpaceBetween>
                                 );
                             },

--- a/src/user-interface/react-app/src/components/admin/agent-core/mcp-server-manager.tsx
+++ b/src/user-interface/react-app/src/components/admin/agent-core/mcp-server-manager.tsx
@@ -20,8 +20,7 @@ import { generateClient } from "aws-amplify/api";
 import { McpServer, ResponseStatus } from "../../../API";
 import { deleteMcpServer as deleteMcpServerMutation } from "../../../graphql/mutations";
 import {
-    getRuntimeConfigurationByVersion as getRuntimeConfigurationByVersionQuery,
-    listAgentVersions as listAgentVersionsQuery,
+    getDefaultRuntimeConfiguration as getDefaultRuntimeConfigurationQuery,
     listAvailableMcpServers as listAvailableMcpServersQuery,
     listRuntimeAgents as listRuntimeAgentsQuery,
 } from "../../../graphql/queries";
@@ -62,32 +61,23 @@ export default function McpServerManager(_props: McpServerManagerProps) {
                 usageMap[s.name] = [];
             });
 
-            // For each agent, get the latest version's config
+            // For each agent, read the DEFAULT (current) config. Config now lives
+            // in AgentCore configuration bundles keyed by bundle versionId, so we
+            // resolve via getDefaultRuntimeConfiguration rather than fetching a
+            // numeric runtime version — the by-version resolver only serves the
+            // versionIds mapped in QualifierToVersion, which numeric versions are not.
             await Promise.all(
                 agents
                     .filter((a) => a.status?.toLowerCase() === "ready")
                     .map(async (agent) => {
                         try {
-                            const versionsResult = await apiClient.graphql({
-                                query: listAgentVersionsQuery,
-                                variables: { agentRuntimeId: agent.agentRuntimeId },
-                            });
-                            const versions = (versionsResult.data?.listAgentVersions || [])
-                                .filter((v): v is string => v !== null)
-                                .sort((a, b) => parseInt(b) - parseInt(a));
-
-                            if (versions.length === 0) return;
-
                             const configResult = await apiClient.graphql({
-                                query: getRuntimeConfigurationByVersionQuery,
-                                variables: {
-                                    agentName: agent.agentName,
-                                    agentVersion: versions[0],
-                                },
+                                query: getDefaultRuntimeConfigurationQuery,
+                                variables: { agentName: agent.agentName },
                             });
 
                             const config = JSON.parse(
-                                configResult.data?.getRuntimeConfigurationByVersion || "{}",
+                                configResult.data?.getDefaultRuntimeConfiguration || "{}",
                             );
                             const agentMcps: string[] = config.mcpServers || [];
 

--- a/src/user-interface/react-app/src/components/admin/agent-core/view-version-modal.tsx
+++ b/src/user-interface/react-app/src/components/admin/agent-core/view-version-modal.tsx
@@ -29,6 +29,16 @@ interface VersionInfo {
     qualifiers: string[];
 }
 
+// Versions are AgentCore configuration-bundle versionIds (opaque UUIDs). Prefer
+// the qualifier names for a human-readable label, falling back to a short id
+// prefix so the selector never shows a full UUID.
+function versionLabel(version: string, qualifiers: string[]): string {
+    if (qualifiers.length > 0) {
+        return qualifiers.join(", ");
+    }
+    return version.slice(0, 8);
+}
+
 // One step in the drill-down navigation. stack[0] is the agent the user opened
 // from the table; the top of the stack is the agent currently displayed.
 interface NavFrame {
@@ -272,7 +282,7 @@ export default function ViewVersionModal({
                                 </Box>
                                 {selectedVersion && (
                                     <Box color="text-status-inactive" display="inline">
-                                        (v{selectedVersion})
+                                        ({selectedVersion.slice(0, 8)})
                                     </Box>
                                 )}
                             </SpaceBetween>
@@ -287,13 +297,11 @@ export default function ViewVersionModal({
                                           const foundVersion = current?.versions.find(
                                               (v) => v.version === selectedVersion,
                                           );
-                                          const hasQualifiers =
-                                              foundVersion?.qualifiers &&
-                                              foundVersion.qualifiers.length > 0;
                                           return {
-                                              label: hasQualifiers
-                                                  ? `${selectedVersion} (${foundVersion!.qualifiers.join(", ")})`
-                                                  : selectedVersion,
+                                              label: versionLabel(
+                                                  selectedVersion,
+                                                  foundVersion?.qualifiers ?? [],
+                                              ),
                                               value: selectedVersion,
                                           };
                                       })()
@@ -303,10 +311,7 @@ export default function ViewVersionModal({
                                 handleVersionChange(detail.selectedOption?.value || "")
                             }
                             options={(current?.versions ?? []).map((v) => ({
-                                label:
-                                    v.qualifiers.length > 0
-                                        ? `${v.version} (${v.qualifiers.join(", ")})`
-                                        : v.version,
+                                label: versionLabel(v.version, v.qualifiers),
                                 value: v.version,
                             }))}
                             placeholder="Select version"

--- a/src/user-interface/react-app/src/components/admin/agent-core/view-version-modal.tsx
+++ b/src/user-interface/react-app/src/components/admin/agent-core/view-version-modal.tsx
@@ -24,19 +24,31 @@ import { RuntimeSummary } from "../../../API";
 import { AgentCoreRuntimeConfiguration } from "../../wizard/types";
 import AgentConfigView, { AgentReferenceTarget } from "./agent-config-view";
 
-interface VersionInfo {
+export interface VersionInfo {
     version: string;
     qualifiers: string[];
+    createdAt?: string | null;
+    commitMessage?: string | null;
 }
 
-// Versions are AgentCore configuration-bundle versionIds (opaque UUIDs). Prefer
-// the qualifier names for a human-readable label, falling back to a short id
-// prefix so the selector never shows a full UUID.
-function versionLabel(version: string, qualifiers: string[]): string {
-    if (qualifiers.length > 0) {
-        return qualifiers.join(", ");
+// Versions are AgentCore configuration-bundle versionIds (opaque UUIDs). Build a
+// human-readable label: qualifiers first (DEFAULT, BACKUP, …), else the creation
+// date, always falling back to a short id prefix so the full UUID never shows.
+function versionLabel(info: VersionInfo): string {
+    const parts: string[] = [];
+    if (info.qualifiers.length > 0) {
+        parts.push(info.qualifiers.join(", "));
     }
-    return version.slice(0, 8);
+    if (info.createdAt) {
+        const d = new Date(info.createdAt);
+        if (!Number.isNaN(d.getTime())) {
+            parts.push(d.toLocaleString());
+        }
+    }
+    if (parts.length === 0) {
+        parts.push(info.version.slice(0, 8));
+    }
+    return parts.join(" · ");
 }
 
 // One step in the drill-down navigation. stack[0] is the agent the user opened
@@ -298,10 +310,9 @@ export default function ViewVersionModal({
                                               (v) => v.version === selectedVersion,
                                           );
                                           return {
-                                              label: versionLabel(
-                                                  selectedVersion,
-                                                  foundVersion?.qualifiers ?? [],
-                                              ),
+                                              label: foundVersion
+                                                  ? versionLabel(foundVersion)
+                                                  : selectedVersion.slice(0, 8),
                                               value: selectedVersion,
                                           };
                                       })()
@@ -311,7 +322,7 @@ export default function ViewVersionModal({
                                 handleVersionChange(detail.selectedOption?.value || "")
                             }
                             options={(current?.versions ?? []).map((v) => ({
-                                label: versionLabel(v.version, v.qualifiers),
+                                label: versionLabel(v),
                                 value: v.version,
                             }))}
                             placeholder="Select version"

--- a/src/user-interface/react-app/src/graphql/queries.ts
+++ b/src/user-interface/react-app/src/graphql/queries.ts
@@ -300,6 +300,19 @@ export const listAgentVersions = /* GraphQL */ `query ListAgentVersions($agentRu
   APITypes.ListAgentVersionsQueryVariables,
   APITypes.ListAgentVersionsQuery
 >;
+export const listAgentBundleVersions = /* GraphQL */ `query ListAgentBundleVersions($agentName: String!) {
+  listAgentBundleVersions(agentName: $agentName) {
+    versionId
+    createdAt
+    commitMessage
+    qualifiers
+    __typename
+  }
+}
+` as GeneratedQuery<
+  APITypes.ListAgentBundleVersionsQueryVariables,
+  APITypes.ListAgentBundleVersionsQuery
+>;
 export const listAgentEndpoints = /* GraphQL */ `query ListAgentEndpoints($agentRuntimeId: String!) {
   listAgentEndpoints(agentRuntimeId: $agentRuntimeId)
 }

--- a/uv.lock
+++ b/uv.lock
@@ -20,6 +20,7 @@ source = { virtual = "." }
 [package.dev-dependencies]
 dev = [
     { name = "aws-lambda-powertools" },
+    { name = "aws-xray-sdk" },
     { name = "bedrock-agentcore" },
     { name = "black" },
     { name = "boto3" },
@@ -45,6 +46,7 @@ dev = [
 [package.metadata.requires-dev]
 dev = [
     { name = "aws-lambda-powertools", specifier = ">=3.4.1" },
+    { name = "aws-xray-sdk", specifier = ">=2.14.0" },
     { name = "bedrock-agentcore", specifier = ">=1.6.1" },
     { name = "black", specifier = ">=24.10.0" },
     { name = "boto3", specifier = ">=1.40.55" },
@@ -295,6 +297,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/48/62/30685f9a096ad834409771a567065cd25094d3a5124874e1d7e373f17dd7/aws_sdk_signers-0.3.0.tar.gz", hash = "sha256:6fd654ea3dafe3ae3cf172fb3bd1e81877fe6e18156e0b638ccefb045ffb420c", size = 18590, upload-time = "2026-05-05T18:04:09.914Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/30/91/25405e647de8dea8419812e85bcb341323500905f4f55fc23cf488b7a2a4/aws_sdk_signers-0.3.0-py3-none-any.whl", hash = "sha256:098c7784064931d2da968400fc0466e092a7c271a79fac9d55daa4a7c35fd6f1", size = 21999, upload-time = "2026-05-05T18:04:08.971Z" },
+]
+
+[[package]]
+name = "aws-xray-sdk"
+version = "2.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/14/25/0cbd7a440080def5e6f063720c3b190a25f8aa2938c1e34415dc18241596/aws_xray_sdk-2.15.0.tar.gz", hash = "sha256:794381b96e835314345068ae1dd3b9120bd8b4e21295066c37e8814dbb341365", size = 76315, upload-time = "2025-10-29T20:59:45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/c3/f30a7a63e664acc7c2545ca0491b6ce8264536e0e5cad3965f1d1b91e960/aws_xray_sdk-2.15.0-py2.py3-none-any.whl", hash = "sha256:422d62ad7d52e373eebb90b642eb1bb24657afe03b22a8df4a8b2e5108e278a3", size = 103228, upload-time = "2025-10-29T21:00:24.12Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Per-agent runtime configuration used to live in a custom DynamoDB table (`agentCoreRuntimeCfgTable` + its `byAgentNameAndVersion` LSI). This PR moves it to **AgentCore configuration bundles**, read by the containers directly over the control plane. The custom config table is removed entirely; the summary table is kept and gains the bundle identity fields. Two ADRs capture the locked decisions: config is read via the control plane rather than Gateway/baggage ([ADR-0001](docs/adr/0001-config-read-via-control-plane.md)), and each agent gets one bundle with a single component keyed by its stable agent id, created before the runtime so `BUNDLE_ID`/`BUNDLE_VERSION` can be injected as container env ([ADR-0002](docs/adr/0002-bundle-identity-and-component-keying.md)).

The change spans the container config loaders, the Agent Factory create/delete flows (Lambdas + Step Functions), and both IaC trees (CDK primary, Terraform mirror). A standalone, idempotent port script migrates existing DynamoDB config rows into bundles; it was run against the live `v2v-aca` environment (12 agents ported, idempotency verified) before this branch's table-removal lands there.

## Changes

**Container loaders (`src/agent-core/`)**
- Shared base loader gains a control-plane bundle fetch (`_fetch_config_from_bundle` → `get_configuration_bundle_version`); fail-fast, no DynamoDB fallback. The eager DynamoDB table binding and the dead `_get_table`/`_fetch_item_from_dynamodb` path were removed.
- All four image loaders (single, swarm, graph, agents-as-tools) read their own config from the bundle. Swarm resolves each referenced sub-agent's config from *its own* bundle; graph and agents-as-tools resolve sub-agents via A2A ARNs (unchanged).
- Bumped `bedrock-agentcore` to `>=1.8` in all four images.

**Agent Factory API (`src/api/`)**
- New `put-config-bundle` Lambda creates or versions an agent's bundle.
- Create-runtime Step Function calls `put-config-bundle` **before** creating the runtime and injects `BUNDLE_ID`/`BUNDLE_VERSION`; `QualifierToVersion.DEFAULT` now stores the bundle versionId instead of the numeric AgentRuntimeVersion.
- Delete flow deletes the bundle by stored `bundleId` instead of purging version rows.
- `agent-factory-resolver` config-read queries (incl. the live chat/voice `getDefaultRuntimeConfiguration`) now read from the bundle via the control plane; DEFAULT/current version only (historical versions return `""`).

**IaC**
- **CDK:** removed the runtime-config table + LSI + all wiring; wired the put-config-bundle Lambda into the create SFN; least-privilege `bedrock-agentcore` bundle IAM (Create/List unscoped — not resource-scopable; Update/Get/GetVersion/Delete scoped to `configuration-bundle/*`).
- **Terraform:** full mirror of the CDK change (the Terraform state machines consume the shared SFN JSON via `templatefile()`, so the substitution keys had to move in lockstep).

**Port + tests + docs**
- `scripts/port_config_to_bundles.py` — idempotent operator script (rows → bundles → summary backfill) with a runbook.
- CDK Jest template assertions for the new construct shape; unit tests for the new/changed Lambdas and loaders.
- Two ADRs.

## Test plan

- [x] `cd iac-cdk && npm test` — 5 template assertions pass (no runtime-config table/LSI, put-config-bundle Lambda present, bundle IAM scoped correctly).
- [x] `cd iac-cdk && npx cdk synth '*'` — synthesizes clean, cdk-nag reports no
  unsuppressed violations.
- [x] `make tf-lint` — fmt + validate + checkov all pass.
- [x] `make run-ash` — no actionable findings introduced by this PR (see pre-existing note below).
- [x] Port script run live against `v2v-aca` (12 agents ported; re-run is a no-op; persisted bundle + summary backfill spot-checked).
- [x] **Reviewer:** deploy to a sandbox, create a SINGLE / SWARM / GRAPH / AGENT AS TOOLS agent via the Agent Factory UI, and confirm each container starts and loads its config from the bundle (this is the path that the fixed startup bug affected).
- [x] **Reviewer:** delete an agent and confirm its bundle is removed.
- [x] Check the UI


## Migration / rollout notes (please read)

- **Destructive:** redeploying drops `agentCoreRuntimeCfgTable`. For any *already deployed* environment other than `v2v-aca`, run `scripts/port_config_to_bundles.py` **after** the bundle-reading code deploys but **before** this branch's table removal reaches that environment. A fresh deploy needs no port.
- The container startup path is behavior-sensitive: the shared loader no longer reads a `tableName` env var. A bug where the base loader still read it (and would have crashed every container at startup) was caught in review and fixed in this branch — see the last commit.

## Pre-existing repo-wide findings (not introduced by this PR)

- **checkov `CKV_AWS_174`** on `iac-terraform/modules/user_interface/cloudfront.tf:97` (CloudFront viewer cert / TLS minimum). The file is **byte-identical to `main`** and the finding is flaky (an earlier ASH run reported checkov passing). It stems from `cloudfront_default_certificate = true` (the default `*.cloudfront.net` cert), which is intentional for this proof-of-value accelerator — enforcing TLS 1.2 requires a custom ACM cert + aliases, a separate hardening feature. Not touched by this PR.

## Follow-ups

- **Deploy-time default agent** (`config.agentRuntimeConfig`): the seeder still creates the runtime before the bundle exists, which violates ADR-0002. It is **guarded off** in both trees (CDK synth-time `throw`, Terraform variable `validation`) and is not active in any deployed config. Follow-up: restructure the seeder into create-bundle → create-runtime(with BUNDLE env) → update-summary, then remove the guard.
- **`tag_agent_core_runtime`** in `agent-factory-resolver` still writes `int(agentVersion)` into `QualifierToVersion`; post-migration those values should be bundle versionId UUIDs, so tagging an endpoint and then reading its config would return `""`. Pre-existing on lines this PR doesn't modify — tracked as a completeness follow-up.
- **uv dependency cooldown:** the semgrep `uv-missing-dependency-cooldown` rule is suppressed in `.ash/.ash.yaml` (with justification). The fix (`exclude-newer = "7 days"` under `[tool.uv]`) needs uv `>=0.9.17`, which the repo/CI/tooling images aren't pinned to yet. Add the cooldown once uv is bumped.