### PR TITLE
🔧 (skills): add AI-DLC inception pipeline skills

### DIFF
--- a/.claude/skills/ai-dlc/SKILL.md
+++ b/.claude/skills/ai-dlc/SKILL.md
@@ -1,0 +1,41 @@
+---
+description: Run the full AI-DLC inception pipeline for a task — story → refine → design → tasks — with a human gate between each phase
+user_invocable: true
+---
+
+# /ai-dlc — inception pipeline orchestrator
+
+Walks a task through the AI-DLC **inception** phases end to end, pausing for human validation between each. A thin conductor over the per-phase skills — it does not re-implement them.
+
+## Phases (each is a separate skill; run them in order)
+
+1. **Story** → `story-new` — draft `story.md` from the idea.
+2. **Refine** → `story-refine` — resolve open questions, verify facts, tighten scope.
+3. **Design** → `design-doc` — architecture + task map (+ ADRs if warranted).
+4. **Tasks** → `tasks` — expand the task map into `tasks/` (API surface per unit, not full code).
+
+`pr-draft` is deliberately **not** part of this orchestrator: it runs *after* the building phase, once real code exists on the branch. Inception stops at the task interfaces.
+
+**Spec-driven entry.** When the work starts from a factory spec (`specs/<name>.yaml`) rather than a rough idea, phases 1–2 are already satisfied — a spec *is* refined requirements. Enter at phase 3 via `spec-design` (spec → `design-doc.md`) instead of `design-doc`, then continue at phase 4 (`tasks`). The spec, not a `story.md`, is the source of truth; re-run `spec-design` when the spec changes.
+
+## Input
+
+An idea and optional slug, e.g. `/ai-dlc weather-tool "MCP tool that fetches current weather"`. If resuming an existing story, pass just the slug and this skill picks up at the first incomplete phase.
+
+## How to run
+
+1. **Determine the starting phase.** First, if a `specs/<slug>.yaml` exists (spec-driven work), enter at phase 3 via `spec-design` and skip phases 1–2 entirely. Otherwise check `local/user-stories/<slug>/` for existing artifacts:
+   - no folder / no `story.md` → start at phase 1.
+   - `story.md` present but has `⏳ open:` items → start at phase 2.
+   - refined `story.md`, no `design-doc.md` → phase 3.
+   - `design-doc.md` present, no `tasks/` → phase 4.
+   State which phase you're starting at and why.
+2. **Run each phase by invoking its skill** (the Skill tool), in order, passing the slug.
+3. **Gate between phases.** After a phase produces its artifact and the user approves it, ask the user to confirm before advancing to the next phase. If the user wants to stop after any phase, stop — each artifact stands on its own and the pipeline is resumable later.
+4. **Never skip a gate or auto-advance past an unapproved artifact.** The value of AI-DLC here is the human validation between steps; preserve it. A phase's output must be approved before the next phase consumes it.
+5. **After phase 4**, tell the user inception is complete and the tasks are ready for the building phase; `/pr-draft <slug>` comes later, after code is written.
+
+## Principles
+
+- Thin orchestration only — defer all phase logic to the per-phase skills so behavior stays consistent whether a phase is run standalone or via `/ai-dlc`.
+- Resumable and re-runnable: any phase can be re-invoked to revise its artifact without redoing the others.

--- a/.claude/skills/design-doc/SKILL.md
+++ b/.claude/skills/design-doc/SKILL.md
@@ -1,0 +1,39 @@
+---
+description: Generate a high-level design doc + task map from an approved story.md
+user_invocable: true
+---
+
+# /design-doc — architecture + task map
+
+Step 3 of the AI-DLC pipeline. Turns an approved `story.md` into `design-doc.md`: the single source of **structure** (architecture, decisions, dependencies, and a task map). Per-task detail — the API surface each unit exposes — lives in the task files produced by `/tasks`. Neither the design doc nor the task files hold full implementations; those are written in the building phase, after inception.
+
+## Input
+
+The story slug, e.g. `/design-doc weather-tool`. Reads `local/user-stories/<slug>/story.md`.
+
+## Steps
+
+1. **Read** the story. If it still has unresolved `⏳ open:` items, STOP and recommend `/story-refine <slug>` first — a design on shifting requirements is wasted work.
+2. **Read the template** in `references/design-template.md` (bundled). Match its section order.
+3. **Draft the design doc.** For each section:
+   - **Goal & non-goals** — lift from the story's Scope; make non-goals explicit.
+   - **Architecture** — the layering/module split and *why*. An ASCII diagram + a package/file layout
+     tree when it's a Python package or React/TS app. Keep each layer independently testable.
+   - **Key dependencies** — a table of load-bearing choices with a one-line justification each.
+     Verify versions/features against real sources; note the date verified. Do not assert versions
+     from memory.
+   - **Task map** — a numbered table (T1…Tn) with Task / Depends-on / File columns, plus a
+     recommended order. Each task must end green (Python: `ruff`/`black`/`pytest`; TS: `tsc`/`eslint`/tests)
+     and map to a DoD checkbox in the story. This table is the contract `/tasks` expands.
+   - **Cross-cutting contract** — any invariant every task must preserve (e.g. the AgentCore Runtime
+     contract: ARM64, FastAPI on `0.0.0.0:8080`, `/ws` + `/invocations` + `/ping`, stateless container).
+   - **Decisions & open questions** — list decided items with rationale; flag remaining ones.
+4. **ADRs.** If a decision is cross-cutting and hard to reverse (e.g. CDK vs. Terraform, AgentCore Runtime vs. Gateway, stateless default), propose recording it under `docs/adr/NNNN-title.md` and reference it from the doc. Ask before creating ADR files — confirm the user wants them and the numbering.
+5. **Show the draft** and confirm the architecture + task map before writing. This is the key gate: the task map drives everything downstream.
+6. **On confirmation**, write `local/user-stories/<slug>/design-doc.md` and suggest `/tasks <slug>`.
+
+## Principles
+
+- **Structure here, API surface in tasks, implementation in the building phase.** If you're writing more than an illustrative snippet, stop — the interface belongs in a task file, the bodies belong to the build.
+- Every task maps to a DoD checkbox; every DoD checkbox is covered by at least one task. Call out any gap rather than papering over it.
+- Reference the story with a relative link; reference ADRs with relative links to `docs/adr/`.

--- a/.claude/skills/design-doc/references/design-template.md
+++ b/.claude/skills/design-doc/references/design-template.md
@@ -1,0 +1,76 @@
+# Design Doc — <Story title>
+
+> Companion to [`story.md`](story.md). **High-level** design: architecture, decisions, and the task map. Detailed code for each unit of work lives in [`tasks/`](tasks/) — this doc is the single source of *structure*, the task files are the single source of *code*.
+>
+> <Optional: note the SDK/library version this was verified against and the date.>
+
+## 1. Goal & non-goals
+
+**Goal:** <one sentence — the deliverable.>
+
+**Non-goals (this story):** <explicitly deferred work.> <Link ADRs where a non-goal is a recorded decision.>
+
+## 2. Architecture
+
+<Prose + an ASCII diagram of the layers/modules and their responsibilities. One line per layer on why it's separated.>
+
+```
+┌───────────────────────────────┐
+│ <layer>   <responsibility>     │
+├───────────────────────────────┤
+│ <layer>   <responsibility>     │
+└───────────────────────────────┘
+```
+
+**File layout:** <a tree of the files to be created/changed, annotated with the task that produces each. Mirror the repo's `src/<feature>/` ↔ `iac-cdk/lib/<feature>/` convention where relevant.>
+
+```
+src/<feature>/<name>/
+├── __init__.py      # T?   (Python) — or index.ts for a TS module
+├── handler.py       # T?
+└── tests/
+    └── test_*.py    # T?
+```
+
+## 3. Key dependencies
+
+<Table of load-bearing choices only — not every transitive dep.>
+
+| Dependency | Why |
+|------------|-----|
+| `<package>` (extras …) | <one-line justification> |
+
+> <Version pinning policy / verification date, if relevant.>
+
+## 4. Task map
+
+Each task ends green (Python: `ruff`/`black`/`pytest`; TS: `tsc`/`eslint`/tests) and maps to a Definition-of-Done checkbox in the story. Detail + code go in each task file.
+
+| # | Task | Depends on | File |
+|---|------|-----------|------|
+| T1 | <scaffold> | — | [tasks/T1-*.md](tasks/T1-*.md) |
+| T2 | <...> | T1 | [tasks/T2-*.md](tasks/T2-*.md) |
+
+Recommended order: <T1 → T2 → …, noting which can run in parallel>.
+
+## 5. <Cross-cutting contract> (optional)
+
+<Any invariant every task must preserve. For AgentCore Runtime containers, restate the contract and which task enforces each row.>
+
+| Requirement | Value | Enforced in |
+|-------------|-------|-------------|
+| Platform | ARM64 / aarch64 | T? |
+| Host / Port | `0.0.0.0` / `8080` (A2A twin: `9000`) | T? |
+| Routes | FastAPI `/ws`, `/invocations`, `/ping` | T? |
+| Session model | stateless container; history in DynamoDB | T? |
+| Auth | none in container (runtime is boundary) | all |
+
+## 6. Decisions & open questions
+
+**Decided:**
+
+1. ✅ **<decision>:** <what and why.> → T?
+
+**Still open:**
+
+- ⏳ **<question>:** <what's undecided and when it'll be decided.> → T?

--- a/.claude/skills/spec-design/SKILL.md
+++ b/.claude/skills/spec-design/SKILL.md
@@ -1,0 +1,56 @@
+---
+description: Turn a specs/<name>.yaml spec into an AI-DLC design-doc.md, entering the pipeline at the design phase (spec is already-refined requirements, so story/refine are skipped)
+user_invocable: true
+---
+
+# /spec-design — spec → design doc (AI-DLC bridge)
+
+Bridges a factory **spec** (`specs/<name>.yaml`) into the AI-DLC inception pipeline. A spec is not a rough idea — it is *already-refined requirements* (tools, inputs, outputs, errors, dependencies, deploy target all resolved). So this skill enters AI-DLC at **phase 3 (design)**, skipping `story-new` and `story-refine`, and produces a `design-doc.md` whose task map the existing `/tasks` skill then expands. Building is manual from those tasks.
+
+The spec is the **source of truth**: this skill is re-runnable, and the design doc points back at the spec (not a `story.md`) as its authority. When the spec changes, re-run this skill to regenerate the design doc, then `/tasks`.
+
+Pipeline position: **specs/\<name\>.yaml → /spec-design → design-doc.md → /tasks → tasks/ → (manual build) → /pr-draft**.
+
+## Input
+
+The spec name, e.g. `/spec-design pubmed` — reads `specs/pubmed.yaml`. Optional slug for the output folder (defaults to the spec name).
+
+## Steps
+
+1. **Read the spec** `specs/<name>.yaml`. If it is missing, STOP and list the specs under `specs/`. Parse its five layers: `server`, `dependencies`, `types`, `tools`, and each tool's inputs/constraints/output/errors/behavior. Also read `specs/SCHEMA-NOTES.md` if present — it records how spec fields map to code (e.g. a reserved word like `abstract` → `abstract_text`, `clamp` in core logic vs. `reject` at the input boundary).
+2. **Resolve the target folder** `local/user-stories/<slug>/`. If a `design-doc.md` already exists, say so and confirm regeneration (the spec is source of truth, so regeneration is expected — but never clobber silently).
+3. **Read the template** in `references/design-template.md` (bundled — a copy of the `/design-doc` template so output is identical in shape to a hand-run design phase). Match its section order exactly, so `/tasks` consumes it unchanged.
+4. **Derive each section from the spec** (see the mapping below). Do not re-elicit requirements — translate what the spec already states into structure. Verify only the *how* (package versions, SDK API shapes) that the spec deliberately leaves to the engine; note the verification date. Do not invent versions from memory.
+5. **Show the draft** design doc — especially the architecture and the task map — and confirm before writing. The task map is the contract `/tasks` expands, so it is the key gate.
+6. **On confirmation**, write `local/user-stories/<slug>/design-doc.md` and suggest `/tasks <slug>`.
+
+## Spec → design-doc mapping
+
+Derive, don't elicit. Each design-doc section comes from spec fields:
+
+| design-doc section | Comes from |
+|---|---|
+| **Goal & non-goals** | `server.description`; non-goals from `dependencies`/scope the spec omits, plus recorded ADR decisions (Runtime-only, stateless default). |
+| **Architecture** | The **invariant spine** (the FastAPI app + AgentCore container contract: entrypoint, ARM64 Dockerfile, shared adapters from `src/agent-core/shared/`) + a **variant core** per the spec's `tools`/`types`/`dependencies`. Reuse the three-layer split: pure/IO core (no framework types) → tool/agent adapter → FastAPI transport spine. Draw the file tree from the tools and shared types. |
+| **Key dependencies** | The spine set (`strands-agents`, `fastapi`/`uvicorn`, `pydantic`, AWS Lambda Powertools) + whatever `dependencies.outbound_http` implies (an HTTP client such as `httpx` for HTTP deps, a JSON/XML parser per `response_format`). State capabilities → concrete packages here; the spec stays capability-level. |
+| **Task map** | The regular decomposition: **T1** scaffold (package layout + `pyproject`/deps), **T2** core (Pydantic types + per-tool logic, unit tests), **T3** tool/agent adapter (a `@tool` per spec tool + input models), **T4** FastAPI transport spine, **T5** integration test, **T6** ARM64 Dockerfile, **T7** README. Add a dependency/config task when `dependencies` is non-trivial (HTTP client + rate limit + response parsing), and capture-fixtures guidance when `response_format` is a structured format. |
+| **Cross-cutting contract** | The AgentCore Runtime invariant (ARM64, FastAPI on `0.0.0.0:8080`, `/ws` + `/invocations` + `/ping`, stateless container per `server.stateful`, auth per `server.auth`) — restate and map each row to the task that enforces it. |
+| **Decisions & open questions** | Decided items from the spec + linked ADRs (target, stateful, auth). Constraint modes (`clamp`/`reject`), `nullable` outputs, and computed fields become explicit decisions with the task that owns them. Flag anything the spec leaves genuinely open. |
+
+## Definition of Done (in place of a story)
+
+A spec has no `story.md`, so derive the DoD — the observable, testable outcomes every task maps to — directly from the spec and state it near the top of the design doc:
+
+- One checkbox per `tool`: it appears in `tools/list` with the spec's input schema, and a representative call returns the spec's output shape.
+- One checkbox per tool `error` case: the stated condition yields the stated model-facing message (surfaced as a tool error, per the framework's convention — not a success envelope).
+- Constraints honored: `clamp` bounds applied in the core; `reject` inputs error before any side effect.
+- The cross-cutting contract holds (builds ARM64; FastAPI serves `0.0.0.0:8080` with `/ws`+`/invocations`+`/ping`; stateless/stateful per spec).
+
+Every task's Acceptance must cover at least one DoD checkbox; flag any gap rather than papering over it.
+
+## Principles
+
+- **Spec is source of truth.** The design doc references `specs/<name>.yaml` as its authority (a link at the top, in place of the usual `story.md` companion link). Re-running this skill after a spec change regenerates the doc.
+- **Structure here, API surface in `/tasks`, implementation in the manual build.** Same rule as `/design-doc`: no function bodies in the design doc — only architecture, dependencies, and the task map.
+- **Honor recorded decisions.** The spine is fixed by ADRs (where present); don't re-litigate CDK-vs-Terraform, Runtime-vs-Gateway, or stateless-default — reference the ADRs.
+- **Thin over `/design-doc`.** This skill *is* the design phase for spec-driven work; it deliberately produces the same artifact shape so everything downstream (`/tasks`, build, `/pr-draft`) is unchanged.

--- a/.claude/skills/spec-design/references/design-template.md
+++ b/.claude/skills/spec-design/references/design-template.md
@@ -1,0 +1,76 @@
+# Design Doc — <Story title>
+
+> Companion to [`story.md`](story.md). **High-level** design: architecture, decisions, and the task map. Detailed code for each unit of work lives in [`tasks/`](tasks/) — this doc is the single source of *structure*, the task files are the single source of *code*.
+>
+> <Optional: note the SDK/library version this was verified against and the date.>
+
+## 1. Goal & non-goals
+
+**Goal:** <one sentence — the deliverable.>
+
+**Non-goals (this story):** <explicitly deferred work.> <Link ADRs where a non-goal is a recorded decision.>
+
+## 2. Architecture
+
+<Prose + an ASCII diagram of the layers/modules and their responsibilities. One line per layer on why it's separated.>
+
+```
+┌───────────────────────────────┐
+│ <layer>   <responsibility>     │
+├───────────────────────────────┤
+│ <layer>   <responsibility>     │
+└───────────────────────────────┘
+```
+
+**File layout:** <a tree of the files to be created/changed, annotated with the task that produces each. Mirror the repo's `src/<feature>/` ↔ `iac-cdk/lib/<feature>/` convention where relevant.>
+
+```
+src/<feature>/<name>/
+├── __init__.py      # T?   (Python) — or index.ts for a TS module
+├── handler.py       # T?
+└── tests/
+    └── test_*.py    # T?
+```
+
+## 3. Key dependencies
+
+<Table of load-bearing choices only — not every transitive dep.>
+
+| Dependency | Why |
+|------------|-----|
+| `<package>` (extras …) | <one-line justification> |
+
+> <Version pinning policy / verification date, if relevant.>
+
+## 4. Task map
+
+Each task ends green (Python: `ruff`/`black`/`pytest`; TS: `tsc`/`eslint`/tests) and maps to a Definition-of-Done checkbox in the story. Detail + code go in each task file.
+
+| # | Task | Depends on | File |
+|---|------|-----------|------|
+| T1 | <scaffold> | — | [tasks/T1-*.md](tasks/T1-*.md) |
+| T2 | <...> | T1 | [tasks/T2-*.md](tasks/T2-*.md) |
+
+Recommended order: <T1 → T2 → …, noting which can run in parallel>.
+
+## 5. <Cross-cutting contract> (optional)
+
+<Any invariant every task must preserve. For AgentCore Runtime containers, restate the contract and which task enforces each row.>
+
+| Requirement | Value | Enforced in |
+|-------------|-------|-------------|
+| Platform | ARM64 / aarch64 | T? |
+| Host / Port | `0.0.0.0` / `8080` (A2A twin: `9000`) | T? |
+| Routes | FastAPI `/ws`, `/invocations`, `/ping` | T? |
+| Session model | stateless container; history in DynamoDB | T? |
+| Auth | none in container (runtime is boundary) | all |
+
+## 6. Decisions & open questions
+
+**Decided:**
+
+1. ✅ **<decision>:** <what and why.> → T?
+
+**Still open:**
+
+- ⏳ **<question>:** <what's undecided and when it'll be decided.> → T?

--- a/.claude/skills/story-new/SKILL.md
+++ b/.claude/skills/story-new/SKILL.md
@@ -1,0 +1,28 @@
+---
+description: Draft a new AI-DLC user story from a one-line idea into local/user-stories/<name>/story.md
+user_invocable: true
+---
+
+# /story-new — draft a user story
+
+Kicks off the AI-DLC pipeline (inception phase) by turning a rough idea into a structured `story.md`. This is step 1 of: **story-new → story-refine → design-doc → tasks → (build) → pr-draft**.
+
+## Input
+
+The user's argument is a short idea and (ideally) a slug for the folder, e.g. `/story-new weather-tool "an MCP tool that fetches current weather for a city"`.
+
+If no slug is given, propose one (kebab-case, derived from the idea) and confirm it.
+
+## Steps
+
+1. **Resolve the target folder.** `local/user-stories/<slug>/`. If it already exists and contains a `story.md`, STOP and ask whether to overwrite or pick a new slug — never clobber silently.
+2. **Read the template** in `references/story-template.md` (bundled in this skill folder). It is the canonical shape. Match its section order and conventions.
+3. **Draft the story.** Fill the template from the idea. It is fine — expected — to leave `Investigation outcomes` sparse and mark unknowns explicitly as `⏳ open:` items; `/story-refine` resolves those next. Do NOT invent library versions, API shapes, or AWS contract details you haven't verified — flag them as open questions instead.
+4. **Show the draft to the user** (the full proposed `story.md`) and ask for approval or edits. Do not write the file until the user confirms.
+5. **On confirmation**, write `local/user-stories/<slug>/story.md` and tell the user the path plus the suggested next step: `/story-refine <slug>`.
+
+## Conventions
+
+- Stories live under `local/user-stories/<slug>/` — this is gitignored working space, by design.
+- Keep it a *story*, not a design: describe **what** and **why**, defer **how** to the design doc.
+- The `Definition of Done` is a checkbox list of observable, testable outcomes.

--- a/.claude/skills/story-new/references/story-template.md
+++ b/.claude/skills/story-new/references/story-template.md
@@ -1,0 +1,39 @@
+# <Title — one line, "As <role>, I want <capability>, so that <benefit>">
+
+## Description
+
+<2–5 sentences: what the feature/tool/change does, where it lives (e.g. a Python package under `src/<feature>/`, a construct under `iac-cdk/lib/<feature>/`, or a React component under `src/user-interface/`), and the essential contract. Include a small contract table when a tool has a typed input/output, e.g.:>
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `operation` | string enum | `add` \| `subtract` \| ... |
+| `a` | number | first operand |
+| result | `{ "result": number }` | error conditions noted |
+
+<Optional: an illustrative code sketch. If shown, label it clearly as illustrative — the real implementation may replace it (e.g. with a framework decorator or SDK helper). Do not present a sketch as the final shape.>
+
+## Investigation outcomes (resolved)
+
+<Numbered subsections, one per decided question. Each states the decision, a one-line rationale, and a source link where external facts are involved. Leave sparse in a fresh draft — /story-refine fills these in. Mark anything unverified as an open question below instead of guessing.>
+
+### 1. <Decision area — e.g. Library choice>
+
+- <what was decided and why, with a source link if it's an external fact>
+
+## Scope
+
+**In scope:** <the observable deliverables of this story.>
+**Out of scope (follow-up):** <explicitly deferred work — deployment, auth, extra features, etc.>
+
+## Definition of Done
+
+<Checkbox list of observable, testable outcomes. Each should map to something a reviewer can verify.>
+
+- [ ] <e.g. a package exists under `src/<feature>/` and `ruff`/`black`/`pytest` pass (or, for TS, `tsc`/`eslint`/tests pass)>
+- [ ] <e.g. the tool can be listed and invoked, including the documented error path>
+- [ ] <...>
+
+---
+
+<!-- Open questions for /story-refine to resolve. Delete this block once none remain. -->
+<!-- ⏳ open: <question that needs an answer before design> -->

--- a/.claude/skills/story-refine/SKILL.md
+++ b/.claude/skills/story-refine/SKILL.md
@@ -1,0 +1,31 @@
+---
+description: Clarify and harden an existing draft story.md — resolve open questions and challenge assumptions before design
+user_invocable: true
+---
+
+# /story-refine — clarify a story
+
+Step 2 of the AI-DLC pipeline. Takes a draft `story.md` and makes it design-ready: resolves open questions, verifies external facts, challenges hidden assumptions, and tightens the Definition of Done. Output is the *same* `story.md`, improved in place.
+
+## Input
+
+The user's argument is the story slug (folder under `local/user-stories/`), e.g. `/story-refine weather-tool`. If omitted and only one in-progress story exists, use it; otherwise list the candidates and ask.
+
+## Steps
+
+1. **Read** `local/user-stories/<slug>/story.md`.
+2. **Interrogate it.** Produce a short list of the things that must be resolved before a design doc can be written. Draw from:
+   - `⏳ open:` items already flagged in the story.
+   - **Unstated assumptions** — transport, statefulness, auth boundary, error semantics, number/data types, dependency choices, target platform (recall: AgentCore requires ARM64).
+   - **Unverified external facts** — library names/versions, SDK API shapes, AWS contract details. Verify these against real sources (PyPI, npm, official docs) rather than asserting from memory. Use WebFetch / the aws docs tools where available; if you cannot verify, say so and keep it an open question rather than guessing.
+   - **Scope creep / ambiguity** — anything in the description that could be read two ways.
+3. **Ask the user the open questions** in a batch (use the question prompt UI). Recommend a default for each where you have a defensible one, so the user can accept quickly. Do not proceed on assumptions the user hasn't confirmed.
+4. **Fold the answers back in:** move resolved items into `Investigation outcomes`, tighten `Scope`, sharpen the `Definition of Done`, and delete the open-questions block once empty. Flag any decision that looks ADR-worthy (a cross-cutting, hard-to-reverse choice) so `/design-doc` can record it.
+5. **Show a diff/summary** of what changed and confirm before writing.
+6. **On confirmation**, write the updated `story.md` and suggest the next step: `/design-doc <slug>`.
+
+## Principles
+
+- Refining means *reducing uncertainty*, not adding implementation detail — leave the **how** to the design doc. If you find yourself writing code or file layouts, that belongs in `/design-doc`.
+- Prefer resolving a question to deferring it, but an honestly-deferred question (with rationale) is better than a guessed answer.
+- Keep the story's proven section shape (see the `story-new` skill's `references/story-template.md`).

--- a/.claude/skills/tasks/SKILL.md
+++ b/.claude/skills/tasks/SKILL.md
@@ -1,0 +1,31 @@
+---
+description: Expand a design doc's task map into a tasks/ folder — a README index plus one file per subtask
+user_invocable: true
+---
+
+# /tasks — decompose into subtasks
+
+Step 4 of the AI-DLC pipeline. Expands the **Task map** from an approved `design-doc.md` into a `tasks/` folder: a `README.md` index and one `T<N>-<slug>.md` file per task. Task files specify the **API surface** (interface + docs) for each unit — not full implementations. Writing the implementation is the building phase's job, which starts after inception is complete.
+
+## Input
+
+The story slug, e.g. `/tasks weather-tool`. Reads `local/user-stories/<slug>/design-doc.md`.
+
+## Steps
+
+1. **Read** the design doc, especially its Task map table (# / Task / Depends on / File) and the cross-cutting contract. If there is no task map, STOP and recommend `/design-doc <slug>` first.
+2. **Read the templates** in `references/` (bundled): `tasks-readme-template.md` and `task-template.md`.
+3. **Generate the index** `tasks/README.md` from the design doc's task map: a status table (#, Task, Status, Depends on) with every task starting at `not-started`, the recommended order, and the status-progression note.
+4. **Generate one file per task**, `tasks/T<N>-<slug>.md`, each with: Status / Depends-on / DoD- mapping header, Objective, Files, an **API surface** for that unit, Notes/gotchas, an Acceptance checkbox list, and any task-local Decisions.
+   - **API surface, not implementation.** Specify the *interface* the building phase will implement: public function signatures, classes, Pydantic/dataclass models, enums, protocols (TS: functions, interfaces, types), key type signatures — each with a docstring describing intent, invariants, and error conditions. Leave bodies as `...` / `raise NotImplementedError` / `throw new Error("todo")` / prose. The goal is to give the building-phase agent clear guidance on **what** to build without handing it a **how** to copy-paste. Do NOT write full implementations here — that is the building phase's job, which runs after inception is complete.
+   - Where an exact SDK API shape is uncertain, include the intended signature and add a "confirm at build/type-check time" note pointing at the relevant docs/example.
+5. **Keep task files consistent with the design doc** — same file paths, same dependency edges, same DoD mapping. Every DoD checkbox in the story should be covered by at least one task's Acceptance; flag any gap.
+6. **Show the proposed file list + the README index** and confirm before writing all files.
+7. **On confirmation**, write `tasks/README.md` and each `tasks/T*.md`. Tell the user the tasks are ready to build, and that status should progress `not-started → in-progress → done` (in both the README table and each file's `**Status:**`) as work proceeds.
+
+## Principles
+
+- One task = one coherent unit that, once *implemented*, ends green (Python: `ruff`/`black`/`pytest`; TS: `tsc`/`eslint`/tests). If a task can't be verified in isolation, it's too big or wrongly cut — revisit the split.
+- Inception stops at the interface. If you're tempted to write function bodies, stop — that's the building phase.
+- Don't re-derive architecture here; if the decomposition reveals a structural problem, surface it and suggest editing the design doc rather than silently diverging.
+- Task code must honor the design doc's cross-cutting contract (e.g. ARM64, FastAPI on `0.0.0.0:8080`, stateless container).

--- a/.claude/skills/tasks/references/task-template.md
+++ b/.claude/skills/tasks/references/task-template.md
@@ -1,0 +1,48 @@
+# T<N> — <task title>
+
+**Status:** not-started
+**Depends on:** <T? or —>
+**DoD mapping:** "<the story Definition-of-Done checkbox this task satisfies>"
+
+## Objective
+
+<1–3 sentences: what this unit delivers and where it stops. State what is explicitly NOT in this task if a reader might assume otherwise.>
+
+## Files
+
+- `<path/to/file>` <(new / modified — one line on what changes)>
+
+## API surface
+
+<The **interface** to implement, NOT the implementation. Specify the public shapes — functions, classes, Pydantic/dataclass models, enums, protocols, key type signatures (TS: functions, interfaces, types) — each with a docstring describing intent, invariants, and error conditions. Bodies stay as `...`/`raise NotImplementedError`/prose so the building-phase agent has clear guidance on *what* to build without copy-pasting a *how*. Include only what pins down the contract: signatures, field/variant meanings, and error conditions.>
+
+```python
+def <name>(<params>: <Type>) -> <ReturnType>:
+    """<what this function is for; invariants; when it raises.>"""
+    ...
+
+
+class <Name>(BaseModel):
+    """<what this model represents.>"""
+
+    <field>: <Type>  # <field meaning>
+
+
+class <Enum>(str, Enum):
+    <VARIANT> = "<value>"  # <meaning>
+```
+
+<For TypeScript units (React/CDK), use a `ts` block instead — exported function signatures, `interface`/`type` shapes, and enums, with bodies left as `throw new Error("todo")` or JSDoc prose.>
+
+## Notes / gotchas
+
+<API points likely to differ across versions, subtle ordering constraints, decisions the builder must honor. Point to the SDK example or docs to confirm exact signatures at build time. Omit if none.>
+
+## Acceptance
+
+- [ ] Lint/type checks pass (Python: `ruff`/`black`/`pytest`; TS: `tsc`/`eslint`).
+- [ ] <task-specific observable check tied to the DoD mapping.>
+
+## Decisions
+
+<Task-local decisions with rationale, marked ✅ once decided. Omit if none.>

--- a/.claude/skills/tasks/references/tasks-readme-template.md
+++ b/.claude/skills/tasks/references/tasks-readme-template.md
@@ -1,0 +1,12 @@
+# Tasks — <Story title>
+
+Per-task breakdown of [`../design-doc.md`](../design-doc.md). Each file is one unit of work with its objective, files, code, acceptance check, and status. **Code lives here, not in the design doc** — the design doc holds architecture + the task map.
+
+| # | Task | Status | Depends on |
+|---|------|--------|-----------|
+| [T1](T1-<slug>.md) | <task> | not-started | — |
+| [T2](T2-<slug>.md) | <task> | not-started | T1 |
+
+**Order:** <T1 → T2 → …, noting parallelizable tasks>.
+
+Update the Status column (and each file's `**Status:**`) as work progresses: `not-started` → `in-progress` → `done`.

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ cdk.out
 
 # MISC
 cache
+local/
 .vscode
 .env
 *.DS_Store*


### PR DESCRIPTION
## Summary

Adds the AI-DLC inception pipeline as a set of Claude Code skills under `.claude/skills/`. These turn a rough idea (or a factory spec) into build-ready task interfaces through a sequence of human-gated phases: **story → refine → design → tasks**. The pipeline deliberately stops at task API surfaces — inception ends where the building phase begins — and each artifact lands in gitignored `local/` working space.

## Changes

- **Orchestrator:** `ai-dlc` — thin conductor that chains the per-phase skills in order, pausing for human validation between each. Resumable (picks up at the first incomplete phase) and spec-aware (enters at design when a `specs/<name>.yaml` exists).
- **Phase skills:**
  - `story-new` — draft a structured `story.md` from a one-line idea; flags unknowns as open questions rather than inventing details.
  - `story-refine` — resolve open questions, verify external facts, challenge assumptions, tighten the Definition of Done.
  - `design-doc` — turn an approved story into `design-doc.md` (architecture, dependencies, task map, optional ADRs).
  - `tasks` — expand the task map into a `tasks/` folder (README index + one file per task specifying API surface, not implementations).
  - `spec-design` — bridge a factory spec into the pipeline at the design phase, skipping story/refine since a spec is already-refined requirements.
- **Templates:** bundled `references/` templates for story, design doc, and tasks so output shape is consistent whether a phase runs standalone or via `/ai-dlc`.
- **`.gitignore`:** ignore `local/` (the pipeline's working directory for stories/designs/tasks).

## Test plan

- [x] Run `/ai-dlc <slug> "<idea>"` end to end and confirm it gates between each phase, writing artifacts under `local/user-stories/<slug>/`.
- [x] Run each skill standalone (`/story-new`, `/story-refine`, `/design-doc`, `/tasks`) and confirm resume behavior picks up the correct phase.
- [x] Run `/spec-design <name>` against an existing `specs/<name>.yaml` and confirm it produces a `design-doc.md` consumable by `/tasks`.
- [x] Confirm `local/` is ignored (`git status` shows no pipeline artifacts).
