### PR TITLE
♻️ Improve AgentCore Runtime Manager: row menu, safe delete, new actions

### DIFF
--- a/docs/adr/0005-update-container-adopts-current-image.md
+++ b/docs/adr/0005-update-container-adopts-current-image.md
@@ -1,0 +1,28 @@
+# 0005 — "Update container" adopts the current image, it does not rebuild from source
+
+- Status: Accepted
+- Date: 2026-07-30
+- Context: [refactor-runtime-manager-ui story](../../local/user-stories/refactor-runtime-manager-ui/story.md), [design doc](../../local/user-stories/refactor-runtime-manager-ui/design-doc.md)
+
+## Context
+
+The AgentCore Runtime Manager gains an "Update container" action. The intuitive expectation is "rebuild the agent's Docker image so my source-code changes take effect." Investigation of the build pipeline shows this is not achievable from the running application:
+
+1. **The container images are generic.** Agent behavior comes from the config bundle read at runtime, not from the image. There is one pre-built image per architecture (single / swarm / graph / agents-as-tools); a "new version" only re-versions *config* against the same image.
+2. **Image tags are content-hash-pinned at deploy time.** `codebuild-docker-image.ts:83-93` derives the tag from an S3 asset of the build-context directory. The S3 source asset and `IMAGE_TAG` are refreshed only at `cdk synth`/deploy.
+3. **Builds are triggered only by the deploy-time script.** `iac-cdk/scripts/build.sh:226` is the sole caller of `codebuild start-build`; there is no Lambda, mutation, Step Function, or EventBridge rule that starts a build or reacts to build completion.
+4. **A Lambda `start-build` would rebuild stale source.** Triggering an existing builder project re-produces the *last-deployed* source snapshot, not newer local code — so even a new backend path could not pick up source changes without refreshing the build asset (a deploy operation).
+5. **The runtime Lambda's `CONTAINER_URI` env is refreshed every deploy** (`agent-core-runtime.ts:79-82,647-650`), but existing runtimes stay pinned to the image tag they were created with — they do not auto-adopt a newer image.
+
+## Decision
+
+"Update container" **re-versions the selected runtime against the image URI currently baked into the runtime Lambda's environment**, keeping the same config bundle. Concretely it reuses the already-deployed path: fetch the agent's current configuration (`getDefaultRuntimeConfiguration`) and re-submit it via `createAgentCoreRuntime`, which calls `update_agent_runtime` with the current env `containerUri` and mints a new runtime version (`create-runtime-version/index.py:241-245,289,332-347`).
+
+This is implemented **entirely client-side** by reusing two deployed GraphQL operations — no new mutation, Lambda, IAM, CodeBuild trigger, or ECR polling.
+
+## Consequences
+
+- **Positive:** Small, safe, UI-only change; lets an existing runtime adopt a platform image update that a prior `make deploy` published, without recreating the agent or editing its config.
+- **Positive:** No new IAM surface, no coupling to the deploy pipeline, no long-running build/poll state to manage in the app.
+- **Negative / expectation gap:** The action does **not** pick up an author's new source code. Picking up new source still requires `make deploy` (which refreshes the build asset and rewires `CONTAINER_URI`). The UI copy and task docs must state this clearly so the action isn't mistaken for a source rebuild.
+- **Trade-off:** A true button-triggered source rebuild is deferred indefinitely; it would require refreshing the S3 build-context asset from outside a deploy plus a build-completion→URI adoption mechanism — a cross-stack effort out of proportion to the value here.

--- a/docs/adr/0006-buttondropdown-row-menu-convention.md
+++ b/docs/adr/0006-buttondropdown-row-menu-convention.md
@@ -1,0 +1,24 @@
+# 0006 — Introduce a per-row `⋯` ButtonDropdown action-menu convention
+
+- Status: Accepted
+- Date: 2026-07-30
+- Context: [refactor-runtime-manager-ui story](../../local/user-stories/refactor-runtime-manager-ui/story.md), [design doc](../../local/user-stories/refactor-runtime-manager-ui/design-doc.md)
+
+## Context
+
+The AgentCore Runtime Manager currently packs all selection-scoped actions (New version, Tag version, Set as Favorite, View, Delete) into the table **header toolbar** as `inline-link` buttons gated on `selectedItems.length === 1` (`agent-core-runtime-manager.tsx:560-647`). This story adds two more actions (Start a session, Update container), bringing the total to ~7 — the toolbar is already crowded.
+
+Every existing admin table in the app renders per-row actions as an **inline-button "Actions" column** (`skill-manager.tsx:232`, `mcp-server-manager.tsx:244`, `run-history-modal.tsx:189`). The only `ButtonDropdown` in the codebase is the header profile menu (`global-header.tsx:65`) — there is **no** per-row dropdown pattern today. Seven inline buttons per row would be visually unmanageable.
+
+## Decision
+
+Introduce a per-row **three-dots (`⋯`) `ButtonDropdown`** as the "Actions" column for the Runtime Manager. Items are the selection-scoped actions; each item's `disabled` state reflects the row's status (e.g. transient-status rows disable Delete/Update). Delete additionally **remains in the header** for multi-select whole-agent deletion.
+
+The `items` / `onItemClick` (`ButtonDropdownProps.ItemClickDetails`) shape follows the existing `global-header.tsx` usage. The dropdown lives in a small dedicated `row-actions.tsx` component so it can be reused and unit-reasoned in isolation.
+
+## Consequences
+
+- **Positive:** Scales cleanly to 7+ actions; declutters the header; per-item disabling gives clearer affordances than a greyed toolbar button.
+- **Positive:** Establishes a reusable row-menu pattern other admin tables can adopt as their action lists grow.
+- **Negative:** Diverges from the current inline-button-Actions-column convention, so the app now has two row-action idioms until others migrate. Acceptable: inline buttons remain fine for tables with ≤2 actions; the dropdown is the choice when the list is long.
+- **Trade-off:** One extra click to reach an action versus a directly-visible button — accepted in exchange for a readable row at 7 actions.

--- a/src/user-interface/react-app/src/components/admin/agent-core-runtime-manager.tsx
+++ b/src/user-interface/react-app/src/components/admin/agent-core-runtime-manager.tsx
@@ -25,6 +25,7 @@ import {
 import CopyToClipboard from "@cloudscape-design/components/copy-to-clipboard";
 import { useCallback, useContext, useEffect, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
+import { v4 as uuidv4 } from "uuid";
 
 import { generateClient } from "aws-amplify/api";
 import { RuntimeSummary } from "../../API";
@@ -182,6 +183,13 @@ export default function AgentCoreEndpointManager(props: AgentManagerProps) {
         navigate(`/agent-core/create?from=${encodeURIComponent(agent.agentName)}`);
     };
 
+    // Start a session: mint a fresh session id and open the chat route with the
+    // agent id as a query param. The chat pre-selects this agent and pins the
+    // qualifier to DEFAULT (implied by not passing one). Mirrors the ?from= idiom.
+    const handleStartSession = (agent: RuntimeSummary) => {
+        navigate(`/${uuidv4()}?agentRuntimeId=${encodeURIComponent(agent.agentRuntimeId)}`);
+    };
+
     // Central dispatch for the per-row `⋯` action menu. Modals below read
     // selectedItems[0], so pin the selection to the acted-on row before
     // delegating to the (agent-taking) handlers. start-session and
@@ -205,8 +213,10 @@ export default function AgentCoreEndpointManager(props: AgentManagerProps) {
                 setShowDeleteModal(true);
                 break;
             case "start-session":
+                handleStartSession(agent);
+                break;
             case "update-container":
-                // Wired in T5 / T6.
+                // Wired in T6.
                 break;
         }
     };

--- a/src/user-interface/react-app/src/components/admin/agent-core-runtime-manager.tsx
+++ b/src/user-interface/react-app/src/components/admin/agent-core-runtime-manager.tsx
@@ -339,6 +339,29 @@ export default function AgentCoreEndpointManager(props: AgentManagerProps) {
         return JSON.parse(result.data.getRuntimeConfigurationByVersion);
     };
 
+    // Refresh the list once the control plane reports an update for `agentName`.
+    // Deletes go through a Step Function, so the row lingers in "Deleting" until
+    // the notification arrives; we resync then and tear the subscription down.
+    const subscribeToAgentUpdate = (agentName: string) => {
+        const subscription = apiClient
+            .graphql({
+                query: receiveUpdateNotification,
+                variables: { agentName },
+            })
+            .subscribe({
+                next: (data) => {
+                    if (data.data?.receiveUpdateNotification?.agentName === agentName) {
+                        fetchAgents();
+                        subscription.unsubscribe();
+                    }
+                },
+                error: (error) => {
+                    console.error("Subscription error:", error);
+                    subscription.unsubscribe();
+                },
+            });
+    };
+
     const handleDelete = async (deleteMode: "all" | "specific", selectedQualifiers?: string[]) => {
         // Re-validate at confirm time: a background fetchAgents() can flip the
         // selection to a transient status while the modal is open. Never fire a
@@ -350,7 +373,39 @@ export default function AgentCoreEndpointManager(props: AgentManagerProps) {
 
         setIsDeleting(true);
         try {
-            if (selectedItems.length === 1) {
+            // Multi-select deletes entire agents (no endpoint picker); the
+            // single-select flow keeps the "all" | "specific" endpoint choice.
+            if (selectedItems.length > 1) {
+                const favoriteResult = await apiClient.graphql({ query: getFavoriteRuntimeQuery });
+                const currentFavorite = favoriteResult.data.getFavoriteRuntime;
+
+                // Reset the favorite if any agent being deleted currently owns it.
+                if (
+                    currentFavorite &&
+                    selectedItems.some((a) => a.agentRuntimeId === currentFavorite.agentRuntimeId)
+                ) {
+                    await apiClient.graphql({ query: resetFavoriteRuntimeMut });
+                }
+
+                // Fire whole-agent deletes in parallel, then refresh once.
+                await Promise.all(
+                    selectedItems.map((agent) =>
+                        apiClient.graphql({
+                            query: deleteAgentRuntimeMut,
+                            variables: {
+                                agentName: agent.agentName,
+                                agentRuntimeId: agent.agentRuntimeId,
+                            },
+                        }),
+                    ),
+                );
+
+                await new Promise((resolve) => setTimeout(resolve, 2000));
+                setShowDeleteModal(false);
+                await fetchAgents();
+
+                selectedItems.forEach((agent) => subscribeToAgentUpdate(agent.agentName));
+            } else if (selectedItems.length === 1) {
                 const agent = selectedItems[0];
 
                 const favoriteResult = await apiClient.graphql({ query: getFavoriteRuntimeQuery });
@@ -391,27 +446,7 @@ export default function AgentCoreEndpointManager(props: AgentManagerProps) {
                     // Fetch agents to show "Deleting" status
                     await fetchAgents();
 
-                    // Subscribe to deletion notification
-                    const subscription = apiClient
-                        .graphql({
-                            query: receiveUpdateNotification,
-                            variables: { agentName: agent.agentName },
-                        })
-                        .subscribe({
-                            next: (data) => {
-                                if (
-                                    data.data?.receiveUpdateNotification?.agentName ===
-                                    agent.agentName
-                                ) {
-                                    fetchAgents(); // Refresh the list when deletion completes
-                                    subscription.unsubscribe();
-                                }
-                            },
-                            error: (error) => {
-                                console.error("Subscription error:", error);
-                                subscription.unsubscribe();
-                            },
-                        });
+                    subscribeToAgentUpdate(agent.agentName);
                 } else if (deleteMode === "specific" && selectedQualifiers) {
                     // Delete specific endpoints
                     await apiClient.graphql({
@@ -429,27 +464,7 @@ export default function AgentCoreEndpointManager(props: AgentManagerProps) {
 
                     await fetchAgents();
 
-                    // Subscribe to deletion notification for refresh only
-                    const subscription = apiClient
-                        .graphql({
-                            query: receiveUpdateNotification,
-                            variables: { agentName: agent.agentName },
-                        })
-                        .subscribe({
-                            next: (data) => {
-                                if (
-                                    data.data?.receiveUpdateNotification?.agentName ===
-                                    agent.agentName
-                                ) {
-                                    fetchAgents(); // Just refresh the list
-                                    subscription.unsubscribe();
-                                }
-                            },
-                            error: (error) => {
-                                console.error("Subscription error:", error);
-                                subscription.unsubscribe();
-                            },
-                        });
+                    subscribeToAgentUpdate(agent.agentName);
                 }
             }
         } catch (error) {
@@ -618,8 +633,8 @@ export default function AgentCoreEndpointManager(props: AgentManagerProps) {
                                         iconName="remove"
                                         variant="inline-link"
                                         disabled={
-                                            selectedItems.length !== 1 ||
-                                            isTransientStatus(selectedItems[0].status)
+                                            selectedItems.length === 0 ||
+                                            selectedItems.some((a) => isTransientStatus(a.status))
                                         }
                                         onClick={() => setShowDeleteModal(true)}
                                     >
@@ -794,11 +809,11 @@ export default function AgentCoreEndpointManager(props: AgentManagerProps) {
                     onVersionSelect={handleVersionSelect}
                 />
             )}
-            {showDeleteModal && selectedItems.length === 1 && (
+            {showDeleteModal && selectedItems.length >= 1 && (
                 <DeleteAgentModal
                     visible={showDeleteModal}
                     onDismiss={() => setShowDeleteModal(false)}
-                    selectedItem={selectedItems[0]}
+                    selectedItems={selectedItems}
                     onDelete={handleDelete}
                     isDeleting={isDeleting}
                 />

--- a/src/user-interface/react-app/src/components/admin/agent-core-runtime-manager.tsx
+++ b/src/user-interface/react-app/src/components/admin/agent-core-runtime-manager.tsx
@@ -47,6 +47,7 @@ import {
 import { receiveUpdateNotification } from "../../graphql/subscriptions";
 import DeleteAgentModal from "./agent-core/delete-agent-modal";
 import RowActions, { RowActionId } from "./agent-core/row-actions";
+import { isTransientStatus } from "./agent-core/runtime-status";
 import TagVersionModal from "./agent-core/tag-version-modal";
 import ViewVersionModal, { VersionInfo } from "./agent-core/view-version-modal";
 
@@ -339,6 +340,14 @@ export default function AgentCoreEndpointManager(props: AgentManagerProps) {
     };
 
     const handleDelete = async (deleteMode: "all" | "specific", selectedQualifiers?: string[]) => {
+        // Re-validate at confirm time: a background fetchAgents() can flip the
+        // selection to a transient status while the modal is open. Never fire a
+        // delete against a runtime with a control-plane op in flight.
+        if (selectedItems.some((a) => isTransientStatus(a.status))) {
+            console.warn("Skipping delete: a selected runtime is in a transient status.");
+            return;
+        }
+
         setIsDeleting(true);
         try {
             if (selectedItems.length === 1) {
@@ -610,7 +619,7 @@ export default function AgentCoreEndpointManager(props: AgentManagerProps) {
                                         variant="inline-link"
                                         disabled={
                                             selectedItems.length !== 1 ||
-                                            selectedItems[0].status.toLowerCase() !== "ready"
+                                            isTransientStatus(selectedItems[0].status)
                                         }
                                         onClick={() => setShowDeleteModal(true)}
                                     >

--- a/src/user-interface/react-app/src/components/admin/agent-core-runtime-manager.tsx
+++ b/src/user-interface/react-app/src/components/admin/agent-core-runtime-manager.tsx
@@ -28,10 +28,11 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { v4 as uuidv4 } from "uuid";
 
 import { generateClient } from "aws-amplify/api";
-import { RuntimeSummary } from "../../API";
+import { ArchitectureType, RuntimeSummary } from "../../API";
 import { AppContext } from "../../common/app-context";
 import { Utils } from "../../common/utils";
 import {
+    createAgentCoreRuntime as createAgentCoreRuntimeMut,
     deleteAgentRuntimeEndpoints as deleteAgentRuntimeEndpointsMut,
     deleteAgentRuntime as deleteAgentRuntimeMut,
     resetFavoriteRuntime as resetFavoriteRuntimeMut,
@@ -39,6 +40,7 @@ import {
     updateFavoriteRuntime as updateFavoriteRuntimeMut,
 } from "../../graphql/mutations";
 import {
+    getDefaultRuntimeConfiguration as getDefaultRuntimeConfigurationQuery,
     getFavoriteRuntime as getFavoriteRuntimeQuery,
     getRuntimeConfigurationByVersion as getRuntimeConfigurationByVersionQuery,
     listAgentBundleVersions as listAgentBundleVersionsQuery,
@@ -73,6 +75,8 @@ export default function AgentCoreEndpointManager(props: AgentManagerProps) {
     const [viewVersions, setViewVersions] = useState<VersionInfo[]>([]);
     const [showDeleteModal, setShowDeleteModal] = useState(false);
     const [isDeleting, setIsDeleting] = useState(false);
+    const [showUpdateContainerModal, setShowUpdateContainerModal] = useState(false);
+    const [isUpdatingContainer, setIsUpdatingContainer] = useState(false);
     const [showFavoriteModal, setShowFavoriteModal] = useState(false);
     const [availableEndpoints, setAvailableEndpoints] = useState<string[]>([]);
     const [isSettingFavorite, setIsSettingFavorite] = useState(false);
@@ -190,6 +194,48 @@ export default function AgentCoreEndpointManager(props: AgentManagerProps) {
         navigate(`/${uuidv4()}?agentRuntimeId=${encodeURIComponent(agent.agentRuntimeId)}`);
     };
 
+    // Update container: re-version the agent against the currently-deployed image
+    // URI without touching its configuration. We fetch the current default config
+    // and re-submit it unchanged through createAgentCoreRuntime; because the name
+    // matches an existing runtime, the backend calls update_agent_runtime with the
+    // Lambda's current CONTAINER_URI, minting a new version on the deployed image.
+    // This does NOT rebuild from source (see ADR 0005) and does NOT open the wizard.
+    const handleUpdateContainer = async (agent: RuntimeSummary) => {
+        // Re-validate at confirm time: a background refresh can flip the row to a
+        // transient status while the modal is open.
+        if (isTransientStatus(agent.status)) {
+            console.warn("Skipping update: runtime is in a transient status.");
+            return;
+        }
+
+        setIsUpdatingContainer(true);
+        try {
+            const configResult = await apiClient.graphql({
+                query: getDefaultRuntimeConfigurationQuery,
+                variables: { agentName: agent.agentName },
+            });
+            const configValue = configResult.data.getDefaultRuntimeConfiguration;
+
+            await apiClient.graphql({
+                query: createAgentCoreRuntimeMut,
+                variables: {
+                    agentName: agent.agentName,
+                    configValue,
+                    architectureType: (agent.architectureType ?? "SINGLE") as ArchitectureType,
+                },
+            });
+
+            await new Promise((resolve) => setTimeout(resolve, 2000));
+            setShowUpdateContainerModal(false);
+            await fetchAgents(); // surface the "Updating" status
+            subscribeToAgentUpdate(agent.agentName);
+        } catch (error) {
+            console.error("Failed to update container:", error);
+        } finally {
+            setIsUpdatingContainer(false);
+        }
+    };
+
     // Central dispatch for the per-row `⋯` action menu. Modals below read
     // selectedItems[0], so pin the selection to the acted-on row before
     // delegating to the (agent-taking) handlers. start-session and
@@ -216,7 +262,7 @@ export default function AgentCoreEndpointManager(props: AgentManagerProps) {
                 handleStartSession(agent);
                 break;
             case "update-container":
-                // Wired in T6.
+                setShowUpdateContainerModal(true);
                 break;
         }
     };
@@ -827,6 +873,46 @@ export default function AgentCoreEndpointManager(props: AgentManagerProps) {
                     onDelete={handleDelete}
                     isDeleting={isDeleting}
                 />
+            )}
+            {showUpdateContainerModal && selectedItems.length === 1 && (
+                <Modal
+                    visible={showUpdateContainerModal}
+                    onDismiss={() => setShowUpdateContainerModal(false)}
+                    header="Update container"
+                    footer={
+                        <Box float="right">
+                            <SpaceBetween direction="horizontal" size="xs">
+                                <Button
+                                    variant="link"
+                                    onClick={() => setShowUpdateContainerModal(false)}
+                                >
+                                    Cancel
+                                </Button>
+                                <Button
+                                    variant="primary"
+                                    onClick={() => handleUpdateContainer(selectedItems[0])}
+                                    loading={isUpdatingContainer}
+                                    disabled={isTransientStatus(selectedItems[0].status)}
+                                >
+                                    Update container
+                                </Button>
+                            </SpaceBetween>
+                        </Box>
+                    }
+                >
+                    <SpaceBetween size="m">
+                        <Box>
+                            This mints a new version of{" "}
+                            <strong>{selectedItems[0].agentName}</strong> using the currently
+                            deployed container image, keeping its configuration unchanged.
+                        </Box>
+                        <Box variant="small" color="text-status-inactive">
+                            This does not rebuild from source. New source code is picked up only by a
+                            redeploy; this action adopts an already-deployed image update on this
+                            runtime.
+                        </Box>
+                    </SpaceBetween>
+                </Modal>
             )}
             {showFavoriteModal && selectedItems.length === 1 && (
                 <SetFavoriteModal

--- a/src/user-interface/react-app/src/components/admin/agent-core-runtime-manager.tsx
+++ b/src/user-interface/react-app/src/components/admin/agent-core-runtime-manager.tsx
@@ -46,6 +46,7 @@ import {
 } from "../../graphql/queries";
 import { receiveUpdateNotification } from "../../graphql/subscriptions";
 import DeleteAgentModal from "./agent-core/delete-agent-modal";
+import RowActions, { RowActionId } from "./agent-core/row-actions";
 import TagVersionModal from "./agent-core/tag-version-modal";
 import ViewVersionModal, { VersionInfo } from "./agent-core/view-version-modal";
 
@@ -136,20 +137,17 @@ export default function AgentCoreEndpointManager(props: AgentManagerProps) {
         fetchFavoriteRuntime();
     }, [props.toolsOpen]);
 
-    const handleSetFavorite = async () => {
-        if (selectedItems.length === 1) {
-            const agent = selectedItems[0];
-            const qualifierToVersion = JSON.parse(agent.qualifierToVersion);
-            const endpoints = Object.keys(qualifierToVersion);
+    const handleSetFavorite = async (agent: RuntimeSummary) => {
+        const qualifierToVersion = JSON.parse(agent.qualifierToVersion);
+        const endpoints = Object.keys(qualifierToVersion);
 
-            if (endpoints.length === 1) {
-                // Only one endpoint, set it as favorite directly
-                await defineFavoriteRuntime(agent.agentRuntimeId, endpoints[0]);
-            } else {
-                // Multiple endpoints, show modal to select
-                setAvailableEndpoints(endpoints);
-                setShowFavoriteModal(true);
-            }
+        if (endpoints.length === 1) {
+            // Only one endpoint, set it as favorite directly
+            await defineFavoriteRuntime(agent.agentRuntimeId, endpoints[0]);
+        } else {
+            // Multiple endpoints, show modal to select
+            setAvailableEndpoints(endpoints);
+            setShowFavoriteModal(true);
         }
     };
 
@@ -179,10 +177,36 @@ export default function AgentCoreEndpointManager(props: AgentManagerProps) {
         }
     };
 
-    const handleCreateNewVersion = () => {
-        if (selectedItems.length === 1) {
-            const agent = selectedItems[0];
-            navigate(`/agent-core/create?from=${encodeURIComponent(agent.agentName)}`);
+    const handleCreateNewVersion = (agent: RuntimeSummary) => {
+        navigate(`/agent-core/create?from=${encodeURIComponent(agent.agentName)}`);
+    };
+
+    // Central dispatch for the per-row `⋯` action menu. Modals below read
+    // selectedItems[0], so pin the selection to the acted-on row before
+    // delegating to the (agent-taking) handlers. start-session and
+    // update-container land in T5/T6.
+    const handleRowAction = (id: RowActionId, agent: RuntimeSummary) => {
+        setSelectedItems([agent]);
+        switch (id) {
+            case "new-version":
+                handleCreateNewVersion(agent);
+                break;
+            case "tag-version":
+                handleTagVersion(agent);
+                break;
+            case "set-favorite":
+                handleSetFavorite(agent);
+                break;
+            case "view":
+                handleViewAgent(agent);
+                break;
+            case "delete":
+                setShowDeleteModal(true);
+                break;
+            case "start-session":
+            case "update-container":
+                // Wired in T5 / T6.
+                break;
         }
     };
 
@@ -223,22 +247,19 @@ export default function AgentCoreEndpointManager(props: AgentManagerProps) {
         }
     }, [searchParams, setSearchParams, apiClient, fetchAgents]);
 
-    const handleTagVersion = async () => {
-        if (selectedItems.length === 1) {
-            setShowTagModal(true);
-            const agent = selectedItems[0];
-            try {
-                const result = await apiClient.graphql({
-                    query: listAgentVersionsQuery,
-                    variables: { agentRuntimeId: agent.agentRuntimeId },
-                });
-                setAvailableVersions(
-                    (result.data.listAgentVersions || []).filter((v): v is string => v !== null),
-                );
-            } catch (error) {
-                console.error("Failed to fetch agent versions:", error);
-                setShowTagModal(false);
-            }
+    const handleTagVersion = async (agent: RuntimeSummary) => {
+        setShowTagModal(true);
+        try {
+            const result = await apiClient.graphql({
+                query: listAgentVersionsQuery,
+                variables: { agentRuntimeId: agent.agentRuntimeId },
+            });
+            setAvailableVersions(
+                (result.data.listAgentVersions || []).filter((v): v is string => v !== null),
+            );
+        } catch (error) {
+            console.error("Failed to fetch agent versions:", error);
+            setShowTagModal(false);
         }
     };
 
@@ -272,37 +293,34 @@ export default function AgentCoreEndpointManager(props: AgentManagerProps) {
         }
     };
 
-    const handleViewAgent = async () => {
-        if (selectedItems.length === 1) {
-            const agent = selectedItems[0];
-            try {
-                // Refresh agent data to get latest qualifiers
-                await apiClient.graphql({ query: listRuntimeAgentsQuery });
+    const handleViewAgent = async (agent: RuntimeSummary) => {
+        try {
+            // Refresh agent data to get latest qualifiers
+            await apiClient.graphql({ query: listRuntimeAgentsQuery });
 
-                // List the full history of the agent's configuration bundle. Config
-                // lives in bundles now, so a "version" is a bundle versionId; the
-                // resolver annotates each with the qualifiers pointing at it and its
-                // creation time, so the modal can list every historical version with
-                // a meaningful label — not just the qualifier-mapped current ones.
-                const result = await apiClient.graphql({
-                    query: listAgentBundleVersionsQuery,
-                    variables: { agentName: agent.agentName },
-                });
+            // List the full history of the agent's configuration bundle. Config
+            // lives in bundles now, so a "version" is a bundle versionId; the
+            // resolver annotates each with the qualifiers pointing at it and its
+            // creation time, so the modal can list every historical version with
+            // a meaningful label — not just the qualifier-mapped current ones.
+            const result = await apiClient.graphql({
+                query: listAgentBundleVersionsQuery,
+                variables: { agentName: agent.agentName },
+            });
 
-                const versions = (result.data.listAgentBundleVersions || [])
-                    .filter((v): v is NonNullable<typeof v> => v !== null)
-                    .map((v) => ({
-                        version: v.versionId,
-                        qualifiers: (v.qualifiers ?? []).filter((q): q is string => q !== null),
-                        createdAt: v.createdAt,
-                        commitMessage: v.commitMessage,
-                    }));
+            const versions = (result.data.listAgentBundleVersions || [])
+                .filter((v): v is NonNullable<typeof v> => v !== null)
+                .map((v) => ({
+                    version: v.versionId,
+                    qualifiers: (v.qualifiers ?? []).filter((q): q is string => q !== null),
+                    createdAt: v.createdAt,
+                    commitMessage: v.commitMessage,
+                }));
 
-                setViewVersions(versions);
-                setShowViewModal(true);
-            } catch (error) {
-                console.error("Failed to fetch agent versions:", error);
-            }
+            setViewVersions(versions);
+            setShowViewModal(true);
+        } catch (error) {
+            console.error("Failed to fetch agent versions:", error);
         }
     };
 
@@ -588,51 +606,6 @@ export default function AgentCoreEndpointManager(props: AgentManagerProps) {
                                         Manage Skills
                                     </Button>
                                     <Button
-                                        disabled={
-                                            selectedItems.length !== 1 ||
-                                            selectedItems[0].status.toLowerCase() !== "ready"
-                                        }
-                                        iconName="copy"
-                                        variant="inline-link"
-                                        onClick={handleCreateNewVersion}
-                                    >
-                                        New version
-                                    </Button>
-                                    <Button
-                                        disabled={
-                                            selectedItems.length !== 1 ||
-                                            selectedItems[0].status.toLowerCase() !== "ready"
-                                        }
-                                        iconName="flag"
-                                        variant="inline-link"
-                                        onClick={handleTagVersion}
-                                    >
-                                        Tag version
-                                    </Button>
-                                    <Button
-                                        disabled={
-                                            selectedItems.length !== 1 ||
-                                            selectedItems[0].status.toLowerCase() !== "ready"
-                                        }
-                                        iconName="star"
-                                        variant="inline-link"
-                                        onClick={handleSetFavorite}
-                                        loading={isSettingFavorite}
-                                    >
-                                        Set as Favorite
-                                    </Button>
-                                    <Button
-                                        disabled={
-                                            selectedItems.length !== 1 ||
-                                            selectedItems[0].status.toLowerCase() !== "ready"
-                                        }
-                                        iconName="zoom-in"
-                                        variant="inline-link"
-                                        onClick={handleViewAgent}
-                                    >
-                                        View
-                                    </Button>
-                                    <Button
                                         iconName="remove"
                                         variant="inline-link"
                                         disabled={
@@ -779,6 +752,14 @@ export default function AgentCoreEndpointManager(props: AgentManagerProps) {
                             ),
                             sortingField: "status",
                             width: "auto",
+                        },
+                        {
+                            id: "actions",
+                            header: "Actions",
+                            cell: (item) => (
+                                <RowActions item={item} onAction={handleRowAction} />
+                            ),
+                            width: 100,
                         },
                     ]}
                 />

--- a/src/user-interface/react-app/src/components/admin/agent-core/delete-agent-modal.tsx
+++ b/src/user-interface/react-app/src/components/admin/agent-core/delete-agent-modal.tsx
@@ -21,7 +21,12 @@ import { isTransientStatus } from "./runtime-status";
 interface DeleteAgentModalProps {
     visible: boolean;
     onDismiss: () => void;
-    selectedItem: RuntimeSummary;
+    /** One agent → endpoint-picker mode. Multiple → whole-agent mode (no picker). */
+    selectedItems: RuntimeSummary[];
+    /**
+     * deleteMode is forced to "all" (whole-agent) when selectedItems.length > 1.
+     * selectedQualifiers is only meaningful in single-select "specific" mode.
+     */
     onDelete: (deleteMode: "all" | "specific", selectedQualifiers?: string[]) => Promise<void>;
     isDeleting: boolean;
 }
@@ -29,12 +34,23 @@ interface DeleteAgentModalProps {
 export default function DeleteAgentModal({
     visible,
     onDismiss,
-    selectedItem,
+    selectedItems,
     onDelete,
     isDeleting,
 }: DeleteAgentModalProps) {
     const [deleteMode, setDeleteMode] = useState<"all" | "specific">("all");
     const [selectedQualifiersToDelete, setSelectedQualifiersToDelete] = useState<string[]>([]);
+
+    const isMulti = selectedItems.length > 1;
+    const singleItem = selectedItems[0];
+
+    // Get deletable qualifiers for single-agent selection, excluding protected DEFAULT.
+    // In multi mode there is no picker, so this stays empty.
+    const qualifiers = isMulti
+        ? []
+        : Object.keys(JSON.parse(singleItem.qualifierToVersion)).filter(
+              (qualifier) => qualifier !== "DEFAULT",
+          );
 
     const handleDismiss = () => {
         setDeleteMode("all");
@@ -42,22 +58,17 @@ export default function DeleteAgentModal({
         onDismiss();
     };
 
-    // A control-plane op may start (e.g. a background refresh flips the row to
+    // A control-plane op may start (e.g. a background refresh flips a row to
     // Deleting/Updating) while this modal is open — re-check on every render so
-    // confirm is blocked the moment the selection goes transient.
-    const isTransient = isTransientStatus(selectedItem.status);
+    // confirm is blocked the moment any targeted agent goes transient.
+    const isTransient = selectedItems.some((item) => isTransientStatus(item.status));
 
     const handleDeleteConfirm = async () => {
         if (isTransient) return;
-        await onDelete(deleteMode, selectedQualifiersToDelete);
+        // Multi-select is always whole-agent; the picker is single-select only.
+        await onDelete(isMulti ? "all" : deleteMode, selectedQualifiersToDelete);
         handleDismiss();
     };
-
-    // Get qualifiers for single agent selection
-    // Get qualifiers for single agent selection, excluding protected ones
-    const qualifiers = Object.keys(JSON.parse(selectedItem.qualifierToVersion)).filter(
-        (qualifier) => qualifier !== "DEFAULT",
-    );
 
     // Clear selected qualifiers when available qualifiers change
     useEffect(() => {
@@ -70,7 +81,7 @@ export default function DeleteAgentModal({
         <Modal
             visible={visible}
             onDismiss={handleDismiss}
-            header="Delete Agent"
+            header={isMulti ? `Delete ${selectedItems.length} Agents` : "Delete Agent"}
             size="medium"
             footer={
                 <Box float="right">
@@ -82,7 +93,8 @@ export default function DeleteAgentModal({
                             loading={isDeleting}
                             disabled={
                                 isTransient ||
-                                (deleteMode === "specific" &&
+                                (!isMulti &&
+                                    deleteMode === "specific" &&
                                     selectedQualifiersToDelete.length === 0)
                             }
                         >
@@ -95,8 +107,9 @@ export default function DeleteAgentModal({
             <SpaceBetween size="m">
                 {isTransient ? (
                     <Alert type="warning">
-                        This agent is currently <strong>{selectedItem.status}</strong>. Wait for the
-                        operation to finish before deleting.
+                        {isMulti
+                            ? "One or more selected agents have an operation in progress. Wait for them to finish before deleting."
+                            : `This agent is currently ${singleItem.status}. Wait for the operation to finish before deleting.`}
                     </Alert>
                 ) : (
                     <Alert type="warning">
@@ -104,72 +117,91 @@ export default function DeleteAgentModal({
                     </Alert>
                 )}
 
-                <Box>
+                {isMulti ? (
                     <SpaceBetween size="m">
-                        <Box variant="strong">Agent: {selectedItem.agentName}</Box>
-                        <Box variant="small">Total endpoints: {qualifiers.length}</Box>
+                        <Box>
+                            This deletes <strong>{selectedItems.length} entire agents</strong> and
+                            all of their endpoints:
+                        </Box>
+                        <ul>
+                            {selectedItems.map((item) => (
+                                <li key={item.agentRuntimeId}>{item.agentName}</li>
+                            ))}
+                        </ul>
                     </SpaceBetween>
-                </Box>
+                ) : (
+                    <>
+                        <Box>
+                            <SpaceBetween size="m">
+                                <Box variant="strong">Agent: {singleItem.agentName}</Box>
+                                <Box variant="small">Total endpoints: {qualifiers.length}</Box>
+                            </SpaceBetween>
+                        </Box>
 
-                <FormField label="Delete options">
-                    <RadioGroup
-                        value={deleteMode}
-                        onChange={({ detail }) => {
-                            setDeleteMode(detail.value as "all" | "specific");
-                            setSelectedQualifiersToDelete([]);
-                        }}
-                        items={[
-                            {
-                                value: "all",
-                                label: "Delete entire agent (all endpoints)",
-                            },
-                            ...[
-                                {
-                                    value: "specific" as const,
-                                    label: "Delete specific endpoints only",
-                                },
-                            ],
-                        ]}
-                    />
-                </FormField>
+                        <FormField label="Delete options">
+                            <RadioGroup
+                                value={deleteMode}
+                                onChange={({ detail }) => {
+                                    setDeleteMode(detail.value as "all" | "specific");
+                                    setSelectedQualifiersToDelete([]);
+                                }}
+                                items={[
+                                    {
+                                        value: "all",
+                                        label: "Delete entire agent (all endpoints)",
+                                    },
+                                    ...[
+                                        {
+                                            value: "specific" as const,
+                                            label: "Delete specific endpoints only",
+                                        },
+                                    ],
+                                ]}
+                            />
+                        </FormField>
 
-                {deleteMode === "specific" && (
-                    <FormField
-                        label="Select endpoints to delete"
-                        description="Choose which endpoints you want to delete"
-                    >
-                        <SpaceBetween size="s">
-                            <Alert type="info">
-                                The `DEFAULT` endpoint is protected, and cannot be deleted.
-                            </Alert>
-                            {qualifiers.length === 0 ? (
-                                <Box color="text-status-inactive">
-                                    No deletable endpoints available. All endpoints are protected.
-                                </Box>
-                            ) : (
-                                qualifiers.map((qualifier) => (
-                                    <Checkbox
-                                        key={qualifier}
-                                        checked={selectedQualifiersToDelete.includes(qualifier)}
-                                        onChange={({ detail }) => {
-                                            if (detail.checked) {
-                                                setSelectedQualifiersToDelete((prev) => [
-                                                    ...prev,
+                        {deleteMode === "specific" && (
+                            <FormField
+                                label="Select endpoints to delete"
+                                description="Choose which endpoints you want to delete"
+                            >
+                                <SpaceBetween size="s">
+                                    <Alert type="info">
+                                        The `DEFAULT` endpoint is protected, and cannot be deleted.
+                                    </Alert>
+                                    {qualifiers.length === 0 ? (
+                                        <Box color="text-status-inactive">
+                                            No deletable endpoints available. All endpoints are
+                                            protected.
+                                        </Box>
+                                    ) : (
+                                        qualifiers.map((qualifier) => (
+                                            <Checkbox
+                                                key={qualifier}
+                                                checked={selectedQualifiersToDelete.includes(
                                                     qualifier,
-                                                ]);
-                                            } else {
-                                                setSelectedQualifiersToDelete((prev) =>
-                                                    prev.filter((q) => q !== qualifier),
-                                                );
-                                            }
-                                        }}
-                                    >
-                                        {qualifier}
-                                    </Checkbox>
-                                ))
-                            )}
-                        </SpaceBetween>
-                    </FormField>
+                                                )}
+                                                onChange={({ detail }) => {
+                                                    if (detail.checked) {
+                                                        setSelectedQualifiersToDelete((prev) => [
+                                                            ...prev,
+                                                            qualifier,
+                                                        ]);
+                                                    } else {
+                                                        setSelectedQualifiersToDelete((prev) =>
+                                                            prev.filter((q) => q !== qualifier),
+                                                        );
+                                                    }
+                                                }}
+                                            >
+                                                {qualifier}
+                                            </Checkbox>
+                                        ))
+                                    )}
+                                </SpaceBetween>
+                            </FormField>
+                        )}
+                    </>
                 )}
             </SpaceBetween>
         </Modal>

--- a/src/user-interface/react-app/src/components/admin/agent-core/delete-agent-modal.tsx
+++ b/src/user-interface/react-app/src/components/admin/agent-core/delete-agent-modal.tsx
@@ -16,6 +16,7 @@ import {
 } from "@cloudscape-design/components";
 import { useEffect, useState } from "react";
 import { RuntimeSummary } from "../../../API";
+import { isTransientStatus } from "./runtime-status";
 
 interface DeleteAgentModalProps {
     visible: boolean;
@@ -41,7 +42,13 @@ export default function DeleteAgentModal({
         onDismiss();
     };
 
+    // A control-plane op may start (e.g. a background refresh flips the row to
+    // Deleting/Updating) while this modal is open — re-check on every render so
+    // confirm is blocked the moment the selection goes transient.
+    const isTransient = isTransientStatus(selectedItem.status);
+
     const handleDeleteConfirm = async () => {
+        if (isTransient) return;
         await onDelete(deleteMode, selectedQualifiersToDelete);
         handleDismiss();
     };
@@ -74,7 +81,9 @@ export default function DeleteAgentModal({
                             onClick={handleDeleteConfirm}
                             loading={isDeleting}
                             disabled={
-                                deleteMode === "specific" && selectedQualifiersToDelete.length === 0
+                                isTransient ||
+                                (deleteMode === "specific" &&
+                                    selectedQualifiersToDelete.length === 0)
                             }
                         >
                             Delete
@@ -84,9 +93,16 @@ export default function DeleteAgentModal({
             }
         >
             <SpaceBetween size="m">
-                <Alert type="warning">
-                    This action cannot be undone. Please confirm what you want to delete.
-                </Alert>
+                {isTransient ? (
+                    <Alert type="warning">
+                        This agent is currently <strong>{selectedItem.status}</strong>. Wait for the
+                        operation to finish before deleting.
+                    </Alert>
+                ) : (
+                    <Alert type="warning">
+                        This action cannot be undone. Please confirm what you want to delete.
+                    </Alert>
+                )}
 
                 <Box>
                     <SpaceBetween size="m">

--- a/src/user-interface/react-app/src/components/admin/agent-core/row-actions.tsx
+++ b/src/user-interface/react-app/src/components/admin/agent-core/row-actions.tsx
@@ -1,0 +1,73 @@
+// -----------------------------------------------------------------------
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: MIT-0
+//
+// -----------------------------------------------------------------------
+
+import { ButtonDropdown, ButtonDropdownProps } from "@cloudscape-design/components";
+import { RuntimeSummary } from "../../../API";
+import { canMutate } from "./runtime-status";
+
+/** Stable ids for each row action; used as ButtonDropdown item ids and in the click switch. */
+export type RowActionId =
+    | "new-version"
+    | "tag-version"
+    | "set-favorite"
+    | "view"
+    | "start-session"
+    | "update-container"
+    | "delete";
+
+export interface RowActionsProps {
+    /** The agent row this menu acts on. */
+    item: RuntimeSummary;
+    /**
+     * Invoked with the chosen action id and the row item. The parent
+     * (agent-core-runtime-manager) owns the handlers and any modals/navigation.
+     */
+    onAction: (id: RowActionId, item: RuntimeSummary) => void;
+    /** True while a mutation for this row is in flight (disables destructive items). */
+    busy?: boolean;
+}
+
+/**
+ * Per-row `⋯` action menu. Renders a Cloudscape ButtonDropdown whose items are
+ * the selection-scoped actions. Item enablement reflects the row's state: while
+ * the runtime is in a transient (in-progress) status — or a mutation for the row
+ * is already in flight — the mutating actions are disabled. "View" stays enabled
+ * so a busy/transient agent can still be inspected.
+ */
+export default function RowActions({ item, onAction, busy }: RowActionsProps) {
+    const mutable = canMutate(item.status) && !busy;
+
+    const items: ButtonDropdownProps.Item[] = [
+        { id: "start-session", text: "Start a session", iconName: "contact", disabled: !mutable },
+        { id: "view", text: "View", iconName: "zoom-in" },
+        { id: "new-version", text: "New version", iconName: "copy", disabled: !mutable },
+        { id: "tag-version", text: "Tag version", iconName: "flag", disabled: !mutable },
+        { id: "set-favorite", text: "Set as Favorite", iconName: "star", disabled: !mutable },
+        {
+            id: "update-container",
+            text: "Update container",
+            iconName: "upload",
+            disabled: !mutable,
+        },
+        { id: "delete", text: "Delete", iconName: "remove", disabled: !mutable },
+    ];
+
+    return (
+        <ButtonDropdown
+            items={items}
+            variant="icon"
+            ariaLabel={`Actions for ${item.agentName}`}
+            expandableGroups={false}
+            // Render the menu in a viewport-level portal so it isn't clipped by
+            // the table row/cell overflow (Cloudscape dropdowns inside tables).
+            expandToViewport
+            onItemClick={({ detail }: { detail: ButtonDropdownProps.ItemClickDetails }) =>
+                onAction(detail.id as RowActionId, item)
+            }
+        />
+    );
+}

--- a/src/user-interface/react-app/src/components/admin/agent-core/runtime-status.ts
+++ b/src/user-interface/react-app/src/components/admin/agent-core/runtime-status.ts
@@ -1,0 +1,29 @@
+// -----------------------------------------------------------------------
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: MIT-0
+//
+// -----------------------------------------------------------------------
+
+/**
+ * A runtime is "transient" when a control-plane operation is in progress and
+ * mutating actions (Delete, Update container, Tag, New version) must be blocked.
+ *
+ * Matched by shape rather than an exact allow-list: any status ending in "ing"
+ * (Creating, Updating, Deleting) is in-progress — mirroring the status cell's
+ * loading branch. Ready, failed, and broken are NOT transient (failed/broken
+ * agents are intentionally deletable for cleanup). Keying on the string shape
+ * means future-persisted transient values are handled without a backend change.
+ */
+export function isTransientStatus(status: string): boolean {
+    return status.trim().toLowerCase().endsWith("ing");
+}
+
+/**
+ * Convenience predicate: may a destructive/mutating action run against this row?
+ * Currently equivalent to `!isTransientStatus`, but named for intent so call
+ * sites read clearly and the rule can evolve in one place.
+ */
+export function canMutate(status: string): boolean {
+    return !isTransientStatus(status);
+}

--- a/src/user-interface/react-app/src/components/chatbot/chat.tsx
+++ b/src/user-interface/react-app/src/components/chatbot/chat.tsx
@@ -61,6 +61,10 @@ const STARTER_PROMPTS: { id: string; key: string }[] = [
  * @param {string} [props.sessionId] - Optional session ID to restore an existing chat session.
  *                                     If provided, loads message history from backend.
  *                                     If not provided, creates a new session with UUID.
+ * @param {string} [props.initialAgentRuntimeId] - Optional agent runtime id to pre-select for a
+ *                                     fresh session (e.g. the Runtime Manager's "Start a session"
+ *                                     hand-off). Pins the qualifier to DEFAULT and takes precedence
+ *                                     over the favorite-runtime effect. Ignored for loaded sessions.
  *
  * @returns {JSX.Element} A grid-based chat interface with message history and input panel
  *
@@ -84,7 +88,7 @@ const STARTER_PROMPTS: { id: string; key: string }[] = [
  * - Main chat area contains message history and input panel
  * - Optional annex panel for additional content (documents, references, etc.)
  */
-export default function Chat(props: { sessionId?: string }) {
+export default function Chat(props: { sessionId?: string; initialAgentRuntimeId?: string }) {
     const appContext = useContext(AppContext);
     const [running, setRunning] = useState<boolean>(false);
     const [session, setSession] = useState<{
@@ -194,9 +198,28 @@ export default function Chat(props: { sessionId?: string }) {
 
     const refreshAgents = () => setRefreshTrigger((prev) => prev + 1);
 
+    // Pre-select an agent handed off from the Runtime Manager ("Start a session").
+    // Runs before the favorite effect below so its `!agentRuntimeId` guard
+    // short-circuits — the passed agent wins over the user's favorite. Pin the
+    // qualifier to DEFAULT via the ref so the endpoint-resolution effect lands on
+    // DEFAULT rather than the QUALIFIER/endpointOptions[0] fallback. Fresh
+    // sessions only: a loaded session (runtimeId set) is left untouched.
+    useEffect(() => {
+        if (session.loading || session.runtimeId) return;
+
+        if (props.initialAgentRuntimeId && messageHistory.length === 0 && !agentRuntimeId) {
+            favoriteQualifierRef.current = "DEFAULT";
+            setAgentRuntimeId(props.initialAgentRuntimeId);
+            setQualifier("DEFAULT");
+        }
+    }, [props.initialAgentRuntimeId, messageHistory.length, agentRuntimeId, session.loading, session.runtimeId]);
+
     // Load favorite runtime for new sessions
     useEffect(() => {
         if (session.loading || session.runtimeId) return;
+        // A "Start a session" hand-off pins the agent; don't let the favorite's
+        // async load resolve and override it (both effects see agentRuntimeId="").
+        if (props.initialAgentRuntimeId) return;
 
         if (messageHistory.length === 0 && !agentRuntimeId) {
             const loadFavoriteRuntime = async () => {
@@ -214,7 +237,7 @@ export default function Chat(props: { sessionId?: string }) {
             };
             loadFavoriteRuntime();
         }
-    }, [messageHistory.length, agentRuntimeId, session.loading, session.runtimeId]);
+    }, [messageHistory.length, agentRuntimeId, session.loading, session.runtimeId, props.initialAgentRuntimeId]);
 
     // Restore agent/endpoint from session (loaded sessions — text or voice)
     useEffect(() => {

--- a/src/user-interface/react-app/src/components/wizard/agent-core-runtime-wizard.tsx
+++ b/src/user-interface/react-app/src/components/wizard/agent-core-runtime-wizard.tsx
@@ -534,9 +534,17 @@ export default function AgentCoreRuntimeCreatorWizard({
                 cancelButton: "Cancel",
                 previousButton: "Previous",
                 nextButton: "Next",
-                submitButton: isCreating ? "Creating..." : "Create Runtime",
+                submitButton: "Create Runtime",
             }}
-            onNavigate={({ detail }) => setActiveStepIndex(detail.requestedStepIndex)}
+            // Gate progression here rather than via isLoadingNextStep: accept
+            // backward/same navigation freely, but only allow moving forward when
+            // the current step is valid. This keeps the Next button geometry stable
+            // (no validity-driven spinner) while still blocking an invalid step.
+            onNavigate={({ detail }) => {
+                const movingForward = detail.requestedStepIndex > activeStepIndex;
+                if (movingForward && !isStepValid(activeStepIndex)) return;
+                setActiveStepIndex(detail.requestedStepIndex);
+            }}
             activeStepIndex={activeStepIndex}
             onCancel={onCancel}
             onSubmit={() =>
@@ -552,7 +560,9 @@ export default function AgentCoreRuntimeCreatorWizard({
                 title: step.title,
                 content: step.content,
             }))}
-            isLoadingNextStep={!isStepValid(activeStepIndex) || isCreating}
+            // Reflect ONLY the in-flight create; never step validity (a
+            // validity-driven spinner is what resized the button between steps).
+            isLoadingNextStep={isCreating}
         />
     );
 

--- a/src/user-interface/react-app/src/components/wizard/agent-core-runtime-wizard.tsx
+++ b/src/user-interface/react-app/src/components/wizard/agent-core-runtime-wizard.tsx
@@ -31,6 +31,7 @@ import {
     listKnowledgeBases as listKnowledgeBasesQuery,
     listRuntimeAgents as listRuntimeAgentsQuery,
 } from "../../graphql/queries";
+import ArchitectureDiagram from "./architectures/architecture-diagram";
 import {
     getAgentsAsToolsSteps,
     isAgentsAsToolsStepValid,
@@ -413,24 +414,28 @@ export default function AgentCoreRuntimeCreatorWizard({
                                         label: "Single Agent",
                                         description:
                                             "A single agent with tools, knowledge bases, and MCP servers",
+                                        image: <ArchitectureDiagram kind="single" />,
                                     },
                                     {
                                         value: "AGENTS_AS_TOOLS",
                                         label: "Agents as Tools",
                                         description:
                                             "An orchestrator agent that delegates to existing agents exposed as tools",
+                                        image: <ArchitectureDiagram kind="agents-as-tools" />,
                                     },
                                     {
                                         value: "SWARM",
                                         label: "Swarm",
                                         description:
                                             "Multiple specialized agents that collaborate via handoffs",
+                                        image: <ArchitectureDiagram kind="swarm" />,
                                     },
                                     {
                                         value: "GRAPH",
                                         label: "Graph",
                                         description:
                                             "Compose existing agents into a stateful LangGraph workflow with directed edges and conditional routing",
+                                        image: <ArchitectureDiagram kind="graph" />,
                                     },
                                 ]}
                             />

--- a/src/user-interface/react-app/src/components/wizard/architectures/architecture-diagram.tsx
+++ b/src/user-interface/react-app/src/components/wizard/architectures/architecture-diagram.tsx
@@ -1,0 +1,116 @@
+// ----------------------------------------------------------------------
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: MIT-0
+// ----------------------------------------------------------------------
+
+/**
+ * Small presentational diagrams for each agent architecture, rendered in the
+ * wizard's Architecture Type tiles. Inline SVG (no asset pipeline) drawn with
+ * `currentColor` so they adapt to light/dark Cloudscape themes. All four share
+ * one viewBox and fixed height so the tiles stay equal-height.
+ */
+
+export type ArchKind = "single" | "agents-as-tools" | "swarm" | "graph";
+
+const VIEW_W = 160;
+const VIEW_H = 72;
+
+// Shared node/edge styling — strokes and fills inherit the tile's text color,
+// kept muted via opacity so the diagram reads as a hint, not a focal point.
+const nodeProps = {
+    fill: "currentColor",
+    fillOpacity: 0.12,
+    stroke: "currentColor",
+    strokeOpacity: 0.7,
+    strokeWidth: 1.5,
+} as const;
+
+const edgeProps = {
+    stroke: "currentColor",
+    strokeOpacity: 0.5,
+    strokeWidth: 1.5,
+    fill: "none",
+} as const;
+
+function Node({ cx, cy, r = 9 }: { cx: number; cy: number; r?: number }) {
+    return <circle cx={cx} cy={cy} r={r} {...nodeProps} />;
+}
+
+function diagram(kind: ArchKind) {
+    switch (kind) {
+        case "single":
+            return <Node cx={80} cy={36} r={12} />;
+        case "agents-as-tools":
+            // Orchestrator on top delegating to three sub-agents.
+            return (
+                <>
+                    <line x1={80} y1={22} x2={40} y2={54} {...edgeProps} />
+                    <line x1={80} y1={22} x2={80} y2={54} {...edgeProps} />
+                    <line x1={80} y1={22} x2={120} y2={54} {...edgeProps} />
+                    <Node cx={80} cy={18} r={10} />
+                    <Node cx={40} cy={54} />
+                    <Node cx={80} cy={54} />
+                    <Node cx={120} cy={54} />
+                </>
+            );
+        case "swarm":
+            // Fully-meshed peers collaborating via handoffs.
+            return (
+                <>
+                    <line x1={50} y1={22} x2={110} y2={22} {...edgeProps} />
+                    <line x1={50} y1={22} x2={50} y2={52} {...edgeProps} />
+                    <line x1={110} y1={22} x2={110} y2={52} {...edgeProps} />
+                    <line x1={50} y1={52} x2={110} y2={52} {...edgeProps} />
+                    <line x1={50} y1={22} x2={110} y2={52} {...edgeProps} />
+                    <line x1={110} y1={22} x2={50} y2={52} {...edgeProps} />
+                    <Node cx={50} cy={22} />
+                    <Node cx={110} cy={22} />
+                    <Node cx={50} cy={52} />
+                    <Node cx={110} cy={52} />
+                </>
+            );
+        case "graph":
+            // Directed workflow: entry → branch → merge, with arrowheads.
+            return (
+                <>
+                    <line x1={38} y1={36} x2={72} y2={20} {...edgeProps} markerEnd="url(#arrow)" />
+                    <line x1={38} y1={36} x2={72} y2={52} {...edgeProps} markerEnd="url(#arrow)" />
+                    <line x1={88} y1={20} x2={122} y2={36} {...edgeProps} markerEnd="url(#arrow)" />
+                    <line x1={88} y1={52} x2={122} y2={36} {...edgeProps} markerEnd="url(#arrow)" />
+                    <Node cx={30} cy={36} />
+                    <Node cx={80} cy={20} />
+                    <Node cx={80} cy={52} />
+                    <Node cx={130} cy={36} />
+                </>
+            );
+    }
+}
+
+export default function ArchitectureDiagram({ kind }: { kind: ArchKind }) {
+    return (
+        <svg
+            role="presentation"
+            aria-hidden="true"
+            width="100%"
+            height={VIEW_H}
+            viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+            preserveAspectRatio="xMidYMid meet"
+        >
+            <defs>
+                <marker
+                    id="arrow"
+                    viewBox="0 0 10 10"
+                    refX={8}
+                    refY={5}
+                    markerWidth={5}
+                    markerHeight={5}
+                    orient="auto-start-reverse"
+                >
+                    <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor" fillOpacity={0.5} />
+                </marker>
+            </defs>
+            {diagram(kind)}
+        </svg>
+    );
+}

--- a/src/user-interface/react-app/src/pages/chatbot/playground.tsx
+++ b/src/user-interface/react-app/src/pages/chatbot/playground.tsx
@@ -5,7 +5,7 @@
 // ----------------------------------------------------------------------
 import { Header, HelpPanel, SpaceBetween } from "@cloudscape-design/components";
 import { useTranslation } from "react-i18next";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { v4 as uuidv4 } from "uuid";
 import BaseAppLayout from "../../components/base-app-layout";
 import Chat from "../../components/chatbot/chat";
@@ -13,8 +13,13 @@ import ConversationHistory from "../../components/chatbot/conversation-history";
 
 export default function Playground() {
     const { sessionId } = useParams();
+    const [searchParams] = useSearchParams();
     const { t } = useTranslation("ACA");
     const navigate = useNavigate();
+
+    // Hand-off from the Runtime Manager's "Start a session" action: pre-select
+    // this agent for a fresh session (chat forces DEFAULT). Undefined otherwise.
+    const initialAgentRuntimeId = searchParams.get("agentRuntimeId") ?? undefined;
 
     return (
         <BaseAppLayout
@@ -75,7 +80,7 @@ export default function Playground() {
             ]}
             toolsWidth={300}
             maxContentWidth={10000}
-            content={<Chat sessionId={sessionId} />}
+            content={<Chat sessionId={sessionId} initialAgentRuntimeId={initialAgentRuntimeId} />}
         />
     );
 }


### PR DESCRIPTION
## Summary

Reworks the AgentCore Runtime Manager admin UI and a few adjacent wizard/chat touch points to make runtime management safer and clearer. Per-row actions move into a `⋯` dropdown, delete is gated on in-flight (transient) status so a mutation can't fire mid-operation, and two previously-inert row actions ("Start a session", "Update container") are wired up. Also redesigns the wizard's Architecture Type tiles with diagrams and stops the wizard footer buttons from shifting between steps.

## Changes

**Runtime Manager (`agent-core-runtime-manager.tsx`, `agent-core/`)**
- Moved per-row actions into a Cloudscape `ButtonDropdown` (`row-actions.tsx`), keeping the header Delete + global actions. ADR 0006 records the row-menu convention.
- Added a status-vocabulary helper (`runtime-status.ts`): `isTransientStatus` (status ends in "ing") / `canMutate`, used to gate mutating actions.
- Delete is now blocked whenever a targeted runtime is transient (Creating/Updating/Deleting); Ready and failed/broken remain deletable. The confirm modal re-validates status on every render so the gate can't be bypassed once open.
- Multi-select Delete removes whole agents (no endpoint picker); single-select keeps the per-endpoint "all vs. specific" picker with DEFAULT protected (`delete-agent-modal.tsx`). Favorite is reset if any deleted agent held it.
- "Start a session" mints a fresh session and opens chat with the agent pre-selected on its DEFAULT endpoint via `?agentRuntimeId=`.
- "Update container" re-versions the runtime against the currently-deployed image URI by re-submitting its current config unchanged, behind a confirm modal that states it does not rebuild from source (ADR 0005).

**Chat / Playground (`chat.tsx`, `playground.tsx`)**
- `playground.tsx` reads `?agentRuntimeId=` and forwards it to `<Chat>` as `initialAgentRuntimeId`.
- `chat.tsx` gains a pre-select effect (ordered before, and gating out, the favorite-runtime load) that pins the qualifier to DEFAULT for fresh sessions only; loaded sessions are untouched.

**Wizard (`agent-core-runtime-wizard.tsx`, `architectures/architecture-diagram.tsx`)**
- Architecture Type tiles show a distinct inline-SVG diagram per kind (Single, Agents as Tools, Swarm, Graph), drawn with `currentColor` for light/dark themes; no asset pipeline introduced.
- Footer buttons no longer shift horizontally between steps: `isLoadingNextStep` now reflects only the in-flight create, the submit label is static, and forward navigation is gated in `onNavigate` (backward/same free; forward blocked when the current step is invalid).

## Test plan

- [x] `tsc --noEmit` passes across the app after every task.
- [x] Runtime Manager: open the `⋯` menu on a Ready agent — all actions enabled; on a Creating/Updating/Deleting agent — mutating actions disabled, View enabled.
- [x] Select 2+ agents → header Delete shows whole-agent confirmation (no endpoint picker) and deletes all; select 1 → endpoint picker (all/specific, DEFAULT protected) still shows.
- [x] Delete an agent that is the current favorite → favorite is reset.
- [x] "Start a session" opens a new chat with that agent selected and endpoint = DEFAULT; the user's favorite does not override it; loading an existing session is unaffected.
- [x] "Update container" on a Ready agent → confirm modal, then status shows Updating → Ready; config unchanged, no wizard opened.
- [x] Wizard: each Architecture tile shows distinct imagery in both light and dark mode; selecting a tile still sets the correct `architectureType`.
- [x] Wizard: Cancel/Previous/Next don't shift horizontally between steps or when a step flips valid/invalid; you still can't advance past an invalid step; the submit button doesn't shift siblings when it enters the in-flight state.

## Known scan findings (non-blocking)

`make run-ash` and code review were **not** run for this draft (deferred at the author's request). Per `CONTRIBUTING.md`, run ASH before merging. The diff is UI-only (`.tsx`/`.ts` under `src/user-interface/react-app/` + two ADR docs); the primary scanner of interest is `npm-audit`/`semgrep` on the React app.
